### PR TITLE
Update enterprise workflows to use latest gitops binary from weave-gitops repository

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -160,8 +160,6 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.WGE_GITHUB_TOKEN }}
       GITHUB_ORG: ${{ secrets.WGE_GITHUB_ORG }}
       GITHUB_USER: ${{ secrets.WGE_GITHUB_USER }}
-      DOCKER_IO_USER: ${{ secrets.WGE_DOCKER_IO_USER }} 
-      DOCKER_IO_PASSWORD: ${{ secrets.WGE_DOCKER_IO_PASSWORD }}
       GITOPS_BIN_PATH: ${{ github.workspace }}/cmd/gitops/gitops-${{ matrix.os_name }}-x86_64
       WKP_BIN_PATH: ${{ github.workspace }}/cmd/wk/wk-v2.5.0-${{ matrix.os_name }}-amd64
       SELENIUM_DEBUG: true
@@ -222,11 +220,11 @@ jobs:
         git config --global user.email "test-user@weave.works"
         git config --global user.name "test-user"
         git config --global url.ssh://git@github.com/.insteadOf https://github.com/    
-    - name: Download gitops binary from GitHub
+    - name: Download gitops binary from s3
       run: |
         mkdir -p cmd/gitops/
-        wget https://github.com/weaveworks/weave-gitops/releases/download/v0.3.2-rc/gitops-${{ matrix.os_name }}-x86_64
-        mv gitops-${{ matrix.os_name }}-x86_64 $GITOPS_BIN_PATH
+        wget https://weave-gitops.s3.us-east-2.amazonaws.com/gitops-${{ matrix.os }}
+        mv gitops-${{ matrix.os }} $GITOPS_BIN_PATH
     - name: Download wk binary from s3
       run: |
         mkdir -p cmd/wk/

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -95,8 +95,6 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.WGE_GITHUB_TOKEN }}
       GITHUB_ORG: ${{ secrets.WGE_GITHUB_ORG }}
       GITHUB_USER: ${{ secrets.WGE_GITHUB_USER }}
-      DOCKER_IO_USER: ${{ secrets.WGE_DOCKER_IO_USER }} 
-      DOCKER_IO_PASSWORD: ${{ secrets.WGE_DOCKER_IO_PASSWORD }}
       GITOPS_BIN_PATH: ${{ github.workspace }}/cmd/gitops/gitops-${{ matrix.os_name }}-x86_64
       WKP_BIN_PATH: ${{ github.workspace }}/cmd/wk/wk-v2.5.0-${{ matrix.os_name }}-amd64
       WGE_ACCEPTANCE_EKS_KUBECONFIG: ${{ secrets.WGE_ACCEPTANCE_EKS_KUBECONFIG }}
@@ -174,11 +172,12 @@ jobs:
         git config --global user.email "test-user@weave.works"
         git config --global user.name "test-user"
         git config --global url.ssh://git@github.com/.insteadOf https://github.com/    
-    - name: Download gitops binary from GitHub
+    - name: Download gitops binary from s3
       run: |
         mkdir -p cmd/gitops/
-        wget https://github.com/weaveworks/weave-gitops/releases/download/v0.3.2-rc/gitops-${{ matrix.os_name }}-x86_64
-        mv gitops-${{ matrix.os_name }}-x86_64 $GITOPS_BIN_PATH    
+        
+        wget https://weave-gitops.s3.us-east-2.amazonaws.com/gitops-${{ matrix.os }}
+        mv gitops-${{ matrix.os }} $GITOPS_BIN_PATH 
     - name: Download wk binary from s3
       run: |
         mkdir -p cmd/wk/
@@ -282,8 +281,6 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.WGE_GITHUB_TOKEN }}
       GITHUB_ORG: ${{ secrets.WGE_GITHUB_ORG }}
       GITHUB_USER: ${{ secrets.WGE_GITHUB_USER }}
-      DOCKER_IO_USER: ${{ secrets.WGE_DOCKER_IO_USER }} 
-      DOCKER_IO_PASSWORD: ${{ secrets.WGE_DOCKER_IO_PASSWORD }}
       GITOPS_BIN_PATH: ${{ github.workspace }}/cmd/gitops/gitops-${{ matrix.os_name }}-x86_64
       WKP_BIN_PATH: ${{ github.workspace }}/cmd/wk/wk-v2.5.0-${{ matrix.os_name }}-amd64
       WGE_ACCEPTANCE_GCE_KUBECONFIG: ${{ secrets.WGE_ACCEPTANCE_GCE_KUBECONFIG }}
