### PR TITLE
fixed downlload gitops container action

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -248,12 +248,10 @@ jobs:
         name: mccp-binaries
         path: cmd/mccp
     - name: Download gitops binary from GitHub
-      uses: Legion2/download-release-action@v2.1.0
-      with:
-        repository: weaveworks/weave-gitops
-        tag: 'v0.3.0'
-        path: cmd/gitops/
-        file: gitops-${{ matrix.os_name }}-x86_64
+      run: |
+        mkdir -p cmd/gitops/
+        wget https://github.com/weaveworks/weave-gitops/releases/download/v0.3.0/gitops-${{ matrix.os_name }}-x86_64
+        mv gitops-${{ matrix.os_name }}-x86_64 $GITOPS_BIN_PATH
     - name: Download wk binary from s3
       run: |
         mkdir -p cmd/wk/

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -202,12 +202,10 @@ jobs:
         name: mccp-binaries
         path: cmd/mccp
     - name: Download gitops binary from GitHub
-      uses: Legion2/download-release-action@v2.1.0
-      with:
-        repository: weaveworks/weave-gitops
-        tag: 'v0.3.0'
-        path: cmd/gitops/
-        file: gitops-${{ matrix.os_name }}-x86_64
+      run: |
+        mkdir -p cmd/gitops/
+        wget https://github.com/weaveworks/weave-gitops/releases/download/v0.3.0/gitops-${{ matrix.os_name }}-x86_64
+        mv gitops-${{ matrix.os_name }}-x86_64 $GITOPS_BIN_PATH    
     - name: Download wk binary from s3
       run: |
         mkdir -p cmd/wk/
@@ -395,12 +393,10 @@ jobs:
   #       name: mccp-binaries
   #       path: cmd/mccp
   #   - name: Download gitops binary from GitHub
-  #     uses: Legion2/download-release-action@v2.1.0
-  #     with:
-  #       repository: weaveworks/weave-gitops
-  #       tag: 'v0.3.0'
-  #       path: cmd/gitops/
-  #       file: gitops-${{ matrix.os_name }}-x86_64
+  #     run: |
+  #       mkdir -p cmd/gitops/
+  #       wget https://github.com/weaveworks/weave-gitops/releases/download/v0.3.0/gitops-${{ matrix.os_name }}-x86_64
+  #       mv gitops-${{ matrix.os_name }}-x86_64 $GITOPS_BIN_PATH    
   #   - name: Download wk binary from s3
   #     run: |
   #       mkdir -p cmd/wk/


### PR DESCRIPTION
- Fixed download container action for gitops binary for macOS

closes #137 