### PR TITLE
Use randalpha to avoid generating tokens that start with numbers

### DIFF
--- a/charts/mccp/Chart.lock
+++ b/charts/mccp/Chart.lock
@@ -8,5 +8,5 @@ dependencies:
 - name: wkp-ui
   repository: file://../../ui/chart/wkp-ui
   version: 0.1.0
-digest: sha256:aff11aae02e840a2397d5001f5739765895a43511d8f145300ddd4a2df0064db
-generated: "2021-05-11T20:02:33.709847+02:00"
+digest: sha256:afb4d91b97d063f13157cd771234ad4457fce72a6bbf479961bbe19570b5d88e
+generated: "2021-10-01T17:11:35.07342+01:00"

--- a/charts/mccp/Chart.yaml
+++ b/charts/mccp/Chart.yaml
@@ -31,4 +31,5 @@ dependencies:
     version: '7.4.7'
     repository: https://charts.bitnami.com/bitnami
   - name: wkp-ui
+    version: '0.1.0'
     repository: 'file://../../ui/chart/wkp-ui'

--- a/charts/mccp/templates/nats/nats-env-vars-secret.yaml
+++ b/charts/mccp/templates/nats/nats-env-vars-secret.yaml
@@ -12,5 +12,5 @@ data:
   {{- else if .Values.NATS_AUTH_TOKEN }}
   NATS_AUTH_TOKEN: {{ .Values.NATS_AUTH_TOKEN | b64enc | quote }}
   {{- else }}
-  NATS_AUTH_TOKEN: {{ randAlphaNum 20 | b64enc | quote }}
+  NATS_AUTH_TOKEN: {{ randAlpha 20 | b64enc | quote }}
   {{- end }}


### PR DESCRIPTION
After noticing some intermittent failures with NATS not starting, we tracked that down to the NATS_AUTH_TOKEN not being quoted. To address this we've attempted to update the NATS chart dependency to the version where the token is being quoted at version 6.2.3. However in doing so, we broke how NATS was reading the token since for the variable to work it needs to start with `$` and not `"` ([docs](https://docs.nats.io/nats-server/configuration#variables)). Which suggests that future updates to newer versions of the NATS chart will be problematic until we address how we pass a token to NATS.

Original fix [here](https://github.com/bitnami/charts/commit/b9c70039a697837098f195d1e2bcd8bf7c28b66c#diff-04b375a0fdc43c4ce6f25653ca33d4c5608b7968868ee09a70de17ab571f0a0e)

As a temporary fix, I've updated the function that generates the token, from `randAlphaNum` to `randAlpha` to address the occassional issue of NATS crashlooping (based on [these](https://docs.nats.io/nats-server/configuration#variables) notes in the docs). 

Fixes #142 