### PR TITLE
GitHub actions deploy workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -704,7 +704,7 @@ jobs:
             export GIT_REPOSITORY_URL="https://github.com/$GITHUB_ORG/$CLUSTER_REPOSITORY"
  
             # Create MCCP Kind cluster
-            kind create cluster --name my-kind-mccp-cluster --config ../../utils/scripts/local-mccp-kind-config.yaml
+            kind create cluster --name my-kind-mccp-cluster --config ../../utils/data/local-mccp-kind-config.yaml
             WORKER_NODE=$(kubectl get node --selector='!node-role.kubernetes.io/master' -o name)
             kubectl label "${WORKER_NODE}" wkp-database-volume-node=true
 

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,372 @@
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+name: deploy
+jobs:
+  build:
+    runs-on: ${{matrix.os}}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macOS-latest]
+    env:
+      GO_CACHE_NAME: cache-go-modules
+      YARN_CACHE_NAME: cache-yarn
+      GITHUB_TOKEN: ${{ secrets.WGE_NPM_GITHUB_TOKEN }}
+    steps:
+    - id: cache-paths
+      run: |
+        echo "::set-output name=dir::$(yarn cache dir)"
+        echo "::set-output name=go-build::$(go env GOCACHE)"
+        echo "::set-output name=go-mod::$(go env GOMODCACHE)"
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.16.x
+    - name: Checkout code
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Go Build Cache
+      uses: actions/cache@v2
+      with:
+        path: |
+          ${{ steps.cache-paths.outputs.go-build }}
+          ${{ steps.cache-paths.outputs.go-mod }}
+        key: ${{ runner.os }}-go-build-${{ env.GO_CACHE_NAME }}-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-build-${{ env.GO_CACHE_NAME }}-
+    - name: Yarn Cache
+      uses: actions/cache@v2
+      with:
+        path: ${{ steps.cache-paths.outputs.dir }}
+        key: ${{ runner.os }}-${{ env.YARN_CACHE_NAME }}-${{ hashFiles('**/yarn.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-${{ env.YARN_CACHE_NAME }}-
+    - name: Build all the services
+      run: |
+        if [ "$RUNNER_OS" == "macOS" ]; then
+          LOCAL_BINARIES_GOOS=darwin make cmd/mccp/mccp BUILD_IN_CONTAINER=false
+        elif [ "$RUNNER_OS" == "Linux" ]; then
+          make -j4 BUILD_IN_CONTAINER=false
+        fi
+        mv cmd/mccp/mccp cmd/mccp/mccp-${{ matrix.os }}
+    - name: Store mccp binaries
+      uses: actions/upload-artifact@v2
+      with:
+        name: mccp-binaries
+        path: cmd/mccp/mccp-${{ matrix.os }}
+        retention-days: 1
+    - name: Install Helm v3
+      if: ${{ runner.os == 'Linux' }}
+      uses: azure/setup-helm@v1
+      with:
+        version: v3.5.4
+    - name: Configure AWS Credentials
+      if: ${{ runner.os == 'Linux' }}
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.WGE_S3_AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.WGE_S3_AWS_SECRET_ACCESS_KEY }}
+        aws-region: eu-central-1
+    - name: Publish helm chart to s3
+      if: ${{ runner.os == 'Linux' }}
+      run: |
+          TAG=$(git describe --always --match "v*")
+          IMAGE_TAG=$(./tools/image-tag)
+          
+          CHART_VALUES_PATH=./charts/mccp/values.yaml
+          # Update the MCCP chart values.yaml file with the current image tag
+          make update-mccp-chart-values CHART_VALUES_PATH=$CHART_VALUES_PATH
+
+          # Publish the MCCP Helm v3 chart
+          ./bin/publish-chart-to-s3.sh $TAG $IMAGE_TAG ./charts/mccp 3
+    - name: Login to Docker Hub
+      if: ${{ runner.os == 'Linux' }}
+      uses: docker/login-action@v1
+      with:
+        registry: docker.io
+        username: ${{ secrets.WGE_DOCKER_IO_USER }}
+        password: ${{ secrets.WGE_DOCKER_IO_PASSWORD }}
+    - name: Push images to docker registry
+      if: ${{ runner.os == 'Linux' }}
+      run: make push
+
+  coverage:
+    runs-on: ubuntu-latest
+    env:
+      GO_CACHE_NAME: cache-go-modules
+      WGE_COVERALLS_TOKEN: ${{ secrets.WGE_COVERALLS_TOKEN }}
+      ARTEFACTS_BASE_DIR: /tmp/workspace/test
+    steps:
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.16.x
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Install dependencies
+      run: |
+        go mod download
+        go get github.com/wadey/gocovmerge
+        go get -u github.com/jstemmer/go-junit-report
+        npm install -g junit-report-merger
+    - name: Install goveralls
+      env:
+        GO111MODULE: off
+      run: go get github.com/mattn/goveralls
+    
+    - name: Run unit tests
+      run: | 
+        go version
+        mkdir -p ${{ env.ARTEFACTS_BASE_DIR }}
+        
+        WKP_DEBUG=true go test -cover -coverprofile=.coverprofile ./cmd/... ./pkg/... | go-junit-report > ${{ env.ARTEFACTS_BASE_DIR }}/test-results.xml
+        cd ${{ github.workspace }}/cmd/event-writer && go test -cover -coverprofile=.coverprofile ./converter/... ./database/... ./liveness/... ./run/... ./test/... | go-junit-report > ${{ env.ARTEFACTS_BASE_DIR }}/event-writer-results.xml
+        cd ${{ github.workspace }}/common && go test -cover -coverprofile=.coverprofile ./... | go-junit-report > ${{ env.ARTEFACTS_BASE_DIR }}/common-results.xml
+        cd ${{ github.workspace }}/cmd/capi-server && go test -cover -coverprofile=.coverprofile ./... | go-junit-report > ${{ env.ARTEFACTS_BASE_DIR }}/capi-server-results.xml
+
+        cd ${{ github.workspace }}
+        # Merge all coverage results
+        gocovmerge .coverprofile cmd/event-writer/.coverprofile common/.coverprofile  cmd/capi-server/.coverprofile > ${{ env.ARTEFACTS_BASE_DIR }}/merged-profiles    
+        # Merge all junit test results
+        jrm ${{ env.ARTEFACTS_BASE_DIR }}/combined-test-results.xml '${{ env.ARTEFACTS_BASE_DIR }}/*.xml'
+    # - name: Send coverage
+    #   run: |
+    #     # submit the coverage 1 by 1, seems important that they have a -flagname
+    #     goveralls -parallel -coverprofile=.coverprofile -service="GitHub Action" -flagname wks -repotoken $WGE_COVERALLS_TOKEN
+    #     (cd cmd/event-writer; goveralls -coverprofile=.coverprofile -flagname event-writer -parallel -service="GitHub Action" -repotoken $WGE_COVERALLS_TOKEN)
+    #     (cd common; goveralls -coverprofile=.coverprofile -flagname common -parallel -service="GitHub Action" -repotoken $WGE_COVERALLS_TOKEN)
+    #     (cd cmd/capi-serve; goveralls -coverprofile=.coverprofile -flagname capi-server -parallel -service="GitHub Action" -repotoken $WGE_COVERALLS_TOKEN)
+
+    #     # We've finished submitting the coverage
+    #     curl -k "https://coveralls.io/webhook?repo_token=$WGE_COVERALLS_TOKEN" -d "payload[build_num]=$GITHUB_RUN_NUMBER&payload[status]=done"
+    - name: Store unit test coverage results
+      uses: actions/upload-artifact@v2
+      with:
+          name: unit-tests-artifacts
+          path: |
+            ${{ env.ARTEFACTS_BASE_DIR }}
+          retention-days: 1
+
+  acceptance-tests:
+    runs-on: ${{matrix.os}}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            wego_suffix: linux-x86_64
+            os_bin_suffix: linux-amd64
+          # - os: macOS-latest
+          #   os_bin_suffix: darwin-amd64
+          #   wego_suffix: darwin-x86_64
+    needs: [build, coverage]
+    timeout-minutes: 90
+    env:
+      GO_CACHE_NAME: cache-go-modules
+      GITHUB_TOKEN: ${{ secrets.WGE_GITHUB_TOKEN }}
+      GITHUB_ORG: ${{ secrets.WGE_GITHUB_ORG }}
+      GITHUB_USER: ${{ secrets.WGE_GITHUB_USER }}
+      DOCKER_IO_USER: ${{ secrets.WGE_DOCKER_IO_USER }} 
+      DOCKER_IO_PASSWORD: ${{ secrets.WGE_DOCKER_IO_PASSWORD }}
+      MCCP_BIN_PATH: ${{ github.workspace }}/cmd/mccp/mccp-${{ matrix.os }}
+      WEGO_BIN_PATH: ${{ github.workspace }}/cmd/wego/wego-${{ matrix.wego_suffix }}
+      WKP_BIN_PATH: ${{ github.workspace }}/cmd/wk/wk-v2.5.0-${{ matrix.os_bin_suffix }}
+      SELENIUM_DEBUG: true
+      ACCEPTANCE_TESTS_DATABASE_TYPE: sqlite
+      MCCP_ACCEPTANCE: true
+      CONNECT_KIND_WKP_LEAF_TEST: true
+      MCCP_KIND_WKP_LEAF_KUBECONFIG: '/tmp/mccp-kind-leaf-kubeconfig'
+      ARTEFACTS_BASE_DIR: /tmp/workspace/test/
+    steps:
+    - id: go-cache-paths
+      run: |
+        echo "::set-output name=go-build::$(go env GOCACHE)"
+        echo "::set-output name=go-mod::$(go env GOMODCACHE)"
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.16.x
+    - name: Checkout code
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0 
+    - name: Go Build Cache
+      uses: actions/cache@v2
+      with:
+        path: |
+          ${{ steps.go-cache-paths.outputs.go-build }}
+          ${{ steps.go-cache-paths.outputs.go-mod }}
+        key: ${{ runner.os }}-go-build-${{ env.GO_CACHE_NAME }}-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-build-${{ env.GO_CACHE_NAME }}-
+    - name: Install docker
+      if: ${{ runner.os == 'macOS' }}
+      uses: docker-practice/actions-setup-docker@master
+    - name: Install kubectl
+      uses: Azure/setup-kubectl@v1
+      with:
+          version: 'v1.20.7'
+    - name: Install kind
+      run: |
+        if [ "$RUNNER_OS" == "Linux" ]; then
+          curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.11.0/kind-linux-amd64
+          chmod +x ./kind
+          sudo mv ./kind /usr/local/bin/kind
+         elif [ "$RUNNER_OS" == "macOS" ]; then
+            brew install kind
+        fi
+    - name: Install clusterctl
+      run: |
+        curl -L https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.4.2/clusterctl-${{ matrix.os_bin_suffix }} -o clusterctl
+        chmod +x ./clusterctl
+        sudo mv ./clusterctl /usr/local/bin/clusterctl
+        clusterctl version 
+    - name: Set up ssh agent
+      uses: webfactory/ssh-agent@v0.5.2
+      with:
+        ssh-private-key: ${{ secrets.WGE_GITHUB_PRIVATE_KEY }}
+    - name: Configure git settings
+      run: |
+        git config --global user.email "test-user@weave.works"
+        git config --global user.name "test-user"
+        git config --global url.ssh://git@github.com/.insteadOf https://github.com/
+    - name: Download mccp binaries
+      uses: actions/download-artifact@v2
+      with:
+        name: mccp-binaries
+        path: cmd/mccp
+    - name: Download wego binary from GitHub
+      run: |
+        mkdir -p cmd/wego/
+        wget https://github.com/weaveworks/weave-gitops/releases/download/v0.2.4/wego-${{ matrix.wego_suffix }}
+        mv wego-${{ matrix.wego_suffix }} $WEGO_BIN_PATH
+    - name: Download wk binary from s3
+      run: |
+        mkdir -p cmd/wk/
+        curl -o $WKP_BIN_PATH https://s3.amazonaws.com/weaveworks-wkp/wk-v2.5.0-${{ matrix.os_bin_suffix }}        
+    - name: Change bin permissions
+      run: |
+        sudo chmod +x ${{ env.MCCP_BIN_PATH }}
+        sudo chmod +x ${{ env.WEGO_BIN_PATH }}
+        sudo chmod +x ${{ env.WKP_BIN_PATH }}  
+    - name: Setup selenium server
+      run: |
+        if [ "$RUNNER_OS" == "Linux" ]; then
+          sudo apt-get update
+          sudo apt-get install -y xvfb
+          sudo apt-get install -y google-chrome-stable
+
+          wget https://chromedriver.storage.googleapis.com/92.0.4515.107/chromedriver_linux64.zip
+          unzip chromedriver_linux64.zip
+          sudo mv -f chromedriver /usr/local/bin/chromedriver
+
+          wget  https://selenium-release.storage.googleapis.com/3.14/selenium-server-standalone-3.14.0.jar
+
+          # Start selenium server in standalone mode
+          xvfb-run -a --server-args="-screen 0 1280x1024x24" java -jar ./selenium-server-standalone-3.14.0.jar &
+
+        elif [ "$RUNNER_OS" == "macOS" ]; then
+          selenium-server & 
+        fi
+    - name: Setup kind management cluster
+      run: |
+        kind create cluster --name management-${{ github.run_id }}-${{ github.run_number}} --image=kindest/node:v1.20.7 --config test/utils/data/local-mccp-kind-config.yaml
+        kubectl get pods -A     
+    - name: Install mccp componenets on management cluster
+      run: |
+        CLUSTER_REPOSITORY=mccp-capi-template-${{ github.run_id }}-$(openssl rand -hex 8)
+        # Set the CLUSTER_REPOSITORY as environment variable for subsequent steps
+        echo "CLUSTER_REPOSITORY=$CLUSTER_REPOSITORY" >> $GITHUB_ENV
+
+        ./test/utils/scripts/ci-cluster-install.sh mccp $CLUSTER_REPOSITORY
+        kubectl port-forward -n mccp svc/my-mccp-nginx-ingress-controller 8090:80 &
+    - name: Setup wkp leaf cluster
+      run: |
+        kind create cluster --name my-wkp-leaf-cluster --image=kindest/node:v1.20.7 --config test/utils/data/kind-config.yaml --kubeconfig $MCCP_KIND_WKP_LEAF_KUBECONFIG
+        export KUBECONFIG=$MCCP_KIND_WKP_LEAF_KUBECONFIG
+
+        export CLUSTER_NAME=leaf-${{ github.run_id }}-${{ github.run_number}}
+        # Set the WKP_CLUSTER_NAME as environment variable for subsequent steps
+        echo "WKP_CLUSTER_NAME=$CLUSTER_NAME" >> $GITHUB_ENV
+        ./test/utils/scripts/ci-cluster-install.sh wkp $CLUSTER_NAME ${{ github.workspace }}
+
+        # Unset KUBECONFIG to let kubectl point back to the MCCP cluster under test
+        unset KUBECONFIG        
+    - name: Run acceptance tests
+      run: |
+        cd test/acceptance/test/
+        go test -ginkgo.v -v --timeout=99999s
+    - name: Delete WKP repository
+      if: ${{ always() }}
+      run: |
+        hub delete -y $GITHUB_ORG/$WKP_CLUSTER_NAME
+    - name: Store acceptance test results
+      if: ${{ always() }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: acceptance-test-artifacts
+        path: ${{ env.ARTEFACTS_BASE_DIR }}
+        retention-days: 1
+
+  publish-binaries:
+    runs-on: ${{matrix.os}}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macOS-latest]
+    needs: [acceptance-tests]
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Download mccp binaries
+      uses: actions/download-artifact@v2
+      with:
+        name: mccp-binaries
+        path: cmd/mccp
+    - name: Configure AWS Credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.WGE_S3_AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.WGE_S3_AWS_SECRET_ACCESS_KEY }}
+        aws-region: eu-central-1
+    - name: Publish mccp to s3
+      run: |
+        TAG=$(./tools/image-tag)
+        # Upload uniquely tagged binaries
+        aws s3 cp cmd/mccp/mccp-${{ matrix.os }} s3://weaveworks-wkp/mccp-${TAG}-${{ matrix.os }}
+
+        # Upload a "main" binary for easy access to latest main build
+        aws s3 cp cmd/mccp/mccp-${{ matrix.os }} s3://weaveworks-wkp/
+
+  # publish-test-results:
+  #   runs-on: ubuntu-latest
+  #   needs: [acceptance-tests]
+  #   env:
+  #     ARTEFACTS_BASE_DIR: /tmp/workspace/test/
+  #   steps:
+  #   - name: Install Go
+  #     uses: actions/setup-go@v2
+  #     with:
+  #       go-version: 1.16.x
+  #   - name: Checkout code
+  #     uses: actions/checkout@v2
+  #   - name: Install testspace client
+  #     uses: testspace-com/setup-testspace@v1
+  #     with:
+  #       domain: weaveworks.testspace.com
+  #   - name: Download artifacts
+  #     uses: actions/download-artifact@v2
+  #     with:
+  #       path:
+  #         results
+  #   - name: Display structure of downloaded files
+  #     run: ls -laR
+  #     working-directory: results
+  #   - name: Publish test results to Testspace
+  #     run: |
+  #       go get github.com/t-yuki/gocover-cobertura
+
+  #       gocover-cobertura < results/unit-tests-artifacts/merged-profiles > coverage.xml
+  #       testspace "[unit-tests]results/unit-tests-artifacts/combined-test-results.xml" "[acceptance-tests]results/acceptance-test-artifacts/acceptance-test-results.xml" "coverage.xml"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,7 +1,4 @@
 on:
