### PR TITLE
Using chrome driver as web driver for macOS runner

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -243,16 +243,12 @@ jobs:
         sudo chmod +x ${{ env.GITOPS_BIN_PATH }}
         sudo chmod +x ${{ env.WKP_BIN_PATH }}  
     - name: Setup selenium server
+      if: ${{ runner.os == 'Linux' }}
       run: |
-        if [ "$RUNNER_OS" == "Linux" ]; then
-          wget  https://selenium-release.storage.googleapis.com/3.14/selenium-server-standalone-3.14.0.jar
+        wget  https://selenium-release.storage.googleapis.com/3.14/selenium-server-standalone-3.14.0.jar
 
-          # Start selenium server in standalone mode
-          xvfb-run -a --server-args="-screen 0 1280x1024x24" java -jar ./selenium-server-standalone-3.14.0.jar &
-
-        elif [ "$RUNNER_OS" == "macOS" ]; then
-          selenium-server & 
-        fi
+        # Start selenium server in standalone mode
+        xvfb-run -a --server-args="-screen 0 1280x1024x24" java -jar ./selenium-server-standalone-3.14.0.jar &
     - name: Setup kind management cluster
       run: |
         kind create cluster --name management-${{ github.run_id }}-${{ github.run_number}} --image=kindest/node:v1.20.7 --config test/utils/data/local-kind-config.yaml

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -196,16 +196,12 @@ jobs:
         sudo chmod +x ${{ env.GITOPS_BIN_PATH }}
         sudo chmod +x ${{ env.WKP_BIN_PATH }}  
     - name: Setup selenium server
+      if: ${{ runner.os == 'Linux' }}
       run: |
-        if [ "$RUNNER_OS" == "Linux" ]; then
-          wget  https://selenium-release.storage.googleapis.com/3.14/selenium-server-standalone-3.14.0.jar
+        wget  https://selenium-release.storage.googleapis.com/3.14/selenium-server-standalone-3.14.0.jar
 
-          # Start selenium server in standalone mode
-          xvfb-run -a --server-args="-screen 0 1280x1024x24" java -jar ./selenium-server-standalone-3.14.0.jar &
-
-        elif [ "$RUNNER_OS" == "macOS" ]; then
-          selenium-server & 
-        fi  
+        # Start selenium server in standalone mode
+        xvfb-run -a --server-args="-screen 0 1280x1024x24" java -jar ./selenium-server-standalone-3.14.0.jar &        
     - name: Setup EKS management cluster
       run: |
         export CLUSTER_NAME=wego-enterprise-nightly-cluster-${{ matrix.os_name }}
@@ -380,16 +376,12 @@ jobs:
         sudo chmod +x ${{ env.GITOPS_BIN_PATH }}
         sudo chmod +x ${{ env.WKP_BIN_PATH }}  
     - name: Setup selenium server
+      if: ${{ runner.os == 'Linux' }}
       run: |
-        if [ "$RUNNER_OS" == "Linux" ]; then
-          wget  https://selenium-release.storage.googleapis.com/3.14/selenium-server-standalone-3.14.0.jar
+        wget  https://selenium-release.storage.googleapis.com/3.14/selenium-server-standalone-3.14.0.jar
 
-          # Start selenium server in standalone mode
-          xvfb-run -a --server-args="-screen 0 1280x1024x24" java -jar ./selenium-server-standalone-3.14.0.jar &
-
-        elif [ "$RUNNER_OS" == "macOS" ]; then
-          selenium-server & 
-        fi  
+        # Start selenium server in standalone mode
+        xvfb-run -a --server-args="-screen 0 1280x1024x24" java -jar ./selenium-server-standalone-3.14.0.jar &
     - name: Setup GKE management cluster
       run: |
         export CLUSTER_NAME=wego-enterprise-nightly-cluster-${{ matrix.os_name }}
