### PR TITLE
Fixes publishing to the release helm chart repo

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -177,7 +177,7 @@ jobs:
         make update-mccp-chart-values CHART_VALUES_PATH=$CHART_VALUES_PATH
 
         # Publish the MCCP Helm v3 chart
-        ./bin/publish-chart-to-s3.sh $TAG "charts-v3" ./charts/mccp
+        ./bin/publish-chart-to-s3.sh $TAG $HELM_REPO ./charts/mccp
     - name: Login to Docker Hub
       uses: docker/login-action@v1
       with:


### PR DESCRIPTION
Use the workflow input, e.g.: 
```
  with:
      helmrepo: "releases/charts-v3"
```

Rather than hard coding it.
Bug introduced in #264 