-  push:
-    branches:
-      - main
   pull_request:
   workflow_dispatch:
 
@@ -82,6 +79,7 @@ jobs:
     #     goveralls -parallel -coverprofile=.coverprofile -service="GitHub Action" -flagname wks -repotoken $WGE_COVERALLS_TOKEN
     #     (cd cmd/event-writer; goveralls -coverprofile=.coverprofile -flagname event-writer -parallel -service="GitHub Action" -repotoken $WGE_COVERALLS_TOKEN)
     #     (cd common; goveralls -coverprofile=.coverprofile -flagname common -parallel -service="GitHub Action" -repotoken $WGE_COVERALLS_TOKEN)
+    #     (cd cmd/capi-serve; goveralls -coverprofile=.coverprofile -flagname capi-server -parallel -service="GitHub Action" -repotoken $WGE_COVERALLS_TOKEN)
 
     #     # We've finished submitting the coverage
     #     curl -k "https://coveralls.io/webhook?repo_token=$WGE_COVERALLS_TOKEN" -d "payload[build_num]=$GITHUB_RUN_NUMBER&payload[status]=done"
@@ -134,13 +132,14 @@ jobs:
       uses: azure/setup-helm@v1
       with:
         version: v3.5.4
-    - name: Publish helm chart to s3
+    - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
         aws-access-key-id: ${{ secrets.WGE_S3_AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.WGE_S3_AWS_SECRET_ACCESS_KEY }}
         aws-region: eu-central-1