@@ -351,11 +348,11 @@ jobs:
         git config --global user.email "test-user@weave.works"
         git config --global user.name "test-user"
         git config --global url.ssh://git@github.com/.insteadOf https://github.com/    
-    - name: Download gitops binary from GitHub
+    - name: Download gitops binary from s3
       run: |
         mkdir -p cmd/gitops/
-        wget https://github.com/weaveworks/weave-gitops/releases/download/v0.3.2-rc/gitops-${{ matrix.os_name }}-x86_64
-        mv gitops-${{ matrix.os_name }}-x86_64 $GITOPS_BIN_PATH    
+        wget https://weave-gitops.s3.us-east-2.amazonaws.com/gitops-${{ matrix.os }}
+        mv gitops-${{ matrix.os }} $GITOPS_BIN_PATH 
     - name: Download wk binary from s3
       run: |
         mkdir -p cmd/wk/

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -71,7 +71,7 @@ jobs:
           # Update the MCCP chart values.yaml file with the current image tag
           make update-mccp-chart-values CHART_VALUES_PATH=$CHART_VALUES_PATH
           # Publish the MCCP Helm v3 chart
-          ./bin/publish-chart-to-s3.sh $TAG "releases/charts-v3" ./charts/mccp
+          ./bin/publish-chart-to-s3.sh $TAG "releases/charts-v3" ./charts/mccp    
     - name: Login to Docker Hub
       uses: docker/login-action@v1
       with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -160,7 +160,7 @@ jobs:
         make update-mccp-chart-values CHART_VALUES_PATH=$CHART_VALUES_PATH
 
         # Publish the MCCP Helm v3 chart
-        ./bin/publish-chart-to-s3.sh $TAG "charts-v3" ./charts/mccp
+        ./bin/publish-chart-to-s3.sh $TAG "charts-v3" ./charts/mccp    
     - name: Login to Docker Hub
       uses: docker/login-action@v1
       with:
@@ -297,8 +297,6 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.WGE_GITHUB_TOKEN }}
       GITHUB_ORG: ${{ secrets.WGE_GITHUB_ORG }}
       GITHUB_USER: ${{ secrets.WGE_GITHUB_USER }}
-      DOCKER_IO_USER: ${{ secrets.WGE_DOCKER_IO_USER }} 
-      DOCKER_IO_PASSWORD: ${{ secrets.WGE_DOCKER_IO_PASSWORD }}
       GITOPS_BIN_PATH: ${{ github.workspace }}/cmd/gitops/gitops-linux-x86_64
       SELENIUM_DEBUG: true
       ACCEPTANCE_TESTS_DATABASE_TYPE: sqlite
@@ -350,13 +348,11 @@ jobs:
         git config --global user.email "test-user@weave.works"
         git config --global user.name "test-user"
         git config --global url.ssh://git@github.com/.insteadOf https://github.com/
-    - name: Download gitops binary from GitHub
-      uses: Legion2/download-release-action@v2.1.0
-      with:
-        repository: weaveworks/weave-gitops
-        tag: 'v0.3.2-rc'
-        path: cmd/gitops/
-        file: gitops-linux-x86_64
+    - name: Download gitops binary from s3
+      run: |
+        mkdir -p cmd/gitops/
+        wget https://weave-gitops.s3.us-east-2.amazonaws.com/gitops-ubuntu-latest
+        mv gitops-ubuntu-latest $GITOPS_BIN_PATH
     - name: Change bin permissions
       run: |
         sudo chmod +x ${{ env.GITOPS_BIN_PATH }}
@@ -404,8 +400,6 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.WGE_GITHUB_TOKEN }}
       GITHUB_ORG: ${{ secrets.WGE_GITHUB_ORG }}
       GITHUB_USER: ${{ secrets.WGE_GITHUB_USER }}
-      DOCKER_IO_USER: ${{ secrets.WGE_DOCKER_IO_USER }} 
-      DOCKER_IO_PASSWORD: ${{ secrets.WGE_DOCKER_IO_PASSWORD }}
       GITOPS_BIN_PATH: ${{ github.workspace }}/cmd/gitops/gitops-linux-x86_64
       WKP_BIN_PATH: ${{ github.workspace }}/cmd/wk/wk-v2.5.0-linux-amd64
       SELENIUM_DEBUG: true
@@ -459,13 +453,11 @@ jobs:
         git config --global user.email "test-user@weave.works"
         git config --global user.name "test-user"
         git config --global url.ssh://git@github.com/.insteadOf https://github.com/
