### PR TITLE
Enable auto cancelling of gh action PR workflow for new commit

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,6 +2,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+concurrency: 
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
+
 name: run tests
 jobs:
   lint:


### PR DESCRIPTION
- Existing GH action test/PR workflow automatically gets cancelled when new commit comes in.
- The new workflow for new commit will start as usual.

closes #123 