-    - run: |
+    - name: Publish helm chart to s3
+      run: |
         TAG=$(git describe --always --match "v*")
         IMAGE_TAG=$(./tools/image-tag)
         
@@ -284,6 +283,8 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.WGE_GITHUB_TOKEN }}
       GITHUB_ORG: ${{ secrets.WGE_GITHUB_ORG }}
       GITHUB_USER: ${{ secrets.WGE_GITHUB_USER }}
+      DOCKER_IO_USER: ${{ secrets.WGE_DOCKER_IO_USER }} 
+      DOCKER_IO_PASSWORD: ${{ secrets.WGE_DOCKER_IO_PASSWORD }}
       MCCP_BIN_PATH: ${{ github.workspace }}/cmd/mccp/mccp
       WEGO_BIN_PATH: ${{ github.workspace }}/cmd/wego/wego-linux-x86_64
       SELENIUM_DEBUG: true
@@ -366,58 +367,17 @@ jobs:
         name: management-${{ github.run_id }}-${{ github.run_number}}
         version: "v0.11.0"
         image: kindest/node:v1.20.7
-        config: "./test/utils/scripts/local-mccp-kind-config.yaml"
+        config: "./test/utils/data/local-mccp-kind-config.yaml"
     - name: Kind-check
       run: |
         kubectl get pods -A    
     - name: Install mccp componenets on management cluster
       run: |
