### PR TITLE
Change ingress object from api extensions/v1beta1 to networking.k8s.i.o/v1

### DIFF
--- a/ui/chart/wkp-ui/templates/_helpers.tpl
+++ b/ui/chart/wkp-ui/templates/_helpers.tpl
@@ -17,3 +17,39 @@ If release name contains chart name it will be used as a full name.
 {{- end -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Return the appropriate apiVersion for ingress.
+*/}}
+{{- define "common.capabilities.ingress.apiVersion" -}}
+{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "extensions/v1beta1" -}}
+{{- else if semverCompare "<1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "networking.k8s.io/v1beta1" -}}
+{{- else -}}
+{{- print "networking.k8s.io/v1" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Params:
+  - serviceName - String. Name of an existing service backend
+  - servicePort - String/Int. Port name (or number) of the service. It will be translated to different yaml depending if it is a string or an integer.
+  - context - Dict - Required. The context for the template evaluation.
+*/}}
+{{- define "common.ingress.backend" -}}
+{{- $apiVersion := (include "common.capabilities.ingress.apiVersion" .context) -}}
+{{- if or (eq $apiVersion "extensions/v1beta1") (eq $apiVersion "networking.k8s.io/v1beta1") -}}
+serviceName: {{ .serviceName }}
+servicePort: {{ .servicePort }}
+{{- else -}}
+service:
+  name: {{ .serviceName }}
+  port:
+    {{- if typeIs "string" .servicePort }}
+    name: {{ .servicePort }}
+    {{- else if or (typeIs "int" .servicePort) (typeIs "float64" .servicePort) }}
+    number: {{ .servicePort | int }}
+    {{- end }}
+{{- end -}}
+{{- end -}}

--- a/ui/chart/wkp-ui/templates/ingress.yaml
+++ b/ui/chart/wkp-ui/templates/ingress.yaml
@@ -2,7 +2,7 @@
 {{- $serviceName := .Values.service.name -}}
 {{- $servicePort := .Values.service.port -}}
 {{- $ingressPath := .Values.ingress.path -}}
-apiVersion: extensions/v1beta1
+apiVersion: {{ include "common.capabilities.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
   name: {{ include "wkp-ui.fullname" . }}
@@ -31,9 +31,8 @@ spec:
   - host: {{ . }}
     http:
       paths:
-      - path: {{ $ingressPath }}
-        backend:
-          serviceName: {{ $serviceName }}
-          servicePort: {{ $servicePort }}
+      - pathType: ImplementationSpecific
+        path: {{ $ingressPath }}
+        backend: {{- include "common.ingress.backend" (dict "serviceName" $serviceName "servicePort" $servicePort "context" $)  | nindent 14 }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
fixes #291

Change ingress object from api extensions/v1beta1 to networking.k8s.i.o/v1 in wkp-ui helm chart

This assumes a kubernetes version equal or higher than 1.19-0.

Signed-off-by: Soule BA <soule@weave.works>