@@ -433,7 +425,7 @@ jobs:
       run: |
         cd test/acceptance/test/
         if [ "$RUNNER_OS" == "macOS" ]; then
-          go test -ginkgo.skip=@eks -ginkgo.skip=@gce -ginkgo.skip=@wkp -ginkgo.skip=@capd -ginkgo.v -v --timeout=99999s
+          go test -ginkgo.skip=@eks -ginkgo.skip=@gce -ginkgo.skip=@wkp -ginkgo.skip=@capd -ginkgo.skip=@upgrade -ginkgo.v -v --timeout=99999s
         else
           go test -ginkgo.skip=@eks -ginkgo.skip=@gce -ginkgo.skip=@capd -ginkgo.v -v --timeout=99999s
         fi

--- a/test/acceptance/test/cli_add_delete.go
+++ b/test/acceptance/test/cli_add_delete.go
@@ -428,7 +428,7 @@ func DescribeCliAddDelete(gitopsTestRunner GitopsTestRunner) {
 
 			JustBeforeEach(func() {
 				log.Println("Connecting cluster to itself")
-				initializeWebdriver(GetWGEUrl())
+				InitializeWebdriver(GetWGEUrl())
 				leaf := LeafSpec{
 					Status:          "Ready",
 					IsWKP:           false,

--- a/test/acceptance/test/cli_upgrade.go
+++ b/test/acceptance/test/cli_upgrade.go
@@ -78,6 +78,7 @@ func DescribeCliUpgrade(gitopsTestRunner GitopsTestRunner) {
 
 			appName := "wego-upgrade"
 			appPath := "upgrade"
+			templateFiles := []string{}
 
 			JustBeforeEach(func() {
 				current_context, _ = runCommandAndReturnStringOutput("kubectl config current-context")
@@ -89,6 +90,9 @@ func DescribeCliUpgrade(gitopsTestRunner GitopsTestRunner) {
 			})
 
 			JustAfterEach(func() {
+
+				gitopsTestRunner.DeleteApplyCapiTemplates(templateFiles)
+				templateFiles = []string{}
 
 				gitopsTestRunner.DeleteRepo(CLUSTER_REPOSITORY)
 				_ = deleteDirectory([]string{path.Join("/tmp", CLUSTER_REPOSITORY)})
@@ -170,10 +174,11 @@ func DescribeCliUpgrade(gitopsTestRunner GitopsTestRunner) {
 				})
 
 				By("And I should update/modify the default upgrade manifest ", func() {
-					public_ip = ClusterWorkloadNonePublicIP()
+					public_ip = ClusterWorkloadNonePublicIP("KIND")
 					natsURL := public_ip + ":" + NATS_NODEPORT
+					repositoryURL := fmt.Sprintf(`https://github.com/%s/%s`, GITHUB_ORG, CLUSTER_REPOSITORY)
 					gitopsTestRunner.PullBranch(repoAbsolutePath, prBranch)
-					configureConfigMapvalues(repoAbsolutePath, UI_NODEPORT, NATS_NODEPORT, natsURL, "")
+					configureConfigMapvalues(repoAbsolutePath, UI_NODEPORT, NATS_NODEPORT, natsURL, repositoryURL)
 					GitSetUpstream(repoAbsolutePath, prBranch)
 					GitUpdateCommitPush(repoAbsolutePath)
 				})
@@ -221,7 +226,7 @@ func DescribeCliUpgrade(gitopsTestRunner GitopsTestRunner) {
 						test_ui_url = "http://localhost:8000"
 						capi_endpoint_url = "http://localhost:8000"
 					}
-					initializeWebdriver(test_ui_url)
+					InitializeWebdriver(test_ui_url)
 				})
 
 				By("And the Cluster service is healthy", func() {

--- a/test/acceptance/test/ui_clusters.go
+++ b/test/acceptance/test/ui_clusters.go
@@ -262,7 +262,7 @@ func DescribeClusters(gitopsTestRunner GitopsTestRunner) {
 			By("Given Kubernetes cluster is setup", func() {
 				//TODO - Verify that cluster is up and running using kubectl
 			})
-			initializeWebdriver(GetWGEUrl())
+			InitializeWebdriver(GetWGEUrl())
 		})
 
 		AfterEach(func() {

--- a/test/acceptance/test/ui_templates.go
+++ b/test/acceptance/test/ui_templates.go
@@ -64,7 +64,7 @@ func DescribeTemplates(gitopsTestRunner GitopsTestRunner) {
 			By("Given Kubernetes cluster is setup", func() {
 				gitopsTestRunner.CheckClusterService(GetCapiEndpointUrl())
 			})
-			initializeWebdriver(GetWGEUrl())
+			InitializeWebdriver(GetWGEUrl())
 		})
 
 		AfterEach(func() {
@@ -823,10 +823,10 @@ func DescribeTemplates(gitopsTestRunner GitopsTestRunner) {
 
 				// Azure template parameter values
 				azureClusterName := "my-azure-cluster"
-				azureK8version := "1.19.7"
+				azureK8version := "1.21.2"
 				azureNamespace := "default"
-				azureControlMAchineType := "HBv2"
-				azureNodeMAchineType := "Dasv4"
+				azureControlMAchineType := "Standard_D2s_v3"
+				azureNodeMAchineType := "Standard_D4_v4"
 
 				paramSection := make(map[string][]TemplateField)
 				paramSection["2.AzureCluster"] = []TemplateField{
@@ -850,16 +850,16 @@ func DescribeTemplates(gitopsTestRunner GitopsTestRunner) {
 					},
 					{
 						Name:   "KUBERNETES_VERSION",
-						Value:  azureK8version,
-						Option: "",
+						Value:  "",
+						Option: azureK8version,
 					},
 				}
 
 				paramSection["4.AzureMachineTemplate"] = []TemplateField{
 					{
 						Name:   "AZURE_CONTROL_PLANE_MACHINE_TYPE",
-						Value:  azureControlMAchineType,
-						Option: "",
+						Value:  "",
+						Option: azureControlMAchineType,
 					},
 				}
 
@@ -874,8 +874,8 @@ func DescribeTemplates(gitopsTestRunner GitopsTestRunner) {
 				paramSection["6.AzureMachineTemplate"] = []TemplateField{
 					{
 						Name:   "AZURE_NODE_MACHINE_TYPE",
-						Value:  azureNodeMAchineType,
-						Option: "",
+						Value:  "",
+						Option: azureNodeMAchineType,
 					},
 				}
 

--- a/test/utils/data/capi-server-v1-template-azure.yaml
+++ b/test/utils/data/capi-server-v1-template-azure.yaml
@@ -7,9 +7,19 @@ spec:
   description: This is Azure capi quick start template-{{.Count}}
   params:
     - name: CLUSTER_NAME
-      description: This is used for the cluster naming.
-      options: []
       required: true
+      description: This is used for the cluster naming.
+    - name: NAMESPACE
+      description: Namespace to create the cluster in
+    - name: KUBERNETES_VERSION
+      description: Kubernetes version to use for the cluster
+      options: ["1.19.7", "1.20.9", "1.21.2"]
+    - name: AZURE_CONTROL_PLANE_MACHINE_TYPE
+      description: VM control plane types
+      options: ["Standard_D2s_v3", "Standard_D4_v4"]
+    - name: AZURE_NODE_MACHINE_TYPE
+      description: VM node types
+      options: ["Standard_D2s_v3", "Standard_D4_v4"]
   resourcetemplates:
     - apiVersion: cluster.x-k8s.io/v1alpha4
       kind: Cluster


### PR DESCRIPTION
- Make UI acceptance tests to use chrome driver as webdriver because selenium server 4.0 is not compatible with agouti
- Fixed failing upgrade test on EKS due to wrong upgrade cluster type

closes #271 