-        set -x
-        # create unique cluster config repository name
         CLUSTER_REPOSITORY=mccp-capi-template-${{ github.run_id }}-$(openssl rand -hex 8)
-        GIT_REPOSITORY_URL="https://github.com/${{ secrets.WGE_GITHUB_ORG }}/$CLUSTER_REPOSITORY"
-
         # Set the CLUSTER_REPOSITORY as environment variable for subsequent steps
         echo "CLUSTER_REPOSITORY=$CLUSTER_REPOSITORY" >> $GITHUB_ENV
-        
-        WORKER_NODE=$(kubectl get node --selector='!node-role.kubernetes.io/master' -o name)
-        kubectl label "${WORKER_NODE}" wkp-database-volume-node=true
 
-        WORKER_NODE_EXTERNAL_IP=$(ifconfig eth0 | grep -i MASK | awk '{print $2}' | cut -f2 -d:)
-        echo "Worker node ip is ${WORKER_NODE_EXTERNAL_IP}"
-        NATS_NODEPORT=31490            
-
-        kubectl create namespace prom
-        helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
-        helm repo update
-        helm install my-prom prometheus-community/kube-prometheus-stack \
-          --namespace prom \
-          --version 14.4.0 \
-          --values test/utils/data/mccp-prometheus-values.yaml
-
-        kubectl create namespace mccp
-        kubectl create secret docker-registry docker-io-pull-secret \
-          --namespace mccp \
-          --docker-username=${{ secrets.WGE_DOCKER_IO_USER }} \
-          --docker-password=${{ secrets.WGE_DOCKER_IO_PASSWORD }} 
-        kubectl create secret generic git-provider-credentials \
-          --namespace=mccp \
-          --from-literal="GIT_PROVIDER_TOKEN=${{ secrets.WGE_GITHUB_TOKEN }}"
-        CHART_VERSION=$(git describe --always | sed 's/^[^0-9]*//')
-        helm repo add wkpv3 https://s3.us-east-1.amazonaws.com/weaveworks-wkp/charts-v3/
-        helm repo update
-        helm install my-mccp wkpv3/mccp --version "${CHART_VERSION}" --namespace mccp \
-          --set "imagePullSecrets[0].name=docker-io-pull-secret" \
-          --set "wkp-ui.image.pullSecrets[0]=docker-io-pull-secret" \
-          --set "nats.client.service.nodePort=${NATS_NODEPORT}" \
-          --set "agentTemplate.natsURL=${WORKER_NODE_EXTERNAL_IP}:${NATS_NODEPORT}" \
-          --set "config.capi.repositoryURL=${GIT_REPOSITORY_URL}" \
-          --set "config.capi.baseBranch=main"
-
-        # Wait for cluster to settle
-        kubectl wait --for=condition=Ready --timeout=120s -n mccp --all pod
-        kubectl get pods -A
-
+        ./test/utils/scripts/ci-cluster-install.sh mccp $CLUSTER_REPOSITORY
         kubectl port-forward -n mccp svc/my-mccp-nginx-ingress-controller 8090:80 &
     - name: Run smoke tests
       run: |
