### PR TITLE
fix mccp binary name for release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -74,7 +74,7 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: mccp-binaries
-        path: cmd/mccp/mccp-${{ matrix.os }}-release
+        path: cmd/mccp/mccp-${{ env.TAG }}-${{ matrix.os_name }}-amd64
         retention-days: 1
     - name: Install Helm v3
       if: ${{ runner.os == 'Linux' }}


### PR DESCRIPTION
- Fixed the mccp binary name for release workflow
closes #107 