### PR TITLE
Populate `required` field for template params in the HTTP API

### DIFF
--- a/cmd/capi-server/pkg/capi/meta_test.go
+++ b/cmd/capi-server/pkg/capi/meta_test.go
@@ -42,10 +42,12 @@ func TestParseTemplateMeta(t *testing.T) {
 			{
 				Name:        "CLUSTER_NAME",
 				Description: "This is used for the cluster naming.",
+				Required:    true,
 			},
 			{
 				Name:        "CONTROL_PLANE_MACHINE_COUNT",
 				Description: "How many machine replicas to setup.",
+				Required:    true,
 			},
 		},
 	}

--- a/cmd/capi-server/pkg/capi/params.go
+++ b/cmd/capi-server/pkg/capi/params.go
@@ -27,6 +27,7 @@ func ParamsFromSpec(s capiv1.CAPITemplateSpec) ([]Param, error) {
 		if m, ok := paramsMeta[v.Name]; ok {
 			m.Description = v.Description
 			m.Options = v.Options
+			m.Required = v.Required
 			paramsMeta[v.Name] = m
 		}
 	}

--- a/cmd/capi-server/pkg/capi/testdata/template3.yaml
+++ b/cmd/capi-server/pkg/capi/testdata/template3.yaml
@@ -7,8 +7,10 @@ spec:
   params:
     - name: CLUSTER_NAME
       description: This is used for the cluster naming.
+      required: true
     - name: CONTROL_PLANE_MACHINE_COUNT
       description: How many machine replicas to setup.
+      required: true
   resourcetemplates:
     - apiVersion: cluster.x-k8s.io/v1alpha3
       kind: Cluster


### PR DESCRIPTION
The `required` field was not being populated.