@@ -440,6 +400,8 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.WGE_GITHUB_TOKEN }}
       GITHUB_ORG: ${{ secrets.WGE_GITHUB_ORG }}
       GITHUB_USER: ${{ secrets.WGE_GITHUB_USER }}
+      DOCKER_IO_USER: ${{ secrets.WGE_DOCKER_IO_USER }} 
+      DOCKER_IO_PASSWORD: ${{ secrets.WGE_DOCKER_IO_PASSWORD }}
       MCCP_BIN_PATH: ${{ github.workspace }}/cmd/mccp/mccp
       WEGO_BIN_PATH: ${{ github.workspace }}/cmd/wego/wego-linux-x86_64
       WKP_BIN_PATH: ${{ github.workspace }}/cmd/wk/wk-v2.5.0-linux-amd64
@@ -530,94 +492,28 @@ jobs:
         name: management-${{ github.run_id }}-${{ github.run_number}}
         version: "v0.11.0"
         image: kindest/node:v1.20.7
-        config: "./test/utils/scripts/local-mccp-kind-config.yaml"
+        config: "./test/utils/data/local-mccp-kind-config.yaml"
     - name: Kind-check
       run: |
         kubectl get pods -A        
     - name: Install mccp componenets on management cluster
       run: |
-        set -x 
-        # create unique cluster config repository name
         CLUSTER_REPOSITORY=mccp-capi-template-${{ github.run_id }}-$(openssl rand -hex 8)
-        GIT_REPOSITORY_URL="https://github.com/${{ secrets.WGE_GITHUB_ORG }}/$CLUSTER_REPOSITORY"
-
         # Set the CLUSTER_REPOSITORY as environment variable for subsequent steps
         echo "CLUSTER_REPOSITORY=$CLUSTER_REPOSITORY" >> $GITHUB_ENV
-        
-        WORKER_NODE=$(kubectl get node --selector='!node-role.kubernetes.io/master' -o name)
-        kubectl label "${WORKER_NODE}" wkp-database-volume-node=true
 
