### PR TITLE
Import auth plugins package so `mccp upgrade` works with GKE

### DIFF
--- a/cmd/mccp/main.go
+++ b/cmd/mccp/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"github.com/weaveworks/weave-gitops-enterprise/cmd/mccp/cmd"
 	"github.com/weaveworks/weave-gitops-enterprise/pkg/cmdutil"
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
 )
 
 func main() {


### PR DESCRIPTION
Fixes #148 