-    - name: Download gitops binary from GitHub
-      uses: Legion2/download-release-action@v2.1.0
-      with:
-        repository: weaveworks/weave-gitops
-        tag: 'v0.3.2-rc'
-        path: cmd/gitops/
-        file: gitops-linux-x86_64
+    - name: Download gitops binary from s3
+      run: |
+        mkdir -p cmd/gitops/
+        wget https://weave-gitops.s3.us-east-2.amazonaws.com/gitops-ubuntu-latest
+        mv gitops-ubuntu-latest $GITOPS_BIN_PATH
     - name: Change bin permissions
       run: |
         sudo chmod +x ${{ env.GITOPS_BIN_PATH }}

--- a/test/acceptance/test/utils.go
+++ b/test/acceptance/test/utils.go
@@ -423,7 +423,7 @@ func (b RealGitopsTestRunner) ResetDatabase() error {
 }
 
 func (b RealGitopsTestRunner) VerifyWegoPodsRunning() {
-	command := exec.Command("sh", "-c", fmt.Sprintf("kubectl wait --for=condition=Ready pods --timeout=60s -n %s --all", GITOPS_DEFAULT_NAMESPACE))
+	command := exec.Command("sh", "-c", fmt.Sprintf("kubectl wait --for=condition=Ready pods --timeout=60s -n %s --all --selector='app!=wego-app'", GITOPS_DEFAULT_NAMESPACE))
 	session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
 	Expect(err).ShouldNot(HaveOccurred())
 	Eventually(session, ASSERTION_2MINUTE_TIME_OUT).Should(gexec.Exit())
@@ -894,7 +894,7 @@ func VerifyControllersInCluster(namespace string) {
 	Expect(waitForResource("pods", "", namespace, ASSERTION_2MINUTE_TIME_OUT))
 
 	By("And I wait for the gitops controllers to be ready", func() {
-		command := exec.Command("sh", "-c", fmt.Sprintf("kubectl wait --for=condition=Ready --timeout=%s -n %s --all pod", "120s", namespace))
+		command := exec.Command("sh", "-c", fmt.Sprintf("kubectl wait --for=condition=Ready --timeout=%s -n %s --all pod --selector='app!=wego-app'", "120s", namespace))
 		session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
 		Expect(err).ShouldNot(HaveOccurred())
 		Eventually(session, ASSERTION_2MINUTE_TIME_OUT).Should(gexec.Exit())

--- a/test/utils/scripts/wego-enterprise.sh
+++ b/test/utils/scripts/wego-enterprise.sh
@@ -63,10 +63,6 @@ function setup {
 
   kubectl create ns wego-system
   kubectl apply -f ${args[1]}/test/utils/scripts/entitlement-secret.yaml
-  kubectl create secret docker-registry docker-io-pull-secret \
-    --namespace wego-system \
-    --docker-username="${DOCKER_IO_USER}" \
-    --docker-password="${DOCKER_IO_PASSWORD}" 
   kubectl create secret generic git-provider-credentials \
     --namespace=wego-system \
     --from-literal="GIT_PROVIDER_TOKEN=${GITHUB_TOKEN}"
@@ -87,8 +83,6 @@ function setup {
     kubectl create secret generic mccp-db-credentials --namespace wego-system --from-literal=username=postgres --from-literal=password=password
 
     helm install my-mccp wkpv3/mccp --version "${CHART_VERSION}" --namespace wego-system \
-      --set "imagePullSecrets[0].name=docker-io-pull-secret" \
-      --set "wkp-ui.image.pullSecrets[0]=docker-io-pull-secret" \
       --set "nats.client.service.nodePort=${NATS_NODEPORT}" \
       --set "agentTemplate.natsURL=${WORKER_NODE_EXTERNAL_IP}:${NATS_NODEPORT}" \
       --set "nginx-ingress-controller.service.type=NodePort" \
@@ -101,8 +95,6 @@ function setup {
   else
     # KIND cluster 
     helm install my-mccp wkpv3/mccp --version "${CHART_VERSION}" --namespace wego-system \
-      --set "imagePullSecrets[0].name=docker-io-pull-secret" \
-      --set "wkp-ui.image.pullSecrets[0]=docker-io-pull-secret" \
       --set "nats.client.service.nodePort=${NATS_NODEPORT}" \
       --set "agentTemplate.natsURL=${WORKER_NODE_EXTERNAL_IP}:${NATS_NODEPORT}" \
       --set "nginx-ingress-controller.service.nodePorts.http=${UI_NODEPORT}" \


### PR DESCRIPTION
- Updated all workflows to use latest gitops binary from weave-gitops
- Remove docker login credentials and secret from wokflows and setup cluster script
- Stop checking wego-app controller status as it is not required for enterprise 

closes #220 