-        WORKER_NODE_EXTERNAL_IP=$(ifconfig eth0 | grep -i MASK | awk '{print $2}' | cut -f2 -d:)
-        echo "Worker node ip is ${WORKER_NODE_EXTERNAL_IP}"
-        NATS_NODEPORT=31490            
-
-        kubectl create namespace prom
-        helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
-        helm repo update
-        helm install my-prom prometheus-community/kube-prometheus-stack \
-          --namespace prom \
-          --version 14.4.0 \
-          --values test/utils/data/mccp-prometheus-values.yaml
-
-        kubectl create namespace mccp
-        kubectl create secret docker-registry docker-io-pull-secret \
-          --namespace mccp \
-          --docker-username=${{ secrets.WGE_DOCKER_IO_USER }} \
-          --docker-password=${{ secrets.WGE_DOCKER_IO_PASSWORD }} 
-        kubectl create secret generic git-provider-credentials \
-          --namespace=mccp \
-          --from-literal="GIT_PROVIDER_TOKEN=${{ secrets.WGE_GITHUB_TOKEN }}"
-        CHART_VERSION=$(git describe --always | sed 's/^[^0-9]*//')
-        helm repo add wkpv3 https://s3.us-east-1.amazonaws.com/weaveworks-wkp/charts-v3/
-        helm repo update
-        helm install my-mccp wkpv3/mccp --version "${CHART_VERSION}" --namespace mccp \
-          --set "imagePullSecrets[0].name=docker-io-pull-secret" \
-          --set "wkp-ui.image.pullSecrets[0]=docker-io-pull-secret" \
-          --set "nats.client.service.nodePort=${NATS_NODEPORT}" \
-          --set "agentTemplate.natsURL=${WORKER_NODE_EXTERNAL_IP}:${NATS_NODEPORT}" \
-          --set "config.capi.repositoryURL=${GIT_REPOSITORY_URL}" \
-          --set "config.capi.baseBranch=main"
-
-        # Wait for cluster to settle
-        kubectl wait --for=condition=Ready --timeout=120s -n mccp --all pod
-        kubectl get pods -A
-
+        ./test/utils/scripts/ci-cluster-install.sh mccp $CLUSTER_REPOSITORY
         kubectl port-forward -n mccp svc/my-mccp-nginx-ingress-controller 8090:80 &
     - name: Setup wkp leaf cluster
       run: |
         kind create cluster --name my-wkp-leaf-cluster --image=kindest/node:v1.20.7 --config test/utils/data/kind-config.yaml --kubeconfig $MCCP_KIND_WKP_LEAF_KUBECONFIG
         export KUBECONFIG=$MCCP_KIND_WKP_LEAF_KUBECONFIG
 
-        export SKIP_PROMPT=1
         export CLUSTER_NAME=leaf-${{ github.run_id }}-${{ github.run_number}}
         # Set the WKP_CLUSTER_NAME as environment variable for subsequent steps
         echo "WKP_CLUSTER_NAME=$CLUSTER_NAME" >> $GITHUB_ENV
-        
-        wkp_kind_cluster_dir=$(mktemp -d)
-        cd $wkp_kind_cluster_dir
-        $WKP_BIN_PATH setup install --entitlements=${{ github.workspace }}/test/ci-wks-unlimited.entitlements
-        echo "${{ secrets.WGE_DOCKER_IO_PASSWORD }}" > /tmp/docker-io-password
-        sed -i "s/track:.*/track: wks-components/" $wkp_kind_cluster_dir/setup/config.yaml
-        sed -i "s/clusterName:.*/clusterName: $CLUSTER_NAME/" $wkp_kind_cluster_dir/setup/config.yaml
-        sed -i "s/gitProvider:.*/gitProvider: github/" $wkp_kind_cluster_dir/setup/config.yaml
-        sed -i "s/gitProviderOrg:.*/gitProviderOrg: ${{ secrets.WGE_GITHUB_ORG }}/" $wkp_kind_cluster_dir/setup/config.yaml
-        sed -i "s/dockerIOUser:.*/dockerIOUser: ${{ secrets.WGE_DOCKER_IO_USER }}/" $wkp_kind_cluster_dir/setup/config.yaml 
-        sed -i "s|dockerIOPasswordFile:.*|dockerIOPasswordFile: /tmp/docker-io-password|" $wkp_kind_cluster_dir/setup/config.yaml 
-        # don't skip the components we need those
-        export SKIP_COMPONENTS=false
-        $WKP_BIN_PATH setup run --entitlements=${{ github.workspace }}/test/ci-wks-unlimited.entitlements
-        # Wait until pods are running
-        kubectl wait nodes --all --for=condition=ready --timeout=120s || true
-        kubectl wait pods -n kube-system -l tier=control-plane --for=condition=ready --timeout=120s || true
-        kubectl wait deployment.apps/coredns -n kube-system --for=condition=available --timeout=120s || true
-        kubectl get pods -A
-        kubectl get nodes
-        $WKP_BIN_PATH workspaces add-provider \
-            --type github \
-            --token "${{ secrets.WGE_GITHUB_TOKEN }}" \
-            --secret-name github-token \
-            --git-commit-push \
-            --entitlements=${{ github.workspace }}/test/ci-wks-unlimited.entitlements
+        ./test/utils/scripts/ci-cluster-install.sh wkp $CLUSTER_NAME ${{ github.workspace }}
+
         # Unset KUBECONFIG to let kubectl point back to the MCCP cluster under test
         unset KUBECONFIG        
     - name: Run acceptance tests

