### PR TITLE
Fixes branch ref for new build workflow

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -7,7 +7,7 @@ on:
 name: deploy
 jobs:
   build:
-    uses: weaveworks/weave-gitops-enterprise/.github/workflows/build.yaml@build-optimizations
+    uses: weaveworks/weave-gitops-enterprise/.github/workflows/build.yaml@main
     with:
       helmrepo: "charts-v3"
     secrets:

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -6,7 +6,7 @@ on:
 name: nightly
 jobs:
   build:
-    uses: weaveworks/weave-gitops-enterprise/.github/workflows/build.yaml@build-optimizations
+    uses: weaveworks/weave-gitops-enterprise/.github/workflows/build.yaml@main
     with:
       helmrepo: "nightly/charts-v3"
     secrets:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,7 +5,7 @@ on:
 name: release
 jobs:
   build:
-    uses: weaveworks/weave-gitops-enterprise/.github/workflows/build.yaml@build-optimizations
+    uses: weaveworks/weave-gitops-enterprise/.github/workflows/build.yaml@main
     with:
       helmrepo: "releases/charts-v3"
     secrets:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -92,7 +92,7 @@ jobs:
     #     curl -k "https://coveralls.io/webhook?repo_token=$WGE_COVERALLS_TOKEN" -d "payload[build_num]=$GITHUB_RUN_NUMBER&payload[status]=done"
   
   build:
-    uses: weaveworks/weave-gitops-enterprise/.github/workflows/build.yaml@build-optimizations
+    uses: weaveworks/weave-gitops-enterprise/.github/workflows/build.yaml@main
     with:
       helmrepo: "dev/charts-v3"
     secrets:


### PR DESCRIPTION
New `build` workflow is a [reusable workflow](https://docs.github.com/en/actions/learn-github-actions/reusing-workflows)

Unfortunately for now you must provide a branch name when referencing them. From the above:

> You reference reusable workflow files using the syntax:
> `{owner}/{repo}/{path}/{filename}@{ref}`

This changes the branch ref from `build-optimizations` where it was developed in #264 to `main` where it will live on.