--- a/test/acceptance/test/acceptance_suite_test.go
+++ b/test/acceptance/test/acceptance_suite_test.go
@@ -66,7 +66,7 @@ func TestAcceptance(t *testing.T) {
 
 	//JUnit style test report
 	junitReporter := reporters.NewJUnitReporter(JUNIT_TEST_REPORT_FILE)
-	RunSpecsWithDefaultAndCustomReporters(t, "WKP Acceptance Suite", []Reporter{junitReporter})
+	RunSpecsWithDefaultAndCustomReporters(t, "WGE Acceptance Suite", []Reporter{junitReporter})
 
 }
 

--- a/test/acceptance/test/mccp_clusters.go
+++ b/test/acceptance/test/mccp_clusters.go
@@ -226,6 +226,7 @@ func DescribeMCCPClusters(mccpTestRunner MCCPTestRunner) {
 				mccpTestRunner.ResetDatabase()
 				mccpTestRunner.VerifyMCCPPodsRunning()
 				mccpTestRunner.checkClusterService()
+				Expect(webDriver.Refresh()).ShouldNot(HaveOccurred())
 			})
 
 			clustersPage := pages.GetClustersPage(webDriver)
@@ -392,6 +393,8 @@ func DescribeMCCPClusters(mccpTestRunner MCCPTestRunner) {
 			mccpTestRunner.ResetDatabase()
 			mccpTestRunner.VerifyMCCPPodsRunning()
 			mccpTestRunner.checkClusterService()
+			Expect(webDriver.Refresh()).ShouldNot(HaveOccurred())
+
 			clustersPage := pages.GetClustersPage(webDriver)
 			Expect(webDriver.Navigate(GetWkpUrl() + "/clusters/alerts")).To(Succeed())
 			Eventually(clustersPage.NoFiringAlertMessage).Should(BeFound())
@@ -501,6 +504,8 @@ func DescribeMCCPClusters(mccpTestRunner MCCPTestRunner) {
 			mccpTestRunner.ResetDatabase()
 			mccpTestRunner.VerifyMCCPPodsRunning()
 			mccpTestRunner.checkClusterService()
+			Expect(webDriver.Refresh()).ShouldNot(HaveOccurred())
+
 			clustersPage := pages.GetClustersPage(webDriver)
 
 			Expect(webDriver.Navigate(GetWkpUrl() + "/clusters/alerts")).To(Succeed())

--- a/test/acceptance/test/utils.go
+++ b/test/acceptance/test/utils.go
@@ -90,7 +90,7 @@ var CLUSTER_REPOSITORY string
 const ARTEFACTS_BASE_DIR string = "/tmp/workspace/test/"
 const SCREENSHOTS_DIR string = ARTEFACTS_BASE_DIR + "screenshots/"
 const CLUSTER_INFO_DIR string = ARTEFACTS_BASE_DIR + "cluster-info/"
-const JUNIT_TEST_REPORT_FILE string = ARTEFACTS_BASE_DIR + "wkp_junit.xml"
+const JUNIT_TEST_REPORT_FILE string = ARTEFACTS_BASE_DIR + "acceptance-test-results.xml"
 
 const ASSERTION_DEFAULT_TIME_OUT time.Duration = 15 * time.Second
 const ASSERTION_10SECONDS_TIME_OUT time.Duration = 10 * time.Second

--- a/test/utils/data/local-mccp-kind-config.yaml
+++ b/test/utils/data/local-mccp-kind-config.yaml
@@ -1,0 +1,18 @@
+# kind-config.yaml
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+  extraMounts:
+    - hostPath: /var/run/docker.sock
+      containerPath: /var/run/docker.sock
+- role: worker
+  extraPortMappings:
+  - containerPort: 30080
+    hostPort: 30080
+    listenAddress: "0.0.0.0" # Optional, defaults to "0.0.0.0"
+    protocol: tcp # Optional, defaults to tcp
+  - containerPort: 31490
+    hostPort: 31490
+    listenAddress: "0.0.0.0" # Optional, defaults to "0.0.0.0"
+    protocol: tcp # Optional, defaults to tcp

--- a/test/utils/scripts/ci-cluster-install.sh
+++ b/test/utils/scripts/ci-cluster-install.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+
+args=("$@")
+
+if [ -z ${args[0]} ] || ([ ${args[0]} != 'mccp' ] && [ ${args[0]} != 'wkp' ])
+then 
+    echo "Invalid option, valid values => [ mccp, wkp ]"
+    exit 1
+fi
+
+set -x 
+
+function setup_mccp {
+  if [ ${#args[@]} -ne 2 ]
+  then
+    echo "Cluster repository name is required arguments for 'mccp' setup."
+    exit 1
+  fi
+
+  # create unique cluster config repository name
+  CLUSTER_REPOSITORY=${args[1]}
+  GIT_REPOSITORY_URL="https://github.com/$GITHUB_ORG/$CLUSTER_REPOSITORY"
+
+  # Set the CLUSTER_REPOSITORY as environment variable for subsequent steps
+  echo "CLUSTER_REPOSITORY=$CLUSTER_REPOSITORY" >> $GITHUB_ENV
+
+  WORKER_NODE=$(kubectl get node --selector='!node-role.kubernetes.io/master' -o name)
+  kubectl label "${WORKER_NODE}" wkp-database-volume-node=true
+
+  if [ "$RUNNER_OS" == "Linux" ]; then
+    WORKER_NODE_EXTERNAL_IP=$(ifconfig eth0 | grep -i MASK | awk '{print $2}' | cut -f2 -d:)
+  elif [ "$RUNNER_OS" == "macOS" ]; then
+    WORKER_NODE_EXTERNAL_IP=$(ifconfig eth0 | grep -i MASK | awk '{print $2}' | cut -f2 -d:)
+  fi
+
+  echo "Worker node ip is ${WORKER_NODE_EXTERNAL_IP}"
+  NATS_NODEPORT=31490            
+
+  kubectl create namespace prom
+  helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+  helm repo update
+  helm install my-prom prometheus-community/kube-prometheus-stack \
+    --namespace prom \
+    --version 14.4.0 \
+    --values test/utils/data/mccp-prometheus-values.yaml
+
+  kubectl create namespace mccp
+  kubectl create secret docker-registry docker-io-pull-secret \
+    --namespace mccp \
+    --docker-username="${DOCKER_IO_USER}" \
+    --docker-password="${DOCKER_IO_PASSWORD}" 
+  kubectl create secret generic git-provider-credentials \
+    --namespace=mccp \
+    --from-literal="GIT_PROVIDER_TOKEN=${GITHUB_TOKEN}"
+  CHART_VERSION=$(git describe --always | sed 's/^[^0-9]*//')
+  helm repo add wkpv3 https://s3.us-east-1.amazonaws.com/weaveworks-wkp/charts-v3/
+  helm repo update
+  helm install my-mccp wkpv3/mccp --version "${CHART_VERSION}" --namespace mccp \
+    --set "imagePullSecrets[0].name=docker-io-pull-secret" \
+    --set "wkp-ui.image.pullSecrets[0]=docker-io-pull-secret" \
+    --set "nats.client.service.nodePort=${NATS_NODEPORT}" \
+    --set "agentTemplate.natsURL=${WORKER_NODE_EXTERNAL_IP}:${NATS_NODEPORT}" \
+    --set "config.capi.repositoryURL=${GIT_REPOSITORY_URL}" \
+    --set "config.capi.baseBranch=main"
+
+  # Wait for cluster to settle
+  kubectl wait --for=condition=Ready --timeout=300s -n mccp --all pod
+  kubectl get pods -A
+}
+
+function setup_wkp {
+  if [ ${#args[@]} -ne 3 ]
+  then
+    echo "Cluster name and workspace path both are required arguments for 'wkp' setup."
+    exit 1
+  fi
+  export SKIP_PROMPT=1
+  export CLUSTER_NAME=${args[1]}
+  
+  wkp_kind_cluster_dir=$(mktemp -d)
+  cd $wkp_kind_cluster_dir
+  $WKP_BIN_PATH setup install --entitlements=${args[2]}/test/ci-wks-unlimited.entitlements
+  echo "${DOCKER_IO_PASSWORD}" > /tmp/docker-io-password
+  sed -i "s/track:.*/track: wks-components/" ${wkp_kind_cluster_dir}/setup/config.yaml
+  sed -i "s/clusterName:.*/clusterName: ${CLUSTER_NAME}/" ${wkp_kind_cluster_dir}/setup/config.yaml
+  sed -i "s/gitProvider:.*/gitProvider: github/" ${wkp_kind_cluster_dir}/setup/config.yaml
+  sed -i "s/gitProviderOrg:.*/gitProviderOrg: ${GITHUB_ORG}/" ${wkp_kind_cluster_dir}/setup/config.yaml
+  sed -i "s/dockerIOUser:.*/dockerIOUser: ${DOCKER_IO_USER}/" ${wkp_kind_cluster_dir}/setup/config.yaml 
+  sed -i "s|dockerIOPasswordFile:.*|dockerIOPasswordFile: /tmp/docker-io-password|" ${wkp_kind_cluster_dir}/setup/config.yaml 
+  # don't skip the components we need those
+  export SKIP_COMPONENTS=false
+  $WKP_BIN_PATH setup run --entitlements=${args[2]}/test/ci-wks-unlimited.entitlements
+  # Wait until pods are running
+  kubectl wait nodes --all --for=condition=ready --timeout=120s || true
+  kubectl wait pods -n kube-system -l tier=control-plane --for=condition=ready --timeout=120s || true
+  kubectl wait deployment.apps/coredns -n kube-system --for=condition=available --timeout=120s || true
+  kubectl get pods -A
+  kubectl get nodes
+  $WKP_BIN_PATH workspaces add-provider \
+      --type github \
+      --token "${GITHUB_TOKEN}" \
+      --secret-name github-token \
+      --git-commit-push \
+      --entitlements=${args[2]}/test/ci-wks-unlimited.entitlements
+}
+
+if [ ${args[0]} = 'mccp' ]
+then
+    setup_mccp
+fi
+
+if [ ${args[0]} = 'wkp' ]
+then
+    setup_wkp
+fi


### PR DESCRIPTION
- Created a deploy work flow which will only trigger when PR is merged to main
- Deploy work flow creates both linux and macOS binaries and publish to S3 when acceptance tests pass.
- Deploy workflow runs unit tests and convert the tests out put to junit format which can be uploaded to any test management system e.g. Teamspace. (Wego core are uploading results to Teamspace)
-  A place holder job for publishing test results is created for future use.
- Moved lengthy cluster setup steps to bash script for reusability among all work flows.
-  Fixed couple of unstable UI tests occasionally failing due to new error popup box.

closes #48 