### PR TITLE
adding go-git-provider support for acceptance tests

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -93,6 +93,7 @@ jobs:
     timeout-minutes: 90
     env:
       GO_CACHE_NAME: cache-go-modules
+      GIT_PROVIDER: github
       GITHUB_TOKEN: ${{ secrets.WGE_GITHUB_TOKEN }}
       GITHUB_ORG: ${{ secrets.WGE_GITHUB_ORG }}
       GITHUB_USER: ${{ secrets.WGE_GITHUB_USER }}
@@ -105,6 +106,7 @@ jobs:
       SELENIUM_DEBUG: true
       ACCEPTANCE_TESTS_DATABASE_TYPE: sqlite
       ARTEFACTS_BASE_DIR: /tmp/workspace/test/
+      CHECKPOINT_DISABLE: 1
     steps:
     - id: go-cache-paths
       run: |

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -28,6 +28,7 @@ jobs:
     timeout-minutes: 90
     env:
       GO_CACHE_NAME: cache-go-modules
+      GIT_PROVIDER: github
       GITHUB_TOKEN: ${{ secrets.WGE_GITHUB_TOKEN }}
       GITHUB_ORG: ${{ secrets.WGE_GITHUB_ORG }}
       GITHUB_USER: ${{ secrets.WGE_GITHUB_USER }}
@@ -43,6 +44,7 @@ jobs:
       MANAGEMENT_CLUSTER_KIND: EKS
       SELENIUM_DEBUG: true
       ARTEFACTS_BASE_DIR: /tmp/workspace/test/
+      CHECKPOINT_DISABLE: 1
     steps:
     - id: go-cache-paths
       run: |
@@ -187,6 +189,7 @@ jobs:
     timeout-minutes: 90
     env:
       GO_CACHE_NAME: cache-go-modules
+      GIT_PROVIDER: github
       GITHUB_TOKEN: ${{ secrets.WGE_GITHUB_TOKEN }}
       GITHUB_ORG: ${{ secrets.WGE_GITHUB_ORG }}
       GITHUB_USER: ${{ secrets.WGE_GITHUB_USER }}
@@ -202,6 +205,7 @@ jobs:
       MANAGEMENT_CLUSTER_KIND: GKE
       SELENIUM_DEBUG: true
       ARTEFACTS_BASE_DIR: /tmp/workspace/test/
+      CHECKPOINT_DISABLE: 1
     steps:
     - id: go-cache-paths
       run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -225,6 +225,7 @@ jobs:
     timeout-minutes: 60
     env:
       GO_CACHE_NAME: cache-go-modules
+      GIT_PROVIDER: github
       GITHUB_TOKEN: ${{ secrets.WGE_GITHUB_TOKEN }}
       GITHUB_ORG: ${{ secrets.WGE_GITHUB_ORG }}
       GITHUB_USER: ${{ secrets.WGE_GITHUB_USER }}
@@ -235,6 +236,7 @@ jobs:
       SELENIUM_DEBUG: true
       ACCEPTANCE_TESTS_DATABASE_TYPE: sqlite
       ARTEFACTS_BASE_DIR: /tmp/workspace/test/
+      CHECKPOINT_DISABLE: 1
     steps:
     - id: go-cache-paths
       run: |
@@ -328,6 +330,7 @@ jobs:
     timeout-minutes: 90
     env:
       GO_CACHE_NAME: cache-go-modules
+      GIT_PROVIDER: github
       GITHUB_TOKEN: ${{ secrets.WGE_GITHUB_TOKEN }}
       GITHUB_ORG: ${{ secrets.WGE_GITHUB_ORG }}
       GITHUB_USER: ${{ secrets.WGE_GITHUB_USER }}
@@ -338,6 +341,7 @@ jobs:
       SELENIUM_DEBUG: true
       ACCEPTANCE_TESTS_DATABASE_TYPE: sqlite
       ARTEFACTS_BASE_DIR: /tmp/workspace/test/
+      CHECKPOINT_DISABLE: 1
     steps:
     - id: go-cache-paths
       run: |

--- a/test/acceptance/test/acceptance_suite_test.go
+++ b/test/acceptance/test/acceptance_suite_test.go
@@ -3,7 +3,6 @@ package acceptance
 import (
 	"fmt"
 	"os"
-	"path"
 	"testing"
 
 	"github.com/onsi/ginkgo"
@@ -24,8 +23,8 @@ func GomegaFail(message string, callerSkip ...int) {
 	}
 
 	// Show management cluster pods etc.
-	_ = ShowItems("")
-	_ = DumpClusterInfo(randID)
+	_ = showItems("")
+	_ = dumpClusterInfo(randID)
 
 	//Pass this down to the default handler for onward processing
 	ginkgo.Fail(message, callerSkip...)
@@ -61,18 +60,7 @@ var _ = BeforeSuite(func() {
 	//Set the suite level defaults
 
 	SetDefaultEventuallyTimeout(ASSERTION_DEFAULT_TIME_OUT) //Things are slow on WKP UI
-
-	SELENIUM_SERVICE_URL = "http://localhost:4444/wd/hub"
-	GITHUB_USER = os.Getenv("GITHUB_USER")
-	GITHUB_PASSWORD = os.Getenv("GITHUB_PASSWORD")
-	GIT_PROVIDER = os.Getenv("GIT_PROVIDER")
-	GITHUB_ORG = os.Getenv("GITHUB_ORG")
-	GITHUB_TOKEN = os.Getenv("GITHUB_TOKEN")
-	CLUSTER_REPOSITORY = os.Getenv("CLUSTER_REPOSITORY")
-	GIT_REPOSITORY_URL = "https://" + path.Join("github.com", GITHUB_ORG, CLUSTER_REPOSITORY)
-
-	DOCKER_IO_USER = os.Getenv("DOCKER_IO_USER")
-	DOCKER_IO_PASSWORD = os.Getenv("DOCKER_IO_PASSWORD")
+	SetupTestEnvironment()                                  // Read OS environment variables and initialize the test environment
 })
 
 var _ = AfterSuite(func() {

--- a/test/acceptance/test/cli_get.go
+++ b/test/acceptance/test/cli_get.go
@@ -16,9 +16,6 @@ import (
 func DescribeCliGet(gitopsTestRunner GitopsTestRunner) {
 	var _ = Describe("Gitops Get Tests", func() {
 
-		GITOPS_BIN_PATH := GetGitopsBinPath()
-		CAPI_ENDPOINT_URL := GetCapiEndpointUrl()
-
 		templateFiles := []string{}
 		var session *gexec.Session
 		var err error
@@ -26,11 +23,11 @@ func DescribeCliGet(gitopsTestRunner GitopsTestRunner) {
 		BeforeEach(func() {
 
 			By("Given I have a gitops binary installed on my local machine", func() {
-				Expect(FileExists(GITOPS_BIN_PATH)).To(BeTrue(), fmt.Sprintf("%s can not be found.", GITOPS_BIN_PATH))
+				Expect(fileExists(GITOPS_BIN_PATH)).To(BeTrue(), fmt.Sprintf("%s can not be found.", GITOPS_BIN_PATH))
 			})
 
 			By("And the Cluster service is healthy", func() {
-				gitopsTestRunner.CheckClusterService(GetCapiEndpointUrl())
+				gitopsTestRunner.CheckClusterService(CAPI_ENDPOINT_URL)
 			})
 		})
 
@@ -364,7 +361,7 @@ func DescribeCliGet(gitopsTestRunner GitopsTestRunner) {
 				By("And gitops state is reset", func() {
 					_ = gitopsTestRunner.ResetDatabase()
 					gitopsTestRunner.VerifyWegoPodsRunning()
-					gitopsTestRunner.CheckClusterService(GetCapiEndpointUrl())
+					gitopsTestRunner.CheckClusterService(CAPI_ENDPOINT_URL)
 				})
 
 				By(fmt.Sprintf("Then I run 'gitops get cluster --endpoint %s'", CAPI_ENDPOINT_URL), func() {

--- a/test/acceptance/test/cli_help.go
+++ b/test/acceptance/test/cli_help.go
@@ -44,16 +44,13 @@ func verifyUsageText(session *gexec.Session) {
 func DescribeCliHelp() {
 	var _ = Describe("Gitops Help Tests", func() {
 
-		GITOPS_BIN_PATH := GetGitopsBinPath()
-		CAPI_ENDPOINT_URL := GetCapiEndpointUrl()
-
 		var session *gexec.Session
 		var err error
 
 		BeforeEach(func() {
 
 			By("Given I have a gitops binary installed on my local machine", func() {
-				Expect(FileExists(GITOPS_BIN_PATH)).To(BeTrue(), fmt.Sprintf("%s can not be found.", GITOPS_BIN_PATH))
+				Expect(fileExists(GITOPS_BIN_PATH)).To(BeTrue(), fmt.Sprintf("%s can not be found.", GITOPS_BIN_PATH))
 			})
 		})
 

--- a/test/acceptance/test/ui_clusters.go
+++ b/test/acceptance/test/ui_clusters.go
@@ -167,7 +167,7 @@ func getCommandEnv(leaf LeafSpec) []string {
 
 func connectACluster(webDriver *agouti.Page, gitopsTestRunner GitopsTestRunner, leaf LeafSpec) (*pages.ClustersPage, string, string) {
 	By("when I navigate to the cluster page..", func() {
-		Expect(webDriver.Navigate(GetWGEUrl() + "/clusters")).To(Succeed())
+		pages.NavigateToPage(webDriver, "Cluster")
 	})
 
 	tokenURLRegex := `https?:\/\/[-a-zA-Z0-9@:%._\+~#=]+\/gitops\/api\/agent\.yaml\?token=[0-9a-zA-Z]+`
@@ -259,13 +259,13 @@ func DescribeClusters(gitopsTestRunner GitopsTestRunner) {
 		BeforeEach(func() {
 
 			By("Given Kubernetes cluster is setup", func() {
-				//TODO - Verify that cluster is up and running using kubectl
+				gitopsTestRunner.CheckClusterService(CAPI_ENDPOINT_URL)
 			})
-			InitializeWebdriver(GetWGEUrl())
+			initializeWebdriver(DEFAULT_UI_URL)
 		})
 
 		AfterEach(func() {
-			TakeNextScreenshot()
+			takeNextScreenshot()
 		})
 
 		It("Verify page structure first time with no cluster configured", func() {
@@ -276,7 +276,7 @@ func DescribeClusters(gitopsTestRunner GitopsTestRunner) {
 			By("And wego enterprise state is reset", func() {
 				_ = gitopsTestRunner.ResetDatabase()
 				gitopsTestRunner.VerifyWegoPodsRunning()
-				gitopsTestRunner.CheckClusterService(GetCapiEndpointUrl())
+				gitopsTestRunner.CheckClusterService(CAPI_ENDPOINT_URL)
 				Expect(webDriver.Refresh()).ShouldNot(HaveOccurred())
 			})
 
@@ -302,7 +302,7 @@ func DescribeClusters(gitopsTestRunner GitopsTestRunner) {
 			})
 
 			By("And should have No alerts firing message", func() {
-				Expect(webDriver.Navigate(GetWGEUrl() + "/clusters/alerts")).To(Succeed())
+				Expect(webDriver.Navigate(DEFAULT_UI_URL + "/clusters/alerts")).To(Succeed())
 				Eventually(clustersPage.NoFiringAlertMessage).Should(HaveText("No alerts firing"))
 			})
 
@@ -445,14 +445,14 @@ func DescribeClusters(gitopsTestRunner GitopsTestRunner) {
 
 			_ = gitopsTestRunner.ResetDatabase()
 			gitopsTestRunner.VerifyWegoPodsRunning()
-			gitopsTestRunner.CheckClusterService(GetCapiEndpointUrl())
+			gitopsTestRunner.CheckClusterService(CAPI_ENDPOINT_URL)
 			Expect(webDriver.Refresh()).ShouldNot(HaveOccurred())
 
 			clustersPage := pages.GetClustersPage(webDriver)
-			Expect(webDriver.Navigate(GetWGEUrl() + "/clusters/alerts")).To(Succeed())
+			pages.NavigateToPage(webDriver, "Alerts")
 			Eventually(clustersPage.NoFiringAlertMessage).Should(BeFound())
 
-			Expect(webDriver.Navigate(GetWGEUrl())).To(Succeed())
+			Expect(webDriver.Navigate(DEFAULT_UI_URL)).To(Succeed())
 			Eventually(clustersPage.NoClusterConfigured).Should(HaveText("No clusters configured"))
 
 			clustersPage, clusterName, _ := connectACluster(webDriver, gitopsTestRunner, leaves["self"])
@@ -462,7 +462,7 @@ func DescribeClusters(gitopsTestRunner GitopsTestRunner) {
 			severity := [3]string{"critical", "warning", "critical"}
 
 			By("when I navigate to the alerts page..", func() {
-				Expect(webDriver.Navigate(GetWGEUrl() + "/clusters/alerts")).To(Succeed())
+				pages.NavigateToPage(webDriver, "Alerts")
 			})
 
 			By("And when a critical alert fires", func() {
@@ -556,7 +556,7 @@ func DescribeClusters(gitopsTestRunner GitopsTestRunner) {
 			}
 			_ = gitopsTestRunner.ResetDatabase()
 			gitopsTestRunner.VerifyWegoPodsRunning()
-			gitopsTestRunner.CheckClusterService(GetCapiEndpointUrl())
+			gitopsTestRunner.CheckClusterService(CAPI_ENDPOINT_URL)
 			Expect(webDriver.Refresh()).ShouldNot(HaveOccurred())
 
 			clustersPage := pages.GetClustersPage(webDriver)
@@ -564,7 +564,7 @@ func DescribeClusters(gitopsTestRunner GitopsTestRunner) {
 			pages.NavigateToPage(webDriver, "Alerts")
 			Eventually(clustersPage.NoFiringAlertMessage).Should(BeFound())
 
-			Expect(webDriver.Navigate(GetWGEUrl())).To(Succeed())
+			Expect(webDriver.Navigate(DEFAULT_UI_URL)).To(Succeed())
 			Eventually(clustersPage.NoClusterConfigured).Should(HaveText("No clusters configured"))
 			clustersPage, clusterName, _ := connectACluster(webDriver, gitopsTestRunner, leaves["self"])
 

--- a/test/acceptance/test/utils.go
+++ b/test/acceptance/test/utils.go
@@ -1,21 +1,14 @@
 package acceptance
 
 import (
-	"bytes"
-	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
-	"net/http"
-	"net/url"
 	"os"
 	"os/exec"
 	"path"
-	"path/filepath"
 	"runtime"
 	"strings"
-	"text/template"
 	"time"
 
 	. "github.com/onsi/ginkgo"
@@ -23,138 +16,60 @@ import (
 	"github.com/onsi/gomega/gexec"
 	"github.com/sclevine/agouti"
 	log "github.com/sirupsen/logrus"
-	"github.com/weaveworks/weave-gitops-enterprise/cmd/clusters-service/pkg/capi"
-	"github.com/weaveworks/weave-gitops-enterprise/common/database/models"
 	"github.com/weaveworks/weave-gitops-enterprise/test/acceptance/test/pages"
-	"gorm.io/datatypes"
-	"gorm.io/gorm"
-	"k8s.io/apimachinery/pkg/types"
-	goclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var DOCKER_IO_USER string
-var DOCKER_IO_PASSWORD string
-var GITHUB_USER string
-var GITHUB_PASSWORD string
-var GIT_PROVIDER string
-var GITHUB_ORG string
-var GITHUB_TOKEN string
-var CLUSTER_REPOSITORY string
-var GIT_REPOSITORY_URL string
-var SELENIUM_SERVICE_URL string
+var (
+	DOCKER_IO_USER       string
+	DOCKER_IO_PASSWORD   string
+	GITHUB_USER          string
+	GITHUB_PASSWORD      string
+	GIT_PROVIDER         string
+	GITHUB_ORG           string
+	GITHUB_TOKEN         string
+	GITLAB_TOKEN         string
+	CLUSTER_REPOSITORY   string
+	GIT_REPOSITORY_URL   string
+	SELENIUM_SERVICE_URL string
+	GITOPS_BIN_PATH      string
+	CAPI_ENDPOINT_URL    string
+	DEFAULT_UI_URL       string
 
-var webDriver *agouti.Page
-var defaultUIURL = "http://localhost:8090"
-var defaultGitopsBinPath = "/usr/local/bin/gitops"
-var defaultCapiEndpointURL = "http://localhost:8090"
+	webDriver    *agouti.Page
+	screenshotNo = 1
+)
 
-const WGE_WINDOW_NAME = "weave-gitops-enterprise"
-const GITOPS_DEFAULT_NAMESPACE = "wego-system"
+const (
+	WGE_WINDOW_NAME          string = "weave-gitops-enterprise"
+	GITOPS_DEFAULT_NAMESPACE string = "wego-system"
+	WINDOW_SIZE_X            int    = 1800
+	WINDOW_SIZE_Y            int    = 2500
+	ARTEFACTS_BASE_DIR       string = "/tmp/workspace/test/"
+	SCREENSHOTS_DIR          string = ARTEFACTS_BASE_DIR + "screenshots/"
+	CLUSTER_INFO_DIR         string = ARTEFACTS_BASE_DIR + "cluster-info/"
+	JUNIT_TEST_REPORT_FILE   string = ARTEFACTS_BASE_DIR + "acceptance-test-results.xml"
 
-func GetWebDriver() *agouti.Page {
-	return webDriver
-}
+	ASSERTION_DEFAULT_TIME_OUT   time.Duration = 15 * time.Second
+	ASSERTION_1SECOND_TIME_OUT   time.Duration = 1 * time.Second
+	ASSERTION_10SECONDS_TIME_OUT time.Duration = 10 * time.Second
+	ASSERTION_30SECONDS_TIME_OUT time.Duration = 30 * time.Second
+	ASSERTION_1MINUTE_TIME_OUT   time.Duration = 1 * time.Minute
+	ASSERTION_2MINUTE_TIME_OUT   time.Duration = 2 * time.Minute
+	ASSERTION_3MINUTE_TIME_OUT   time.Duration = 3 * time.Minute
+	ASSERTION_5MINUTE_TIME_OUT   time.Duration = 5 * time.Minute
+	ASSERTION_6MINUTE_TIME_OUT   time.Duration = 6 * time.Minute
 
-func SetWebDriver(wb *agouti.Page) {
-	webDriver = wb
-}
-
-func GetGitopsBinPath() string {
-	if os.Getenv("GITOPS_BIN_PATH") != "" {
-		return os.Getenv("GITOPS_BIN_PATH")
-	}
-	return defaultGitopsBinPath
-}
-
-func GetWGEUrl() string {
-	if os.Getenv("TEST_UI_URL") != "" {
-		return os.Getenv("TEST_UI_URL")
-	}
-	return defaultUIURL
-}
-
-func GetCapiEndpointUrl() string {
-	if os.Getenv("TEST_CAPI_ENDPOINT_URL") != "" {
-		return os.Getenv("TEST_CAPI_ENDPOINT_URL")
-	}
-	return defaultCapiEndpointURL
-}
-
-func SetDefaultUIURL(url string) {
-	defaultUIURL = url
-}
-
-func SetSeleniumServiceUrl(url string) {
-	SELENIUM_SERVICE_URL = url
-}
-
-const WINDOW_SIZE_X int = 1800
-const WINDOW_SIZE_Y int = 2500
-const ARTEFACTS_BASE_DIR string = "/tmp/workspace/test/"
-const SCREENSHOTS_DIR string = ARTEFACTS_BASE_DIR + "screenshots/"
-const CLUSTER_INFO_DIR string = ARTEFACTS_BASE_DIR + "cluster-info/"
-const JUNIT_TEST_REPORT_FILE string = ARTEFACTS_BASE_DIR + "acceptance-test-results.xml"
-
-const ASSERTION_DEFAULT_TIME_OUT time.Duration = 15 * time.Second
-const ASSERTION_1SECOND_TIME_OUT time.Duration = 1 * time.Second
-const ASSERTION_10SECONDS_TIME_OUT time.Duration = 10 * time.Second
-const ASSERTION_30SECONDS_TIME_OUT time.Duration = 30 * time.Second
-const ASSERTION_1MINUTE_TIME_OUT time.Duration = 1 * time.Minute
-const ASSERTION_2MINUTE_TIME_OUT time.Duration = 2 * time.Minute
-const ASSERTION_3MINUTE_TIME_OUT time.Duration = 3 * time.Minute
-const ASSERTION_5MINUTE_TIME_OUT time.Duration = 5 * time.Minute
-const ASSERTION_6MINUTE_TIME_OUT time.Duration = 6 * time.Minute
-
-const POLL_INTERVAL_1SECONDS time.Duration = 1 * time.Second
-const POLL_INTERVAL_5SECONDS time.Duration = 5 * time.Second
-const POLL_INTERVAL_15SECONDS time.Duration = 15 * time.Second
-const POLL_INTERVAL_100MILLISECONDS time.Duration = 100 * time.Millisecond
+	POLL_INTERVAL_1SECONDS        time.Duration = 1 * time.Second
+	POLL_INTERVAL_5SECONDS        time.Duration = 5 * time.Second
+	POLL_INTERVAL_15SECONDS       time.Duration = 15 * time.Second
+	POLL_INTERVAL_100MILLISECONDS time.Duration = 100 * time.Millisecond
+)
 
 const charset = "abcdefghijklmnopqrstuvwxyz" +
 	"ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 
 var seededRand *rand.Rand = rand.New(
 	rand.NewSource(time.Now().UnixNano()))
-
-func StringWithCharset(length int, charset string) string {
-	b := make([]byte, length)
-	for i := range b {
-		b[i] = charset[seededRand.Intn(len(charset))]
-	}
-	return string(b)
-}
-
-func RandString(length int) string {
-	return StringWithCharset(length, charset)
-}
-
-// WaitUntil runs checkDone until a timeout is reached
-func WaitUntil(out io.Writer, poll, timeout time.Duration, checkDone func() error) error {
-	for start := time.Now(); time.Since(start) < timeout; time.Sleep(poll) {
-		err := checkDone()
-		if err == nil {
-			return nil
-		}
-		fmt.Fprintf(out, "error occurred %s, retrying in %s\n", err, poll.String())
-	}
-	return fmt.Errorf("timeout reached %s", timeout.String())
-}
-
-func TakeScreenShot(name string) string {
-	if webDriver != nil {
-		filepath := path.Join(SCREENSHOTS_DIR, name+".png")
-		_ = webDriver.Screenshot(filepath)
-		return filepath
-	}
-	return ""
-}
-
-var n = 1
-
-func TakeNextScreenshot() {
-	TakeScreenShot(fmt.Sprintf("test-%v", n))
-	n += 1
-}
 
 // Describes all the UI acceptance tests
 func DescribeSpecsUi(gitopsTestRunner GitopsTestRunner) {
@@ -171,39 +86,72 @@ func DescribeSpecsCli(gitopsTestRunner GitopsTestRunner) {
 	DescribeCliUpgrade(gitopsTestRunner)
 }
 
-// Interface that can be implemented either with:
-// - "Real" commands like "exec(kubectl...)"
-// - "Mock" commands like db.Create(cluster_info...)
-
-type GitopsTestRunner interface {
-	ResetDatabase() error
-	VerifyWegoPodsRunning()
-	FireAlert(name, severity, message string, fireFor time.Duration) error
-	KubectlApply(env []string, tokenURL string) error
-	KubectlDelete(env []string, tokenURL string) error
-	KubectlDeleteAllAgents(env []string) error
-	TimeTravelToLastSeen() error
-	TimeTravelToAlertsResolved() error
-	AddWorkspace(env []string, clusterName string) error
-	CreateApplyCapitemplates(templateCount int, templateFile string) []string
-	DeleteApplyCapiTemplates(templateFiles []string)
-	CreateIPCredentials(infrastructureProvider string)
-	DeleteIPCredentials(infrastructureProvider string)
-	CheckClusterService(capiEndpointURL string)
-	RestartDeploymentPods(env []string, appName string, namespace string) error
-
-	// Git repository helper functions
-	DeleteRepo(repoName string)
-	InitAndCreateEmptyRepo(repoName string, IsPrivateRepo bool) string
-	GitAddCommitPush(repoAbsolutePath string, fileToAdd string)
-	CreateGitRepoBranch(repoAbsolutePath string, branchName string) string
-	PullBranch(repoAbsolutePath string, branch string)
-	ListPullRequest(repoAbsolutePath string) []string
-	MergePullRequest(repoAbsolutePath string, prBranch string)
-	GetRepoVisibility(org string, repo string) string
+func GetWebDriver() *agouti.Page {
+	return webDriver
 }
 
-func InitializeWebdriver(wgeURL string) {
+func SetDefaultUIURL(url string) {
+	DEFAULT_UI_URL = url
+}
+
+func SetSeleniumServiceUrl(url string) {
+	SELENIUM_SERVICE_URL = url
+}
+
+func TakeScreenShot(name string) string {
+	if webDriver != nil {
+		filepath := path.Join(SCREENSHOTS_DIR, name+".png")
+		_ = webDriver.Screenshot(filepath)
+		return filepath
+	}
+	return ""
+}
+
+func RandString(length int) string {
+	return stringWithCharset(length, charset)
+}
+
+func SetupTestEnvironment() {
+	SELENIUM_SERVICE_URL = "http://localhost:4444/wd/hub"
+	DEFAULT_UI_URL = getEnv("TEST_UI_URL", "http://localhost:8000")
+	CAPI_ENDPOINT_URL = getEnv("TEST_CAPI_ENDPOINT_URL", "http://localhost:8000")
+	GITOPS_BIN_PATH = getEnv("GITOPS_BIN_PATH", "/usr/local/bin/gitops")
+
+	GITHUB_USER = getEnv("GITHUB_USER", "")
+	GITHUB_PASSWORD = getEnv("GITHUB_PASSWORD", "")
+	GIT_PROVIDER = getEnv("GIT_PROVIDER", "")
+	GITHUB_ORG = getEnv("GITHUB_ORG", "")
+	GITHUB_TOKEN = getEnv("GITHUB_TOKEN", "")
+	GITLAB_TOKEN = getEnv("GITLAB_TOKEN", "")
+	CLUSTER_REPOSITORY = getEnv("CLUSTER_REPOSITORY", "")
+	GIT_REPOSITORY_URL = "https://" + path.Join("github.com", GITHUB_ORG, CLUSTER_REPOSITORY)
+
+	DOCKER_IO_USER = getEnv("DOCKER_IO_USER", "")
+	DOCKER_IO_PASSWORD = getEnv("DOCKER_IO_PASSWORD", "")
+}
+
+func getEnv(key, fallback string) string {
+	value, exists := os.LookupEnv(key)
+	if !exists {
+		value = fallback
+	}
+	return value
+}
+
+func stringWithCharset(length int, charset string) string {
+	b := make([]byte, length)
+	for i := range b {
+		b[i] = charset[seededRand.Intn(len(charset))]
+	}
+	return string(b)
+}
+
+func takeNextScreenshot() {
+	TakeScreenShot(fmt.Sprintf("test-%v", screenshotNo))
+	screenshotNo += 1
+}
+
+func initializeWebdriver(wgeURL string) {
 	var err error
 	if webDriver == nil {
 		switch runtime.GOOS {
@@ -238,514 +186,6 @@ func InitializeWebdriver(wgeURL string) {
 	})
 }
 
-// "DB" backend that creates/delete rows
-
-type DatabaseGitopsTestRunner struct {
-	DB     *gorm.DB
-	Client goclient.Client
-}
-
-func (b DatabaseGitopsTestRunner) TimeTravelToLastSeen() error {
-	oneMinuteAgo := time.Now().UTC().Add(time.Minute * -2)
-	b.DB.Exec("update cluster_info set updated_at = ?", oneMinuteAgo)
-	return nil
-}
-
-func (b DatabaseGitopsTestRunner) TimeTravelToAlertsResolved() error {
-	b.DB.Where("1 = 1").Delete(&models.Alert{})
-	return nil
-}
-
-func (b DatabaseGitopsTestRunner) ResetDatabase() error {
-	b.DB.Where("1 = 1").Delete(&models.Cluster{})
-	return nil
-}
-
-func (b DatabaseGitopsTestRunner) VerifyWegoPodsRunning() {
-
-}
-
-func (b DatabaseGitopsTestRunner) KubectlApply(env []string, tokenURL string) error {
-	u, err := url.Parse(tokenURL)
-	if err != nil {
-		return err
-	}
-	token := u.Query()["token"][0]
-
-	b.DB.Create(&models.ClusterInfo{
-		UID:          types.UID(RandString(10)),
-		ClusterToken: token,
-		UpdatedAt:    time.Now().UTC(),
-	})
-	b.DB.Create(&models.GitCommit{
-		ClusterToken: token,
-		Sha:          "abcdef123456",
-		AuthorName:   "Alice",
-		AuthorEmail:  "alice@acme.org",
-		AuthorDate:   time.Now().UTC().Add(time.Hour * -1),
-		Message:      "Fixed it",
-	})
-	b.DB.Create(&models.FluxInfo{
-		ClusterToken: token,
-		Name:         "flux",
-		Namespace:    "wkp-flux",
-		RepoURL:      "git@github.com:wkp/my-cluster",
-		RepoBranch:   "main",
-	})
-	return nil
-}
-
-func (b DatabaseGitopsTestRunner) KubectlDelete(env []string, tokenURL string) error {
-	//
-	// No more cluster_infos will be created anyway..
-	// FIXME: maybe we add a polling loop that keeps creating cluster_info while its connected
-	//
-	return nil
-}
-
-func (b DatabaseGitopsTestRunner) KubectlDeleteAllAgents(env []string) error {
-	// No more cluster_infos will be created anyway..
-	return nil
-}
-
-func (b DatabaseGitopsTestRunner) FireAlert(name, severity, message string, fireFor time.Duration) error {
-	var firstCluster models.Cluster
-	b.DB.Last(&firstCluster)
-
-	//
-	// FIXME: we shouldn't need this. The UI should stop showing the alerts after 30s anyway
-	// But its not filtering on endsAt right now.
-	//
-	go func() {
-		time.Sleep(fireFor)
-		b.DB.Where("1 = 1").Delete(&models.Alert{})
-	}()
-
-	labels := fmt.Sprintf(`{ "alertname": "%s", "severity": "%s" }`, name, severity)
-	annotations := fmt.Sprintf(`{ "message": "%s" }`, message)
-	b.DB.Create(&models.Alert{
-		ClusterToken: firstCluster.Token,
-		UpdatedAt:    time.Now().UTC(),
-		Labels:       datatypes.JSON(labels),
-		Annotations:  datatypes.JSON(annotations),
-		Severity:     severity,
-		StartsAt:     time.Now().UTC().Add(fireFor * -1),
-		EndsAt:       time.Now().UTC().Add(fireFor),
-	})
-
-	return nil
-}
-
-func (b DatabaseGitopsTestRunner) AddWorkspace(env []string, clusterName string) error {
-	var firstCluster models.Cluster
-	b.DB.Where("Name = ?", clusterName).First(&firstCluster)
-
-	b.DB.Create(&models.Workspace{
-		ClusterToken: firstCluster.Token,
-		Name:         "mccp-devs-workspace",
-		Namespace:    "wkp-workspace",
-	})
-
-	return nil
-}
-
-func (b DatabaseGitopsTestRunner) CreateApplyCapitemplates(templateCount int, templateFile string) []string {
-	templateFiles, err := generateTestCapiTemplates(templateCount, templateFile)
-	Expect(err).To(BeNil(), "Failed to generate CAPITemplate template test files")
-	By("Apply/Install CAPITemplate templates", func() {
-		for _, fileName := range templateFiles {
-			template, err := capi.ParseFile(fileName)
-			Expect(err).To(BeNil(), "Failed to parse CAPITemplate template files")
-			err = b.Client.Create(context.Background(), template)
-			Expect(err).To(BeNil(), "Failed to create CAPITemplate template files")
-		}
-	})
-
-	return templateFiles
-}
-
-func (b DatabaseGitopsTestRunner) DeleteApplyCapiTemplates(templateFiles []string) {
-	By("Delete CAPITemplate templates", func() {
-		for _, fileName := range templateFiles {
-			template, err := capi.ParseFile(fileName)
-			Expect(err).To(BeNil(), "Failed to parse CAPITemplate template files")
-			err = b.Client.Delete(context.Background(), template)
-			Expect(err).To(BeNil(), "Failed to delete CAPITemplate template files")
-		}
-	})
-}
-
-func (b DatabaseGitopsTestRunner) CheckClusterService(capiEndpointURL string) {
-
-}
-
-func (b DatabaseGitopsTestRunner) RestartDeploymentPods(env []string, appName string, namespace string) error {
-	return nil
-}
-
-func (b DatabaseGitopsTestRunner) CreateIPCredentials(infrastructureProvider string) {
-
-}
-
-func (b DatabaseGitopsTestRunner) DeleteIPCredentials(infrastructureProvider string) {
-
-}
-
-func (b DatabaseGitopsTestRunner) DeleteRepo(repoName string) {
-
-}
-
-func (b DatabaseGitopsTestRunner) InitAndCreateEmptyRepo(repoName string, IsPrivateRepo bool) string {
-	return ""
-}
-
-func (b DatabaseGitopsTestRunner) GitAddCommitPush(repoAbsolutePath string, fileToAdd string) {
-
-}
-
-func (b DatabaseGitopsTestRunner) CreateGitRepoBranch(repoAbsolutePath string, branchName string) string {
-	return ""
-}
-
-func (b DatabaseGitopsTestRunner) PullBranch(repoAbsolutePath string, branch string) {
-
-}
-
-func (b DatabaseGitopsTestRunner) ListPullRequest(repoAbsolutePath string) []string {
-	return []string{}
-}
-
-func (b DatabaseGitopsTestRunner) MergePullRequest(repoAbsolutePath string, prBranch string) {
-
-}
-
-func (b DatabaseGitopsTestRunner) GetRepoVisibility(org string, repo string) string {
-	return ""
-}
-
-// "Real" backend that call kubectl and posts to alertmanagement
-
-type RealGitopsTestRunner struct{}
-
-func (b RealGitopsTestRunner) TimeTravelToLastSeen() error {
-	return nil
-}
-
-func (b RealGitopsTestRunner) TimeTravelToAlertsResolved() error {
-	return nil
-}
-
-func (b RealGitopsTestRunner) ResetDatabase() error {
-	return runCommandPassThrough([]string{}, "../../utils/scripts/wego-enterprise.sh", "reset_mccp")
-}
-
-func (b RealGitopsTestRunner) VerifyWegoPodsRunning() {
-	VerifyEnterpriseControllers("my-mccp", "", GITOPS_DEFAULT_NAMESPACE)
-}
-
-func (b RealGitopsTestRunner) KubectlApply(env []string, tokenURL string) error {
-	err := runCommandPassThrough(env, "kubectl", "apply", "-f", tokenURL)
-	fmt.Println("Cluster pods after apply")
-	if err := runCommandPassThrough(env, "kubectl", "get", "pods", "-A"); err != nil {
-		fmt.Printf("Error getting cluster pods after apply: %v\n", err)
-	}
-	return err
-}
-
-func (b RealGitopsTestRunner) KubectlDelete(env []string, tokenURL string) error {
-	return runCommandPassThrough(env, "kubectl", "delete", "-f", tokenURL)
-}
-
-func (b RealGitopsTestRunner) KubectlDeleteAllAgents(env []string) error {
-	return runCommandPassThrough(env, "kubectl", "delete", "-n", "wkp-agent", "deploy", "wkp-agent")
-}
-
-func (b RealGitopsTestRunner) FireAlert(name, severity, message string, fireFor time.Duration) error {
-	const alertTemplate = `
-    [
-      {
-        "labels": {
-          "alertname": "{{ .Name }}",
-          "severity": "{{ .Severity }}"
-        },
-        "annotations": {
-          "message": "{{ .Message }}"
-        },
-        "startsAt": "{{ .StartsAt }}",
-        "endsAt": "{{ .EndsAt }}"
-      }
-    ]
-    `
-
-	t, err := template.New("alert").Parse(alertTemplate)
-	if err != nil {
-		return err
-	}
-	var populated bytes.Buffer
-	err = t.Execute(&populated, struct {
-		Name     string
-		Severity string
-		Message  string
-		StartsAt string
-		EndsAt   string
-	}{
-		name,
-		severity,
-		message,
-		time.Now().UTC().Add(fireFor * -1).Format(time.RFC3339),
-		time.Now().UTC().Add(fireFor).Format(time.RFC3339),
-	})
-
-	if err != nil {
-		return err
-	}
-
-	fmt.Print(populated.String())
-	req, err := http.NewRequest("POST", GetWGEUrl()+"/alertmanager/api/v2/alerts", &populated)
-	if err != nil {
-		return err
-	}
-	req.Header.Set("Content-Type", "application/json")
-	client := &http.Client{}
-	resp, err := client.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-	body, _ := ioutil.ReadAll(resp.Body)
-	fmt.Println("response Body:", string(body))
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("alertmanager didn't like the alert: %v", resp.StatusCode)
-	}
-
-	return nil
-}
-
-func (b RealGitopsTestRunner) AddWorkspace(env []string, clusterName string) error {
-	return runCommandPassThrough(env, "kubectl", "apply", "-f", "../../utils/data/mccp-workspace.yaml")
-}
-
-// This function will crete the test capiTemplate files and do the kubectl apply for capiserver availability
-func (b RealGitopsTestRunner) CreateApplyCapitemplates(templateCount int, templateFile string) []string {
-	templateFiles, err := generateTestCapiTemplates(templateCount, templateFile)
-	Expect(err).To(BeNil(), "Failed to generate CAPITemplate template test files")
-
-	By("Apply/Install CAPITemplate templates", func() {
-		for _, fileName := range templateFiles {
-			err = runCommandPassThrough([]string{}, "kubectl", "apply", "-f", fileName)
-			Expect(err).To(BeNil(), "Failed to apply/install CAPITemplate template files")
-		}
-	})
-
-	return templateFiles
-}
-
-// This function deletes the test capiTemplate files and do the kubectl delete to clean the cluster
-func (b RealGitopsTestRunner) DeleteApplyCapiTemplates(templateFiles []string) {
-	By("Delete CAPITemplate templates", func() {
-
-		for _, fileName := range templateFiles {
-			err := b.KubectlDelete([]string{}, fileName)
-			Expect(err).To(BeNil(), "Failed to delete CAPITemplate template")
-		}
-	})
-
-	err := deleteFile(templateFiles)
-	Expect(err).To(BeNil(), "Failed to delete CAPITemplate template test files")
-}
-
-func (b RealGitopsTestRunner) CheckClusterService(capiEndpointURL string) {
-	output := func() string {
-		command := exec.Command("curl", "-s", "-o", "/dev/null", "-w", "%{http_code}", capiEndpointURL+"/v1/templates")
-		session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
-		Expect(err).ShouldNot(HaveOccurred())
-		return string(session.Wait(ASSERTION_30SECONDS_TIME_OUT).Out.Contents())
-	}
-	Eventually(output, ASSERTION_1MINUTE_TIME_OUT, POLL_INTERVAL_5SECONDS).Should(MatchRegexp("200"), "Cluster Service is not healthy")
-}
-
-func (b RealGitopsTestRunner) RestartDeploymentPods(env []string, appName string, namespace string) error {
-	// Restart the deployment pods
-	err := runCommandPassThrough(env, "kubectl", "rollout", "restart", "deployment", appName, "-n", namespace)
-	if err == nil {
-		// Wait for all the deployments replicas to rolled out successfully
-		err = runCommandPassThrough(env, "kubectl", "rollout", "status", "deployment", appName, "-n", namespace)
-	}
-	return err
-}
-
-func (b RealGitopsTestRunner) CreateIPCredentials(infrastructureProvider string) {
-	if infrastructureProvider == "AWS" {
-		By("Install AWSClusterStaticIdentity CRD", func() {
-			err := runCommandPassThrough([]string{}, "kubectl", "apply", "-f", "../../utils/data/infrastructure.cluster.x-k8s.io_awsclusterstaticidentities.yaml")
-			Expect(err).To(BeNil(), "Failed to install AWSClusterStaticIdentity CRD")
-			err = runCommandPassThrough([]string{}, "kubectl", "wait", "--for=condition=established", "--timeout=90s", "crd/awsclusterstaticidentities.infrastructure.cluster.x-k8s.io")
-			Expect(err).To(BeNil(), "Failed to verify AWSClusterStaticIdentity CRD")
-		})
-
-		By("Install AWSClusterRoleIdentity CRD", func() {
-			err := runCommandPassThrough([]string{}, "kubectl", "apply", "-f", "../../utils/data/infrastructure.cluster.x-k8s.io_awsclusterroleidentities.yaml")
-			Expect(err).To(BeNil(), "Failed to install AWSClusterRoleIdentity CRD")
-			err = runCommandPassThrough([]string{}, "kubectl", "wait", "--for=condition=established", "--timeout=90s", "crd/awsclusterroleidentities.infrastructure.cluster.x-k8s.io")
-			Expect(err).To(BeNil(), "Failed to verify AWSClusterRoleIdentity CRD")
-		})
-
-		By("Create AWS Secret, AWSClusterStaticIdentity and AWSClusterRoleIdentity)", func() {
-			err := runCommandPassThrough([]string{}, "kubectl", "apply", "-f", "../../utils/data/aws_cluster_credentials.yaml")
-			Expect(err).To(BeNil(), "Failed to create AWS credentials")
-		})
-
-	} else if infrastructureProvider == "AZURE" {
-		By("Install AzureClusterIdentity CRD", func() {
-			err := runCommandPassThrough([]string{}, "kubectl", "apply", "-f", "../../utils/data/infrastructure.cluster.x-k8s.io_azureclusteridentities.yaml")
-			Expect(err).To(BeNil(), "Failed to install AzureClusterIdentity CRD")
-			err = runCommandPassThrough([]string{}, "kubectl", "wait", "--for=condition=established", "--timeout=90s", "crd/azureclusteridentities.infrastructure.cluster.x-k8s.io")
-			Expect(err).To(BeNil(), "Failed to verify AzureClusterIdentity CRD")
-		})
-
-		By("Create Azure Secret and AzureClusterIdentity)", func() {
-			err := runCommandPassThrough([]string{}, "kubectl", "apply", "-f", "../../utils/data/azure_cluster_credentials.yaml")
-			Expect(err).To(BeNil(), "Failed to create Azure credentials")
-		})
-	}
-
-}
-
-func (b RealGitopsTestRunner) DeleteIPCredentials(infrastructureProvider string) {
-	if infrastructureProvider == "AWS" {
-		_ = runCommandPassThrough([]string{}, "kubectl", "delete", "-f", "../../utils/data/aws_cluster_credentials.yaml")
-		_ = runCommandPassThrough([]string{}, "kubectl", "delete", "-f", "../../utils/data/infrastructure.cluster.x-k8s.io_awsclusterroleidentities.yaml")
-		_ = runCommandPassThrough([]string{}, "kubectl", "delete", "-f", "../../utils/data/infrastructure.cluster.x-k8s.io_awsclusterstaticidentities.yaml")
-
-	} else if infrastructureProvider == "AZURE" {
-		_ = runCommandPassThrough([]string{}, "kubectl", "delete", "-f", "../../utils/data/azure_cluster_credentials.yaml")
-		_ = runCommandPassThrough([]string{}, "kubectl", "delete", "-f", "../../utils/data/infrastructure.cluster.x-k8s.io_azureclusteridentities.yaml")
-	}
-}
-
-func (b RealGitopsTestRunner) DeleteRepo(repoName string) {
-	log.Printf("Delete application repo: %s", path.Join(GITHUB_ORG, repoName))
-	_ = runCommandPassThrough([]string{}, "hub", "delete", "-y", path.Join(GITHUB_ORG, repoName))
-
-	output := func() string {
-		command := exec.Command("sh", "-c", fmt.Sprintf(`git ls-remote https://github.com/%s/%s`, GITHUB_ORG, GITHUB_ORG))
-		session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
-		Expect(err).ShouldNot(HaveOccurred())
-		return string(session.Wait().Err.Contents())
-	}
-	Eventually(output, ASSERTION_2MINUTE_TIME_OUT, POLL_INTERVAL_5SECONDS).Should(MatchRegexp("Repository not found"))
-}
-
-func (b RealGitopsTestRunner) InitAndCreateEmptyRepo(repoName string, IsPrivateRepo bool) string {
-	log.Printf("Init and create repo: %s, %v\n", repoName, IsPrivateRepo)
-	repoAbsolutePath := path.Join("/tmp/", repoName)
-	privateRepo := ""
-	if IsPrivateRepo {
-		privateRepo = "-p"
-	}
-	command := exec.Command("sh", "-c", fmt.Sprintf(`
-                            mkdir %s &&
-                            cd %s &&
-                            git init &&
-                            git checkout -b main &&
-                            hub create %s %s`, repoAbsolutePath, repoAbsolutePath, path.Join(GITHUB_ORG, repoName), privateRepo))
-	session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
-	Expect(err).ShouldNot(HaveOccurred())
-	Eventually(session).Should(gexec.Exit(), "err %v, out, %v", string(session.Err.Contents()), string(session.Out.Contents()))
-
-	log.Printf("Waiting for repo to be created %v/%v", GITHUB_ORG, repoName)
-	Expect(WaitUntil(os.Stdout, POLL_INTERVAL_5SECONDS, ASSERTION_1MINUTE_TIME_OUT, func() error {
-		cmd := fmt.Sprintf(`hub api repos/%s/%s`, GITHUB_ORG, repoName)
-		command := exec.Command("sh", "-c", cmd)
-		return command.Run()
-	})).ShouldNot(HaveOccurred())
-
-	return repoAbsolutePath
-}
-
-func (b RealGitopsTestRunner) GitAddCommitPush(repoAbsolutePath string, fileToAdd string) {
-	command := exec.Command("sh", "-c", fmt.Sprintf(`
-                            cp -r -f %s %s &&
-                            cd %s &&
-                            git add . &&
-                            git commit -m 'add workload manifest' &&
-                            git push -u origin main`, fileToAdd, repoAbsolutePath, repoAbsolutePath))
-	session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
-	Expect(err).ShouldNot(HaveOccurred())
-	Eventually(session).Should(gexec.Exit())
-	fmt.Println(string(session.Wait().Err.Contents()))
-}
-
-func GitUpdateCommitPush(repoAbsolutePath string, commitMessage string) {
-	log.Infof("Pushing changes made to file(s) in repo: %s", repoAbsolutePath)
-	if commitMessage == "" {
-		commitMessage = "edit repo file"
-	}
-
-	_ = runCommandPassThrough([]string{}, "sh", "-c", fmt.Sprintf("cd %s && git add -u && git add -A && git commit -m '%s' && git pull --rebase && git push origin HEAD", repoAbsolutePath, commitMessage))
-}
-
-func GitSetUpstream(repoAbsolutePath string, upstreamBranch string) {
-	log.Infof("Setting tracking/upstream remote branch %s", upstreamBranch)
-	_ = runCommandPassThrough([]string{}, "sh", "-c", fmt.Sprintf("cd %s && git branch -u origin/%s", repoAbsolutePath, upstreamBranch))
-}
-
-func GetGitRepositoryURL(repoAbsolutePath string) string {
-	repoURL, _ := runCommandAndReturnStringOutput(fmt.Sprintf(`cd %s && git config --get remote.origin.url`, repoAbsolutePath))
-	return strings.Trim(repoURL, "\n")
-}
-
-func (b RealGitopsTestRunner) CreateGitRepoBranch(repoAbsolutePath string, branchName string) string {
-	command := exec.Command("sh", "-c", fmt.Sprintf("cd %s && git checkout -b %s && git push --set-upstream origin %s", repoAbsolutePath, branchName, branchName))
-	session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
-	Expect(err).ShouldNot(HaveOccurred())
-	Eventually(session).Should(gexec.Exit())
-	return string(session.Wait().Out.Contents())
-}
-
-func (b RealGitopsTestRunner) PullBranch(repoAbsolutePath string, branch string) {
-	command := exec.Command("sh", "-c", fmt.Sprintf(`
-                            cd %s &&
-                            git pull origin %s --rebase`, repoAbsolutePath, branch))
-	session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
-	Expect(err).ShouldNot(HaveOccurred())
-	Eventually(session).Should(gexec.Exit())
-}
-
-func (b RealGitopsTestRunner) ListPullRequest(repoAbsolutePath string) []string {
-	command := exec.Command("sh", "-c", fmt.Sprintf(`
-                            cd %s &&
-                            hub pr list --limit 1 --base main --format='%%t|%%H|%%U%%n'`, repoAbsolutePath))
-	session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
-	Expect(err).ShouldNot(HaveOccurred())
-	Eventually(session).Should(gexec.Exit())
-
-	return strings.Split(string(session.Wait().Out.Contents()), "|")
-}
-
-func (b RealGitopsTestRunner) GetRepoVisibility(org string, repo string) string {
-	command := exec.Command("sh", "-c", fmt.Sprintf("hub api --flat repos/%s/%s|grep -i private|cut -f2", org, repo))
-	session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
-	Expect(err).ShouldNot(HaveOccurred())
-	Eventually(session).Should(gexec.Exit())
-	visibilityStr := strings.TrimSpace(string(session.Wait().Out.Contents()))
-	log.Printf("Repo visibility private=%s", visibilityStr)
-	return visibilityStr
-}
-
-func (b RealGitopsTestRunner) MergePullRequest(repoAbsolutePath string, prBranch string) {
-	command := exec.Command("sh", "-c", fmt.Sprintf(`
-                            cd %s &&
-							git fetch
-							git checkout main &&
-							git pull --no-ff &&
-                            git merge --no-ff --no-edit origin/%s &&
-							git push origin main`, repoAbsolutePath, prBranch))
-	session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
-	Expect(err).ShouldNot(HaveOccurred())
-	Eventually(session).Should(gexec.Exit())
-}
-
 // Run a command, passing through stdout/stderr to the OS standard streams
 func runCommandPassThrough(env []string, name string, arg ...string) error {
 	cmd := exec.Command(name, arg...)
@@ -771,70 +211,21 @@ func runCommandAndReturnStringOutput(commandToRun string) (stdOut string, stdErr
 	Expect(err).ShouldNot(HaveOccurred())
 	Eventually(session, ASSERTION_2MINUTE_TIME_OUT).Should(gexec.Exit())
 
-	return string(session.Wait().Out.Contents()), string(session.Wait().Err.Contents())
+	return strings.Trim(string(session.Wait().Out.Contents()), "\n"), strings.Trim(string(session.Wait().Err.Contents()), "\n")
 }
 
-func getEnv(key, fallback string) string {
-	value, exists := os.LookupEnv(key)
-	if !exists {
-		value = fallback
-	}
-	return value
-}
-
-// ShowItems displays the current set of a specified object type in tabular format
-func ShowItems(itemType string) error {
+func showItems(itemType string) error {
 	if itemType != "" {
 		return runCommandPassThrough([]string{}, "kubectl", "get", itemType, "--all-namespaces", "-o", "wide")
 	}
 	return runCommandPassThrough([]string{}, "kubectl", "get", "all", "--all-namespaces", "-o", "wide")
 }
 
-func DumpClusterInfo(testName string) error {
+func dumpClusterInfo(testName string) error {
 	return runCommandPassThrough([]string{}, "../../utils/scripts/dump-cluster-info.sh", testName, CLUSTER_INFO_DIR)
 }
 
-// This function generates multiple capitemplate files from a single capitemplate to be used as test data
-func generateTestCapiTemplates(templateCount int, templateFile string) (templateFiles []string, err error) {
-	// Read input capitemplate
-	contents, err := ioutil.ReadFile(fmt.Sprintf("../../utils/data/%s", templateFile))
-
-	if err != nil {
-		return templateFiles, err
-	}
-
-	// Prepare  data to insert into the template.
-	type TemplateInput struct {
-		Count int
-	}
-
-	// Create a new template and parse the letter into it.
-	t := template.Must(template.New("capi-template").Parse(string(contents)))
-
-	// Execute the template for each count.
-	for i := 0; i < templateCount; i++ {
-		input := TemplateInput{i}
-
-		fileName := fmt.Sprintf("%s%d", templateFile, i)
-
-		f, err := os.Create(path.Join("/tmp", fileName))
-		if err != nil {
-			return templateFiles, err
-		}
-		templateFiles = append(templateFiles, f.Name())
-
-		err = t.Execute(f, input)
-		if err != nil {
-			log.Println("executing template:", err)
-		}
-
-		f.Close()
-	}
-
-	return templateFiles, nil
-}
-
-// Utility function to delete all the files passed in a list
+// utility functions
 func deleteFile(name []string) error {
 	for _, name := range name {
 		log.Printf("Deleting: %s", name)
@@ -846,13 +237,11 @@ func deleteFile(name []string) error {
 	return nil
 }
 
-//Utility function delete directory
 func deleteDirectory(name []string) error {
 	return deleteFile(name)
 }
 
-// Utility function to check if file exists
-func FileExists(name string) bool {
+func fileExists(name string) bool {
 	if _, err := os.Stat(name); err != nil {
 		if os.IsNotExist(err) {
 			return false
@@ -861,239 +250,14 @@ func FileExists(name string) bool {
 	return true
 }
 
-//Utility function to compute public IP of cluster workload node
-func ClusterWorkloadNonePublicIP(clusterKind string) string {
-	var expernal_ip string
-	if clusterKind == "EKS" || clusterKind == "GKE" {
-		node_name, _ := runCommandAndReturnStringOutput(`kubectl get node --selector='!node-role.kubernetes.io/master' -o name | head -n 1`)
-		worker_name := strings.Trim(strings.Split(node_name, "/")[1], "\n")
-		expernal_ip, _ = runCommandAndReturnStringOutput(fmt.Sprintf(`kubectl get nodes -o jsonpath="{.items[?(@.metadata.name=='%s')].status.addresses[?(@.type=='ExternalIP')].address}"`, worker_name))
-	} else {
-		switch runtime.GOOS {
-		case "darwin":
-			expernal_ip, _ = runCommandAndReturnStringOutput(`ifconfig en0 | grep -i MASK | awk '{print $2}' | cut -f2 -d:`)
-		case "linux":
-			expernal_ip, _ = runCommandAndReturnStringOutput(`ifconfig eth0 | grep -i MASK | awk '{print $2}' | cut -f2 -d:`)
-		}
-	}
-	return strings.Trim(expernal_ip, "\n")
-}
-
-func CreateCluster(clusterType string, clusterName string, configFile string) {
-	if clusterType == "kind" {
-		err := runCommandPassThrough([]string{}, "kind", "create", "cluster", "--name", clusterName, "--image=kindest/node:v1.20.7", "--config", "../../utils/data/"+configFile)
-		Expect(err).ShouldNot(HaveOccurred())
-	} else {
-		Fail(fmt.Sprintf("%s cluster type is not supported for test WGE upgrade", clusterType))
-	}
-}
-
-func createTestFile(fileName string, fileContents string) string {
-	testFilePath := filepath.Join(os.TempDir(), fileName)
-
-	command := exec.Command("sh", "-c", fmt.Sprintf(`
-							cd /tmp &&
-                            echo "%s" > %s`, fileContents, testFilePath))
-	session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
-	Expect(err).ShouldNot(HaveOccurred())
-	Eventually(session).Should(gexec.Exit())
-
-	return testFilePath
-}
-
-func deleteClusters(clusterType string, clusters []string) {
-	for _, cluster := range clusters {
-		if clusterType == "kind" {
-			log.Printf("Deleting cluster: %s", cluster)
-			err := runCommandPassThrough([]string{}, "kind", "delete", "cluster", "--name", cluster)
-			Expect(err).ShouldNot(HaveOccurred())
-		} else {
-			err := runCommandPassThrough([]string{}, "kubectl", "get", "cluster", cluster)
-			if err == nil {
-				log.Printf("Deleting cluster: %s", cluster)
-				err := runCommandPassThrough([]string{}, "kubectl", "delete", "cluster", cluster)
-				Expect(err).ShouldNot(HaveOccurred())
-				err = runCommandPassThrough([]string{}, "kubectl", "get", "cluster", cluster)
-				Expect(err).Should(HaveOccurred(), fmt.Sprintf("Failed to delete cluster %s", cluster))
-			}
-		}
-	}
-}
-
-func VerifyCapiClusterKubeconfig(kubeconfigPath string, capiCluster string) {
-	contents, err := ioutil.ReadFile(kubeconfigPath)
-	Expect(err).ShouldNot(HaveOccurred())
-	Eventually(contents).Should(MatchRegexp(fmt.Sprintf(`context:\s+cluster: %s`, capiCluster)))
-
-	if runtime.GOOS == "darwin" {
-		// Point the kubeconfig to the exposed port of the load balancer, rather than the inaccessible container IP.
-		_, err := runCommandAndReturnStringOutput(fmt.Sprintf(`sed -i -e "s/server:.*/server: https:\/\/$(docker port %s-lb 6443/tcp | sed "s/0.0.0.0/127.0.0.1/")/g" %s`, capiCluster, kubeconfigPath))
-		Expect(err).Should(BeEmpty(), "Failed to delete ClusterBootstrapConfig secret")
-	}
-}
-
-func VerifyCapiClusterHealth(kubeconfigPath string, capiCluster string) {
-
-	Expect(waitForResource("nodes", "", "default", kubeconfigPath, ASSERTION_2MINUTE_TIME_OUT))
-	Expect(waitForResource("pods", "", "kube-system", kubeconfigPath, ASSERTION_2MINUTE_TIME_OUT))
-	Expect(waitForResource("pods", "", "wego-system", kubeconfigPath, ASSERTION_2MINUTE_TIME_OUT))
-}
-
-// gitops system helper functions
-func waitForResource(resourceType string, resourceName string, namespace string, kubeconfig string, timeout time.Duration) error {
-	pollInterval := 5
-	if timeout < 5*time.Second {
-		timeout = 5 * time.Second
-	}
-
-	if kubeconfig != "" {
-		kubeconfig = "--kubeconfig=" + kubeconfig
-	}
-
-	timeoutInSeconds := int(timeout.Seconds())
-	for i := pollInterval; i < timeoutInSeconds; i += pollInterval {
-		log.Infof("Waiting for %s in namespace: %s... : %d second(s) passed of %d seconds timeout", resourceType+"/"+resourceName, namespace, i, timeoutInSeconds)
-		err := runCommandPassThroughWithoutOutput([]string{}, "sh", "-c", fmt.Sprintf("kubectl %s get %s %s -n %s", kubeconfig, resourceType, resourceName, namespace))
+// WaitUntil runs checkDone until a timeout is reached
+func waitUntil(out io.Writer, poll, timeout time.Duration, checkDone func() error) error {
+	for start := time.Now(); time.Since(start) < timeout; time.Sleep(poll) {
+		err := checkDone()
 		if err == nil {
-			log.Infof("%s are available in cluster", resourceType+"/"+resourceName)
-			command := exec.Command("sh", "-c", fmt.Sprintf("kubectl %s get %s %s -n %s", kubeconfig, resourceType, resourceName, namespace))
-			session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
-			Expect(err).ShouldNot(HaveOccurred())
-			Eventually(session).Should(gexec.Exit())
-
-			noResourcesFoundMessage := ""
-			if namespace == "default" {
-				noResourcesFoundMessage = "No resources found"
-			} else {
-				noResourcesFoundMessage = fmt.Sprintf("No resources found in %s namespace", namespace)
-			}
-			if strings.Contains(string(session.Wait().Out.Contents()), noResourcesFoundMessage) {
-				log.Infof("Got message => {" + noResourcesFoundMessage + "} Continue looking for resource(s)")
-				continue
-			}
 			return nil
 		}
-		time.Sleep(time.Duration(pollInterval) * time.Second)
+		fmt.Fprintf(out, "error occurred %s, retrying in %s\n", err, poll.String())
 	}
-	return fmt.Errorf("error: Failed to find the resource %s of type %s, timeout reached", resourceName, resourceType)
-}
-
-func VerifyCoreControllers(namespace string) {
-	Expect(waitForResource("deploy", "helm-controller", namespace, "", ASSERTION_2MINUTE_TIME_OUT))
-	Expect(waitForResource("deploy", "kustomize-controller", namespace, "", ASSERTION_2MINUTE_TIME_OUT))
-	Expect(waitForResource("deploy", "notification-controller", namespace, "", ASSERTION_2MINUTE_TIME_OUT))
-	Expect(waitForResource("deploy", "source-controller", namespace, "", ASSERTION_2MINUTE_TIME_OUT))
-	Expect(waitForResource("deploy", "image-automation-controller", namespace, "", ASSERTION_2MINUTE_TIME_OUT))
-	Expect(waitForResource("deploy", "image-reflector-controller", namespace, "", ASSERTION_2MINUTE_TIME_OUT))
-	Expect(waitForResource("pods", "", namespace, "", ASSERTION_2MINUTE_TIME_OUT))
-
-	By("And I wait for the gitops core controllers to be ready", func() {
-		command := exec.Command("sh", "-c", fmt.Sprintf("kubectl wait --for=condition=Ready --timeout=%s -n %s --all pod --selector='app!=wego-app'", "180s", namespace))
-		session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
-		Expect(err).ShouldNot(HaveOccurred())
-		Eventually(session, ASSERTION_3MINUTE_TIME_OUT).Should(gexec.Exit())
-	})
-}
-
-func VerifyEnterpriseControllers(releaseName string, mccpPrefix, namespace string) {
-	// SOMETIMES (?) (with helm install ./local-path), the mccpPrefix is skipped
-	Expect(waitForResource("deploy", releaseName+"-"+mccpPrefix+"gitops-repo-broker", namespace, "", ASSERTION_2MINUTE_TIME_OUT))
-	Expect(waitForResource("deploy", releaseName+"-"+mccpPrefix+"event-writer", namespace, "", ASSERTION_2MINUTE_TIME_OUT))
-	Expect(waitForResource("deploy", releaseName+"-"+mccpPrefix+"cluster-service", namespace, "", ASSERTION_2MINUTE_TIME_OUT))
-	Expect(waitForResource("deploy", releaseName+"-nginx-ingress-controller", namespace, "", ASSERTION_2MINUTE_TIME_OUT))
-	// FIXME
-	// const maxDeploymentLength = 63
-	// Expect(waitForResource("deploy", (releaseName + "-nginx-ingress-controller-default-backend")[:maxDeploymentLength], namespace, ASSERTION_2MINUTE_TIME_OUT))
-	Expect(waitForResource("deploy", releaseName+"-wkp-ui-server", namespace, "", ASSERTION_2MINUTE_TIME_OUT))
-	Expect(waitForResource("pods", "", namespace, "", ASSERTION_2MINUTE_TIME_OUT))
-
-	By("And I wait for the gitops enterprise controllers to be ready", func() {
-		command := exec.Command("sh", "-c", fmt.Sprintf("kubectl wait --for=condition=Ready --timeout=%s -n %s --all pod --selector='app!=wego-app'", "180s", namespace))
-		session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
-		Expect(err).ShouldNot(HaveOccurred())
-		Eventually(session, ASSERTION_3MINUTE_TIME_OUT).Should(gexec.Exit())
-	})
-}
-
-func RunWegoAddCommand(repoAbsolutePath string, addCommand string, namespace string) {
-	log.Infof("Add command to run: %s in namespace %s from dir %s", addCommand, namespace, repoAbsolutePath)
-	_, errOutput := runCommandAndReturnStringOutput(fmt.Sprintf("cd %s && %s %s", repoAbsolutePath, GetGitopsBinPath(), addCommand))
-	Expect(errOutput).Should(BeEmpty())
-}
-
-func verifyWegoAddCommand(appName string, namespace string) {
-	command := exec.Command("sh", "-c", fmt.Sprintf(" kubectl wait --for=condition=Ready --timeout=60s -n %s GitRepositories --all", namespace))
-	session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
-	Expect(err).ShouldNot(HaveOccurred())
-	Eventually(session, ASSERTION_5MINUTE_TIME_OUT).Should(gexec.Exit())
-	Expect(waitForResource("GitRepositories", appName, namespace, "", ASSERTION_6MINUTE_TIME_OUT)).To(Succeed())
-}
-
-func InstallAndVerifyGitops(gitopsNamespace string, manifestRepoURL string) {
-	By("And I run 'gitops install' command with namespace "+gitopsNamespace, func() {
-		command := exec.Command("sh", "-c", fmt.Sprintf("%s install --config-repo %s --namespace=%s --auto-merge", GetGitopsBinPath(), manifestRepoURL, gitopsNamespace))
-		session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
-		Expect(err).ShouldNot(HaveOccurred())
-		Eventually(session, ASSERTION_2MINUTE_TIME_OUT).Should(gexec.Exit())
-		Expect(string(session.Err.Contents())).Should(BeEmpty())
-		VerifyCoreControllers(gitopsNamespace)
-	})
-}
-
-func RemoveGitopsCapiClusters(appName string, clusternames []string, nameSpace string) {
-	SusspendGitopsApplication(appName, nameSpace)
-
-	deleteClusters("capi", clusternames)
-
-	DeleteGitopsApplication(appName, nameSpace)
-	DeleteGitopsDeploySecret(nameSpace)
-}
-
-func SusspendGitopsApplication(appName string, nameSpace string) {
-	command := fmt.Sprintf("suspend app %s", appName)
-	By(fmt.Sprintf("And I run gitops suspend app command '%s'", command), func() {
-		command := exec.Command("sh", "-c", fmt.Sprintf("%s %s", GetGitopsBinPath(), command))
-		session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
-		Expect(err).ShouldNot(HaveOccurred())
-		Eventually(session).Should(gexec.Exit())
-	})
-}
-
-func ListGitopsApplication(appName string, nameSpace string) string {
-	var session *gexec.Session
-	var err error
-
-	cmd := fmt.Sprintf("get app %s", appName)
-	command := exec.Command("sh", "-c", fmt.Sprintf("%s %s", GetGitopsBinPath(), cmd))
-	session, err = gexec.Start(command, GinkgoWriter, GinkgoWriter)
-	Expect(err).ShouldNot(HaveOccurred())
-	Eventually(session).Should(gexec.Exit())
-
-	return string(session.Out.Contents())
-}
-
-func DeleteGitopsApplication(appName string, nameSpace string) {
-	command := fmt.Sprintf("delete app %s --auto-merge=true", appName)
-	By(fmt.Sprintf("And I run gitops delete app command '%s'", command), func() {
-		command := exec.Command("sh", "-c", fmt.Sprintf("%s %s", GetGitopsBinPath(), command))
-		session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
-		Expect(err).ShouldNot(HaveOccurred())
-		Eventually(session).Should(gexec.Exit())
-
-		appDeleted := func() bool {
-			status := ListGitopsApplication(appName, nameSpace)
-			return status == ""
-		}
-		Eventually(appDeleted, ASSERTION_2MINUTE_TIME_OUT, POLL_INTERVAL_5SECONDS).Should(BeTrue(), fmt.Sprintf("%s application failed to delete", appName))
-	})
-}
-
-func DeleteGitopsDeploySecret(nameSpace string) {
-	command := fmt.Sprintf(`kubectl get secrets -n %[1]v  | grep Opaque | grep wego- | cut -d' ' -f1 | xargs kubectl delete secrets -n %[1]v`, nameSpace)
-	By("And I delete deploy key secret", func() {
-		command := exec.Command("sh", "-c", command)
-		session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
-		Expect(err).ShouldNot(HaveOccurred())
-		Eventually(session).Should(gexec.Exit())
-	})
+	return fmt.Errorf("timeout reached %s", timeout.String())
 }

--- a/test/acceptance/test/utils_git.go
+++ b/test/acceptance/test/utils_git.go
@@ -1,0 +1,270 @@
+package acceptance
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/fluxcd/go-git-providers/github"
+	"github.com/fluxcd/go-git-providers/gitlab"
+	"github.com/fluxcd/go-git-providers/gitprovider"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gexec"
+	log "github.com/sirupsen/logrus"
+	"github.com/weaveworks/weave-gitops/pkg/git"
+	"github.com/weaveworks/weave-gitops/pkg/git/wrapper"
+	"github.com/weaveworks/weave-gitops/pkg/gitproviders"
+)
+
+const (
+	GitProviderGitHub = "github"
+	GitProviderGitLab = "gitlab"
+	tokenTypeOauth    = "oauth2"
+)
+
+func getWaitTimeFromErr(errOutput string) (time.Duration, error) {
+	var re = regexp.MustCompile(`(?m)\[rate reset in (.*)\]`)
+	match := re.FindAllStringSubmatch(errOutput, -1)
+
+	if len(match) >= 1 && len(match[1][0]) > 0 {
+		duration, err := time.ParseDuration(match[1][0])
+		if err != nil {
+			return 0, fmt.Errorf("error pasing rate reset time %w", err)
+		}
+
+		return duration, nil
+	}
+
+	return 0, fmt.Errorf("could not found a rate reset on string: %s", errOutput)
+}
+
+func extractOrgAndRepo(url string) (string, string) {
+	normalized, normErr := gitproviders.NewRepoURL(url)
+	Expect(normErr).ShouldNot(HaveOccurred())
+
+	re := regexp.MustCompile("^[^/]+//[^/]+/([^/]+)/([^/]+).*$")
+	matches := re.FindStringSubmatch(strings.TrimSuffix(normalized.String(), ".git"))
+
+	return matches[1], matches[2]
+}
+
+func getRepoVisibility(org string, repo string, providerName string) string {
+	gitProvider, orgRef, err := getGitProvider(org, repo, providerName)
+	Expect(err).ShouldNot(HaveOccurred())
+
+	orgInfo, err := gitProvider.OrgRepositories().Get(context.Background(), orgRef)
+	Expect(err).ShouldNot(HaveOccurred())
+
+	visibility := string(*orgInfo.Get().Visibility)
+
+	return visibility
+}
+
+func initAndCreateEmptyRepo(repoName string, providerName string, isPrivateRepo bool, org string) string {
+	repoAbsolutePath := path.Join("/tmp/", repoName)
+
+	deleteRepo(CLUSTER_REPOSITORY, GIT_PROVIDER, GITHUB_ORG)
+	err := deleteDirectory([]string{repoAbsolutePath})
+	Expect(err).ShouldNot(HaveOccurred())
+
+	err = createGitRepository(repoName, "main", isPrivateRepo, providerName, org)
+	Expect(err).ShouldNot(HaveOccurred())
+
+	err = waitUntil(os.Stdout, POLL_INTERVAL_5SECONDS, ASSERTION_30SECONDS_TIME_OUT, func() error {
+		command := exec.Command("sh", "-c", fmt.Sprintf(`
+            git clone git@%s.com:%s/%s.git %s`, providerName, org, repoName, repoAbsolutePath))
+		command.Stdout = os.Stdout
+		command.Stderr = os.Stderr
+		err := command.Run()
+		if err != nil {
+			os.RemoveAll(repoAbsolutePath)
+			return err
+		}
+		return nil
+	})
+	Expect(err).ShouldNot(HaveOccurred())
+
+	return repoAbsolutePath
+}
+
+func createGitRepository(repoName, branch string, private bool, providerName string, org string) error {
+	visibility := gitprovider.RepositoryVisibilityPublic
+	if private {
+		visibility = gitprovider.RepositoryVisibilityPrivate
+	}
+
+	description := "Weave Gitops enterprise test repository"
+	defaultBranch := branch
+	repoInfo := gitprovider.RepositoryInfo{
+		Description:   &description,
+		Visibility:    &visibility,
+		DefaultBranch: &defaultBranch,
+	}
+
+	repoCreateOpts := &gitprovider.RepositoryCreateOptions{
+		AutoInit: gitprovider.BoolVar(true),
+	}
+
+	gitProvider, orgRef, err := getGitProvider(org, repoName, providerName)
+	if err != nil {
+		return err
+	}
+
+	ctx := context.Background()
+
+	fmt.Printf("creating repo %s ...\n", repoName)
+
+	if err := waitUntil(os.Stdout, time.Second, ASSERTION_30SECONDS_TIME_OUT, func() error {
+		_, err := gitProvider.OrgRepositories().Create(ctx, orgRef, repoInfo, repoCreateOpts)
+		if err != nil && strings.Contains(err.Error(), "rate limit exceeded") {
+			waitForRateQuota, err := getWaitTimeFromErr(err.Error())
+			if err != nil {
+				return err
+			}
+			fmt.Printf("Waiting for rate quota %s \n", waitForRateQuota.String())
+			time.Sleep(waitForRateQuota)
+			return fmt.Errorf("retry after waiting for rate quota")
+		}
+		return err
+	}); err != nil {
+		return fmt.Errorf("error creating repo %s", err)
+	}
+
+	fmt.Printf("repo %s created ...\n", repoName)
+	fmt.Printf("validating access to the repo %s ...\n", repoName)
+
+	err = waitUntil(os.Stdout, POLL_INTERVAL_1SECONDS, ASSERTION_30SECONDS_TIME_OUT, func() error {
+		_, err := gitProvider.OrgRepositories().Get(ctx, orgRef)
+		return err
+	})
+	if err != nil {
+		return fmt.Errorf("error validating access to the repository %w", err)
+	}
+	fmt.Printf("repo %s is accessible through the api ...\n", repoName)
+
+	return nil
+}
+
+func getGitProvider(org string, repo string, providerName string) (gitprovider.Client, gitprovider.OrgRepositoryRef, error) {
+	var gitProvider gitprovider.Client
+
+	var orgRef gitprovider.OrgRepositoryRef
+
+	var err error
+
+	switch providerName {
+	case GitProviderGitHub:
+		orgRef = gitproviders.NewOrgRepositoryRef(github.DefaultDomain, org, repo)
+
+		gitProvider, err = github.NewClient(
+			gitprovider.WithOAuth2Token(GITHUB_TOKEN),
+			gitprovider.WithDestructiveAPICalls(true),
+		)
+	case GitProviderGitLab:
+		orgRef = gitproviders.NewOrgRepositoryRef(gitlab.DefaultDomain, org, repo)
+
+		gitProvider, err = gitlab.NewClient(
+			GITLAB_TOKEN,
+			tokenTypeOauth,
+			gitprovider.WithOAuth2Token(GITLAB_TOKEN),
+			gitprovider.WithDestructiveAPICalls(true),
+		)
+	default:
+		err = fmt.Errorf("invalid git provider name: %s", providerName)
+	}
+
+	return gitProvider, orgRef, err
+}
+
+func deleteRepo(repoName string, providerName string, org string) {
+	log.Printf("Delete application repo: %s", path.Join(GITHUB_ORG, repoName))
+
+	gitProvider, orgRef, providerErr := getGitProvider(org, repoName, providerName)
+	Expect(providerErr).ShouldNot(HaveOccurred())
+
+	ctx := context.Background()
+	or, repoErr := gitProvider.OrgRepositories().Get(ctx, orgRef)
+
+	// allow repo to be absent (as tests assume this)
+	if repoErr == nil {
+		deleteErr := or.Delete(ctx)
+		Expect(deleteErr).ShouldNot(HaveOccurred())
+	}
+}
+
+func verifyPRCreated(repoAbsolutePath, providerName string) string {
+	ctx := context.Background()
+
+	repoUrlString, repoUrlErr := git.New(nil, wrapper.NewGoGit()).GetRemoteUrl(repoAbsolutePath, "origin")
+	Expect(repoUrlErr).ShouldNot(HaveOccurred())
+
+	org, _ := extractOrgAndRepo(repoUrlString)
+	gitProvider, orgRef, providerErr := getGitProvider(org, filepath.Base(repoAbsolutePath), providerName)
+	Expect(providerErr).ShouldNot(HaveOccurred())
+
+	or, repoErr := gitProvider.OrgRepositories().Get(ctx, orgRef)
+	Expect(repoErr).ShouldNot(HaveOccurred())
+
+	prs, err := or.PullRequests().List(ctx)
+	Expect(err).ShouldNot(HaveOccurred())
+
+	Expect(len(prs)).To(Equal(1))
+	return prs[0].Get().WebURL
+}
+
+func mergePullRequest(repoAbsolutePath string, prLink string, providerName string) {
+	ctx := context.Background()
+	prNumberStr := filepath.Base(prLink)
+	prNumber, numErr := strconv.Atoi(prNumberStr)
+	Expect(numErr).ShouldNot(HaveOccurred())
+
+	repoUrlString, repoUrlErr := git.New(nil, wrapper.NewGoGit()).GetRemoteUrl(repoAbsolutePath, "origin")
+	Expect(repoUrlErr).ShouldNot(HaveOccurred())
+
+	org, repo := extractOrgAndRepo(repoUrlString)
+	gitProvider, orgRef, providerErr := getGitProvider(org, repo, providerName)
+	Expect(providerErr).ShouldNot(HaveOccurred())
+
+	or, repoErr := gitProvider.OrgRepositories().Get(ctx, orgRef)
+	Expect(repoErr).ShouldNot(HaveOccurred())
+
+	err := or.PullRequests().Merge(ctx, prNumber, gitprovider.MergeMethodMerge, "merge for test")
+	Expect(err).ShouldNot(HaveOccurred())
+}
+
+func gitUpdateCommitPush(repoAbsolutePath string, commitMessage string) {
+	log.Infof("Pushing changes made to file(s) in repo: %s", repoAbsolutePath)
+	if commitMessage == "" {
+		commitMessage = "edit repo file"
+	}
+
+	_ = runCommandPassThrough([]string{}, "sh", "-c", fmt.Sprintf("cd %s && git add -u && git add -A && git commit -m '%s' && git pull --rebase && git push origin HEAD", repoAbsolutePath, commitMessage))
+}
+
+func getGitRepositoryURL(repoAbsolutePath string) string {
+	repoURL, _ := runCommandAndReturnStringOutput(fmt.Sprintf(`cd %s && git config --get remote.origin.url`, repoAbsolutePath))
+	return repoURL
+}
+
+func createGitRepoBranch(repoAbsolutePath string, branchName string) string {
+	command := exec.Command("sh", "-c", fmt.Sprintf("cd %s && git checkout -b %s && git push --set-upstream origin %s", repoAbsolutePath, branchName, branchName))
+	session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
+	Expect(err).ShouldNot(HaveOccurred())
+	Eventually(session).Should(gexec.Exit())
+	return string(session.Wait().Out.Contents())
+}
+
+func pullGitRepo(repoAbsolutePath string) {
+	command := exec.Command("sh", "-c", fmt.Sprintf("cd %s && git pull", repoAbsolutePath))
+	session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
+	Expect(err).ShouldNot(HaveOccurred())
+	Eventually(session).Should(gexec.Exit())
+}

--- a/test/acceptance/test/utils_gitops.go
+++ b/test/acceptance/test/utils_gitops.go
@@ -1,0 +1,237 @@
+package acceptance
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os/exec"
+	"runtime"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gexec"
+	log "github.com/sirupsen/logrus"
+)
+
+func waitForResource(resourceType string, resourceName string, namespace string, kubeconfig string, timeout time.Duration) error {
+	pollInterval := 5
+	if timeout < 5*time.Second {
+		timeout = 5 * time.Second
+	}
+
+	if kubeconfig != "" {
+		kubeconfig = "--kubeconfig=" + kubeconfig
+	}
+
+	timeoutInSeconds := int(timeout.Seconds())
+	for i := pollInterval; i < timeoutInSeconds; i += pollInterval {
+		log.Infof("Waiting for %s in namespace: %s... : %d second(s) passed of %d seconds timeout", resourceType+"/"+resourceName, namespace, i, timeoutInSeconds)
+		err := runCommandPassThroughWithoutOutput([]string{}, "sh", "-c", fmt.Sprintf("kubectl %s get %s %s -n %s", kubeconfig, resourceType, resourceName, namespace))
+		if err == nil {
+			command := exec.Command("sh", "-c", fmt.Sprintf("kubectl %s get %s %s -n %s", kubeconfig, resourceType, resourceName, namespace))
+			session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
+			Expect(err).ShouldNot(HaveOccurred())
+			Eventually(session).Should(gexec.Exit())
+
+			noResourcesFoundMessage := ""
+			if namespace == "default" {
+				noResourcesFoundMessage = "No resources found"
+			} else {
+				noResourcesFoundMessage = fmt.Sprintf("No resources found in %s namespace", namespace)
+			}
+			output := string(session.Wait().Out.Contents())
+			if len(output) == 0 || strings.Contains(output, noResourcesFoundMessage) {
+				log.Infof("Got message => {" + noResourcesFoundMessage + "} Continue looking for resource(s)")
+			} else {
+				return nil
+			}
+		}
+		time.Sleep(time.Duration(pollInterval) * time.Second)
+	}
+	return fmt.Errorf("error: Failed to find the resource %s of type %s, timeout reached", resourceName, resourceType)
+}
+
+func verifyCoreControllers(namespace string) {
+	Expect(waitForResource("deploy", "helm-controller", namespace, "", ASSERTION_2MINUTE_TIME_OUT))
+	Expect(waitForResource("deploy", "kustomize-controller", namespace, "", ASSERTION_2MINUTE_TIME_OUT))
+	Expect(waitForResource("deploy", "notification-controller", namespace, "", ASSERTION_2MINUTE_TIME_OUT))
+	Expect(waitForResource("deploy", "source-controller", namespace, "", ASSERTION_2MINUTE_TIME_OUT))
+	Expect(waitForResource("deploy", "image-automation-controller", namespace, "", ASSERTION_2MINUTE_TIME_OUT))
+	Expect(waitForResource("deploy", "image-reflector-controller", namespace, "", ASSERTION_2MINUTE_TIME_OUT))
+	Expect(waitForResource("pods", "", namespace, "", ASSERTION_2MINUTE_TIME_OUT))
+
+	By("And I wait for the gitops core controllers to be ready", func() {
+		command := exec.Command("sh", "-c", fmt.Sprintf("kubectl wait --for=condition=Ready --timeout=%s -n %s --all pod --selector='app!=wego-app'", "180s", namespace))
+		session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
+		Expect(err).ShouldNot(HaveOccurred())
+		Eventually(session, ASSERTION_3MINUTE_TIME_OUT).Should(gexec.Exit())
+	})
+}
+
+func verifyEnterpriseControllers(releaseName string, mccpPrefix, namespace string) {
+	// SOMETIMES (?) (with helm install ./local-path), the mccpPrefix is skipped
+	Expect(waitForResource("deploy", releaseName+"-"+mccpPrefix+"gitops-repo-broker", namespace, "", ASSERTION_2MINUTE_TIME_OUT))
+	Expect(waitForResource("deploy", releaseName+"-"+mccpPrefix+"event-writer", namespace, "", ASSERTION_2MINUTE_TIME_OUT))
+	Expect(waitForResource("deploy", releaseName+"-"+mccpPrefix+"cluster-service", namespace, "", ASSERTION_2MINUTE_TIME_OUT))
+	Expect(waitForResource("deploy", releaseName+"-nginx-ingress-controller", namespace, "", ASSERTION_2MINUTE_TIME_OUT))
+	// FIXME
+	// const maxDeploymentLength = 63
+	// Expect(waitForResource("deploy", (releaseName + "-nginx-ingress-controller-default-backend")[:maxDeploymentLength], namespace, ASSERTION_2MINUTE_TIME_OUT))
+	Expect(waitForResource("deploy", releaseName+"-wkp-ui-server", namespace, "", ASSERTION_2MINUTE_TIME_OUT))
+	Expect(waitForResource("pods", "", namespace, "", ASSERTION_2MINUTE_TIME_OUT))
+
+	By("And I wait for the gitops enterprise controllers to be ready", func() {
+		command := exec.Command("sh", "-c", fmt.Sprintf("kubectl wait --for=condition=Ready --timeout=%s -n %s --all pod --selector='app!=wego-app'", "180s", namespace))
+		session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
+		Expect(err).ShouldNot(HaveOccurred())
+		Eventually(session, ASSERTION_3MINUTE_TIME_OUT).Should(gexec.Exit())
+	})
+}
+
+func runWegoAddCommand(repoAbsolutePath string, addCommand string, namespace string) {
+	log.Infof("Add command to run: %s in namespace %s from dir %s", addCommand, namespace, repoAbsolutePath)
+	_, errOutput := runCommandAndReturnStringOutput(fmt.Sprintf("cd %s && %s %s", repoAbsolutePath, GITOPS_BIN_PATH, addCommand))
+	Expect(errOutput).Should(BeEmpty())
+}
+
+func verifyWegoAddCommand(appName string, namespace string) {
+	command := exec.Command("sh", "-c", fmt.Sprintf(" kubectl wait --for=condition=Ready --timeout=60s -n %s GitRepositories --all", namespace))
+	session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
+	Expect(err).ShouldNot(HaveOccurred())
+	Eventually(session, ASSERTION_5MINUTE_TIME_OUT).Should(gexec.Exit())
+	Expect(waitForResource("GitRepositories", appName, namespace, "", ASSERTION_6MINUTE_TIME_OUT)).To(Succeed())
+}
+
+func installAndVerifyGitops(gitopsNamespace string, manifestRepoURL string) {
+	By("And I run 'gitops install' command with namespace "+gitopsNamespace, func() {
+		command := exec.Command("sh", "-c", fmt.Sprintf("%s install --config-repo %s --namespace=%s --auto-merge", GITOPS_BIN_PATH, manifestRepoURL, gitopsNamespace))
+		session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
+		Expect(err).ShouldNot(HaveOccurred())
+		Eventually(session, ASSERTION_2MINUTE_TIME_OUT).Should(gexec.Exit())
+		Expect(string(session.Err.Contents())).Should(BeEmpty())
+		verifyCoreControllers(gitopsNamespace)
+	})
+}
+
+func removeGitopsCapiClusters(appName string, clusternames []string, nameSpace string) {
+	susspendGitopsApplication(appName, nameSpace)
+
+	deleteClusters("capi", clusternames)
+
+	deleteGitopsApplication(appName, nameSpace)
+	deleteGitopsDeploySecret(nameSpace)
+}
+
+func susspendGitopsApplication(appName string, nameSpace string) {
+	command := fmt.Sprintf("suspend app %s", appName)
+	By(fmt.Sprintf("And I run gitops suspend app command '%s'", command), func() {
+		command := exec.Command("sh", "-c", fmt.Sprintf("%s %s", GITOPS_BIN_PATH, command))
+		session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
+		Expect(err).ShouldNot(HaveOccurred())
+		Eventually(session).Should(gexec.Exit())
+	})
+}
+
+func listGitopsApplication(appName string, nameSpace string) string {
+	var session *gexec.Session
+	var err error
+
+	cmd := fmt.Sprintf("get app %s", appName)
+	command := exec.Command("sh", "-c", fmt.Sprintf("%s %s", GITOPS_BIN_PATH, cmd))
+	session, err = gexec.Start(command, GinkgoWriter, GinkgoWriter)
+	Expect(err).ShouldNot(HaveOccurred())
+	Eventually(session).Should(gexec.Exit())
+
+	return string(session.Out.Contents())
+}
+
+func deleteGitopsApplication(appName string, nameSpace string) {
+	command := fmt.Sprintf("delete app %s --auto-merge=true", appName)
+	By(fmt.Sprintf("And I run gitops delete app command '%s'", command), func() {
+		command := exec.Command("sh", "-c", fmt.Sprintf("%s %s", GITOPS_BIN_PATH, command))
+		session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
+		Expect(err).ShouldNot(HaveOccurred())
+		Eventually(session).Should(gexec.Exit())
+
+		appDeleted := func() bool {
+			status := listGitopsApplication(appName, nameSpace)
+			return status == ""
+		}
+		Eventually(appDeleted, ASSERTION_2MINUTE_TIME_OUT, POLL_INTERVAL_5SECONDS).Should(BeTrue(), fmt.Sprintf("%s application failed to delete", appName))
+	})
+}
+
+func deleteGitopsDeploySecret(nameSpace string) {
+	command := fmt.Sprintf(`kubectl get secrets -n %[1]v  | grep Opaque | grep wego- | cut -d' ' -f1 | xargs kubectl delete secrets -n %[1]v`, nameSpace)
+	By("And I delete deploy key secret", func() {
+		command := exec.Command("sh", "-c", command)
+		session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
+		Expect(err).ShouldNot(HaveOccurred())
+		Eventually(session).Should(gexec.Exit())
+	})
+}
+
+func clusterWorkloadNonePublicIP(clusterKind string) string {
+	var expernal_ip string
+	if clusterKind == "EKS" || clusterKind == "GKE" {
+		node_name, _ := runCommandAndReturnStringOutput(`kubectl get node --selector='!node-role.kubernetes.io/master' -o name | head -n 1`)
+		worker_name := strings.Split(node_name, "/")[1]
+		expernal_ip, _ = runCommandAndReturnStringOutput(fmt.Sprintf(`kubectl get nodes -o jsonpath="{.items[?(@.metadata.name=='%s')].status.addresses[?(@.type=='ExternalIP')].address}"`, worker_name))
+	} else {
+		switch runtime.GOOS {
+		case "darwin":
+			expernal_ip, _ = runCommandAndReturnStringOutput(`ifconfig en0 | grep -i MASK | awk '{print $2}' | cut -f2 -d:`)
+		case "linux":
+			expernal_ip, _ = runCommandAndReturnStringOutput(`ifconfig eth0 | grep -i MASK | awk '{print $2}' | cut -f2 -d:`)
+		}
+	}
+	return expernal_ip
+}
+
+func createCluster(clusterType string, clusterName string, configFile string) {
+	if clusterType == "kind" {
+		err := runCommandPassThrough([]string{}, "kind", "create", "cluster", "--name", clusterName, "--image=kindest/node:v1.20.7", "--config", "../../utils/data/"+configFile)
+		Expect(err).ShouldNot(HaveOccurred())
+	} else {
+		Fail(fmt.Sprintf("%s cluster type is not supported for test WGE upgrade", clusterType))
+	}
+}
+
+func deleteClusters(clusterType string, clusters []string) {
+	for _, cluster := range clusters {
+		if clusterType == "kind" {
+			log.Printf("Deleting cluster: %s", cluster)
+			err := runCommandPassThrough([]string{}, "kind", "delete", "cluster", "--name", cluster)
+			Expect(err).ShouldNot(HaveOccurred())
+		} else {
+			err := runCommandPassThrough([]string{}, "kubectl", "get", "cluster", cluster)
+			if err == nil {
+				log.Printf("Deleting cluster: %s", cluster)
+				err := runCommandPassThrough([]string{}, "kubectl", "delete", "cluster", cluster)
+				Expect(err).ShouldNot(HaveOccurred())
+				err = runCommandPassThrough([]string{}, "kubectl", "get", "cluster", cluster)
+				Expect(err).Should(HaveOccurred(), fmt.Sprintf("Failed to delete cluster %s", cluster))
+			}
+		}
+	}
+}
+
+func verifyCapiClusterKubeconfig(kubeconfigPath string, capiCluster string) {
+	contents, err := ioutil.ReadFile(kubeconfigPath)
+	Expect(err).ShouldNot(HaveOccurred())
+	Eventually(contents).Should(MatchRegexp(fmt.Sprintf(`context:\s+cluster: %s`, capiCluster)))
+
+	if runtime.GOOS == "darwin" {
+		// Point the kubeconfig to the exposed port of the load balancer, rather than the inaccessible container IP.
+		_, err := runCommandAndReturnStringOutput(fmt.Sprintf(`sed -i -e "s/server:.*/server: https:\/\/$(docker port %s-lb 6443/tcp | sed "s/0.0.0.0/127.0.0.1/")/g" %s`, capiCluster, kubeconfigPath))
+		Expect(err).Should(BeEmpty(), "Failed to delete ClusterBootstrapConfig secret")
+	}
+}
+
+func verifyCapiClusterHealth(kubeconfigPath string, capiCluster string) {
+
+	Expect(waitForResource("nodes", "", "default", kubeconfigPath, ASSERTION_2MINUTE_TIME_OUT))
+	Expect(waitForResource("pods", "", "kube-system", kubeconfigPath, ASSERTION_2MINUTE_TIME_OUT))
+	Expect(waitForResource("pods", "", "wego-system", kubeconfigPath, ASSERTION_2MINUTE_TIME_OUT))
+}

--- a/test/acceptance/test/utils_runner.go
+++ b/test/acceptance/test/utils_runner.go
@@ -1,0 +1,440 @@
+package acceptance
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"net/url"
+	"os"
+	"os/exec"
+	"path"
+	"text/template"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gexec"
+	"github.com/weaveworks/weave-gitops-enterprise/cmd/clusters-service/pkg/capi"
+	"github.com/weaveworks/weave-gitops-enterprise/common/database/models"
+	"gorm.io/datatypes"
+	"gorm.io/gorm"
+	"k8s.io/apimachinery/pkg/types"
+	goclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Interface that can be implemented either with:
+// - "Real" commands like "exec(kubectl...)"
+// - "Mock" commands like db.Create(cluster_info...)
+type GitopsTestRunner interface {
+	ResetDatabase() error
+	VerifyWegoPodsRunning()
+	FireAlert(name, severity, message string, fireFor time.Duration) error
+	KubectlApply(env []string, tokenURL string) error
+	KubectlDelete(env []string, tokenURL string) error
+	KubectlDeleteAllAgents(env []string) error
+	TimeTravelToLastSeen() error
+	TimeTravelToAlertsResolved() error
+	AddWorkspace(env []string, clusterName string) error
+	CreateApplyCapitemplates(templateCount int, templateFile string) []string
+	DeleteApplyCapiTemplates(templateFiles []string)
+	CreateIPCredentials(infrastructureProvider string)
+	DeleteIPCredentials(infrastructureProvider string)
+	CheckClusterService(capiEndpointURL string)
+	RestartDeploymentPods(env []string, appName string, namespace string) error
+}
+
+// "DB" backend that creates/delete rows
+
+type DatabaseGitopsTestRunner struct {
+	DB     *gorm.DB
+	Client goclient.Client
+}
+
+func (b DatabaseGitopsTestRunner) TimeTravelToLastSeen() error {
+	oneMinuteAgo := time.Now().UTC().Add(time.Minute * -2)
+	b.DB.Exec("update cluster_info set updated_at = ?", oneMinuteAgo)
+	return nil
+}
+
+func (b DatabaseGitopsTestRunner) TimeTravelToAlertsResolved() error {
+	b.DB.Where("1 = 1").Delete(&models.Alert{})
+	return nil
+}
+
+func (b DatabaseGitopsTestRunner) ResetDatabase() error {
+	b.DB.Where("1 = 1").Delete(&models.Cluster{})
+	return nil
+}
+
+func (b DatabaseGitopsTestRunner) VerifyWegoPodsRunning() {
+
+}
+
+func (b DatabaseGitopsTestRunner) KubectlApply(env []string, tokenURL string) error {
+	u, err := url.Parse(tokenURL)
+	if err != nil {
+		return err
+	}
+	token := u.Query()["token"][0]
+
+	b.DB.Create(&models.ClusterInfo{
+		UID:          types.UID(RandString(10)),
+		ClusterToken: token,
+		UpdatedAt:    time.Now().UTC(),
+	})
+	b.DB.Create(&models.GitCommit{
+		ClusterToken: token,
+		Sha:          "abcdef123456",
+		AuthorName:   "Alice",
+		AuthorEmail:  "alice@acme.org",
+		AuthorDate:   time.Now().UTC().Add(time.Hour * -1),
+		Message:      "Fixed it",
+	})
+	b.DB.Create(&models.FluxInfo{
+		ClusterToken: token,
+		Name:         "flux",
+		Namespace:    "wkp-flux",
+		RepoURL:      "git@github.com:wkp/my-cluster",
+		RepoBranch:   "main",
+	})
+	return nil
+}
+
+func (b DatabaseGitopsTestRunner) KubectlDelete(env []string, tokenURL string) error {
+	//
+	// No more cluster_infos will be created anyway..
+	// FIXME: maybe we add a polling loop that keeps creating cluster_info while its connected
+	//
+	return nil
+}
+
+func (b DatabaseGitopsTestRunner) KubectlDeleteAllAgents(env []string) error {
+	// No more cluster_infos will be created anyway..
+	return nil
+}
+
+func (b DatabaseGitopsTestRunner) FireAlert(name, severity, message string, fireFor time.Duration) error {
+	var firstCluster models.Cluster
+	b.DB.Last(&firstCluster)
+
+	//
+	// FIXME: we shouldn't need this. The UI should stop showing the alerts after 30s anyway
+	// But its not filtering on endsAt right now.
+	//
+	go func() {
+		time.Sleep(fireFor)
+		b.DB.Where("1 = 1").Delete(&models.Alert{})
+	}()
+
+	labels := fmt.Sprintf(`{ "alertname": "%s", "severity": "%s" }`, name, severity)
+	annotations := fmt.Sprintf(`{ "message": "%s" }`, message)
+	b.DB.Create(&models.Alert{
+		ClusterToken: firstCluster.Token,
+		UpdatedAt:    time.Now().UTC(),
+		Labels:       datatypes.JSON(labels),
+		Annotations:  datatypes.JSON(annotations),
+		Severity:     severity,
+		StartsAt:     time.Now().UTC().Add(fireFor * -1),
+		EndsAt:       time.Now().UTC().Add(fireFor),
+	})
+
+	return nil
+}
+
+func (b DatabaseGitopsTestRunner) AddWorkspace(env []string, clusterName string) error {
+	var firstCluster models.Cluster
+	b.DB.Where("Name = ?", clusterName).First(&firstCluster)
+
+	b.DB.Create(&models.Workspace{
+		ClusterToken: firstCluster.Token,
+		Name:         "mccp-devs-workspace",
+		Namespace:    "wkp-workspace",
+	})
+
+	return nil
+}
+
+func (b DatabaseGitopsTestRunner) CreateApplyCapitemplates(templateCount int, templateFile string) []string {
+	templateFiles, err := generateTestCapiTemplates(templateCount, templateFile)
+	Expect(err).To(BeNil(), "Failed to generate CAPITemplate template test files")
+	By("Apply/Install CAPITemplate templates", func() {
+		for _, fileName := range templateFiles {
+			template, err := capi.ParseFile(fileName)
+			Expect(err).To(BeNil(), "Failed to parse CAPITemplate template files")
+			err = b.Client.Create(context.Background(), template)
+			Expect(err).To(BeNil(), "Failed to create CAPITemplate template files")
+		}
+	})
+
+	return templateFiles
+}
+
+func (b DatabaseGitopsTestRunner) DeleteApplyCapiTemplates(templateFiles []string) {
+	By("Delete CAPITemplate templates", func() {
+		for _, fileName := range templateFiles {
+			template, err := capi.ParseFile(fileName)
+			Expect(err).To(BeNil(), "Failed to parse CAPITemplate template files")
+			err = b.Client.Delete(context.Background(), template)
+			Expect(err).To(BeNil(), "Failed to delete CAPITemplate template files")
+		}
+	})
+}
+
+func (b DatabaseGitopsTestRunner) CheckClusterService(capiEndpointURL string) {
+
+}
+
+func (b DatabaseGitopsTestRunner) RestartDeploymentPods(env []string, appName string, namespace string) error {
+	return nil
+}
+
+func (b DatabaseGitopsTestRunner) CreateIPCredentials(infrastructureProvider string) {
+
+}
+
+func (b DatabaseGitopsTestRunner) DeleteIPCredentials(infrastructureProvider string) {
+
+}
+
+// "Real" backend that call kubectl and posts to alertmanagement
+
+type RealGitopsTestRunner struct{}
+
+func (b RealGitopsTestRunner) TimeTravelToLastSeen() error {
+	return nil
+}
+
+func (b RealGitopsTestRunner) TimeTravelToAlertsResolved() error {
+	return nil
+}
+
+func (b RealGitopsTestRunner) ResetDatabase() error {
+	return runCommandPassThrough([]string{}, "../../utils/scripts/wego-enterprise.sh", "reset_mccp")
+}
+
+func (b RealGitopsTestRunner) VerifyWegoPodsRunning() {
+	verifyEnterpriseControllers("my-mccp", "", GITOPS_DEFAULT_NAMESPACE)
+}
+
+func (b RealGitopsTestRunner) KubectlApply(env []string, tokenURL string) error {
+	err := runCommandPassThrough(env, "kubectl", "apply", "-f", tokenURL)
+	fmt.Println("Cluster pods after apply")
+	if err := runCommandPassThrough(env, "kubectl", "get", "pods", "-A"); err != nil {
+		fmt.Printf("Error getting cluster pods after apply: %v\n", err)
+	}
+	return err
+}
+
+func (b RealGitopsTestRunner) KubectlDelete(env []string, tokenURL string) error {
+	return runCommandPassThrough(env, "kubectl", "delete", "-f", tokenURL)
+}
+
+func (b RealGitopsTestRunner) KubectlDeleteAllAgents(env []string) error {
+	return runCommandPassThrough(env, "kubectl", "delete", "-n", "wkp-agent", "deploy", "wkp-agent")
+}
+
+func (b RealGitopsTestRunner) FireAlert(name, severity, message string, fireFor time.Duration) error {
+	const alertTemplate = `
+    [
+      {
+        "labels": {
+          "alertname": "{{ .Name }}",
+          "severity": "{{ .Severity }}"
+        },
+        "annotations": {
+          "message": "{{ .Message }}"
+        },
+        "startsAt": "{{ .StartsAt }}",
+        "endsAt": "{{ .EndsAt }}"
+      }
+    ]
+    `
+
+	t, err := template.New("alert").Parse(alertTemplate)
+	if err != nil {
+		return err
+	}
+	var populated bytes.Buffer
+	err = t.Execute(&populated, struct {
+		Name     string
+		Severity string
+		Message  string
+		StartsAt string
+		EndsAt   string
+	}{
+		name,
+		severity,
+		message,
+		time.Now().UTC().Add(fireFor * -1).Format(time.RFC3339),
+		time.Now().UTC().Add(fireFor).Format(time.RFC3339),
+	})
+
+	if err != nil {
+		return err
+	}
+
+	fmt.Print(populated.String())
+	req, err := http.NewRequest("POST", DEFAULT_UI_URL+"/alertmanager/api/v2/alerts", &populated)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	body, _ := ioutil.ReadAll(resp.Body)
+	fmt.Println("response Body:", string(body))
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("alertmanager didn't like the alert: %v", resp.StatusCode)
+	}
+
+	return nil
+}
+
+func (b RealGitopsTestRunner) AddWorkspace(env []string, clusterName string) error {
+	return runCommandPassThrough(env, "kubectl", "apply", "-f", "../../utils/data/mccp-workspace.yaml")
+}
+
+// This function will crete the test capiTemplate files and do the kubectl apply for capiserver availability
+func (b RealGitopsTestRunner) CreateApplyCapitemplates(templateCount int, templateFile string) []string {
+	templateFiles, err := generateTestCapiTemplates(templateCount, templateFile)
+	Expect(err).To(BeNil(), "Failed to generate CAPITemplate template test files")
+
+	By("Apply/Install CAPITemplate templates", func() {
+		for _, fileName := range templateFiles {
+			err = runCommandPassThrough([]string{}, "kubectl", "apply", "-f", fileName)
+			Expect(err).To(BeNil(), "Failed to apply/install CAPITemplate template files")
+		}
+	})
+
+	return templateFiles
+}
+
+// This function deletes the test capiTemplate files and do the kubectl delete to clean the cluster
+func (b RealGitopsTestRunner) DeleteApplyCapiTemplates(templateFiles []string) {
+	By("Delete CAPITemplate templates", func() {
+
+		for _, fileName := range templateFiles {
+			err := b.KubectlDelete([]string{}, fileName)
+			Expect(err).To(BeNil(), "Failed to delete CAPITemplate template")
+		}
+	})
+
+	err := deleteFile(templateFiles)
+	Expect(err).To(BeNil(), "Failed to delete CAPITemplate template test files")
+}
+
+func (b RealGitopsTestRunner) CheckClusterService(capiEndpointURL string) {
+	output := func() string {
+		command := exec.Command("curl", "-s", "-o", "/dev/null", "-w", "%{http_code}", capiEndpointURL+"/v1/templates")
+		session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
+		Expect(err).ShouldNot(HaveOccurred())
+		return string(session.Wait(ASSERTION_30SECONDS_TIME_OUT).Out.Contents())
+	}
+	Eventually(output, ASSERTION_1MINUTE_TIME_OUT, POLL_INTERVAL_5SECONDS).Should(MatchRegexp("200"), "Cluster Service is not healthy")
+}
+
+func (b RealGitopsTestRunner) RestartDeploymentPods(env []string, appName string, namespace string) error {
+	// Restart the deployment pods
+	err := runCommandPassThrough(env, "kubectl", "rollout", "restart", "deployment", appName, "-n", namespace)
+	if err == nil {
+		// Wait for all the deployments replicas to rolled out successfully
+		err = runCommandPassThrough(env, "kubectl", "rollout", "status", "deployment", appName, "-n", namespace)
+	}
+	return err
+}
+
+func (b RealGitopsTestRunner) CreateIPCredentials(infrastructureProvider string) {
+	if infrastructureProvider == "AWS" {
+		By("Install AWSClusterStaticIdentity CRD", func() {
+			err := runCommandPassThrough([]string{}, "kubectl", "apply", "-f", "../../utils/data/infrastructure.cluster.x-k8s.io_awsclusterstaticidentities.yaml")
+			Expect(err).To(BeNil(), "Failed to install AWSClusterStaticIdentity CRD")
+			err = runCommandPassThrough([]string{}, "kubectl", "wait", "--for=condition=established", "--timeout=90s", "crd/awsclusterstaticidentities.infrastructure.cluster.x-k8s.io")
+			Expect(err).To(BeNil(), "Failed to verify AWSClusterStaticIdentity CRD")
+		})
+
+		By("Install AWSClusterRoleIdentity CRD", func() {
+			err := runCommandPassThrough([]string{}, "kubectl", "apply", "-f", "../../utils/data/infrastructure.cluster.x-k8s.io_awsclusterroleidentities.yaml")
+			Expect(err).To(BeNil(), "Failed to install AWSClusterRoleIdentity CRD")
+			err = runCommandPassThrough([]string{}, "kubectl", "wait", "--for=condition=established", "--timeout=90s", "crd/awsclusterroleidentities.infrastructure.cluster.x-k8s.io")
+			Expect(err).To(BeNil(), "Failed to verify AWSClusterRoleIdentity CRD")
+		})
+
+		By("Create AWS Secret, AWSClusterStaticIdentity and AWSClusterRoleIdentity)", func() {
+			err := runCommandPassThrough([]string{}, "kubectl", "apply", "-f", "../../utils/data/aws_cluster_credentials.yaml")
+			Expect(err).To(BeNil(), "Failed to create AWS credentials")
+		})
+
+	} else if infrastructureProvider == "AZURE" {
+		By("Install AzureClusterIdentity CRD", func() {
+			err := runCommandPassThrough([]string{}, "kubectl", "apply", "-f", "../../utils/data/infrastructure.cluster.x-k8s.io_azureclusteridentities.yaml")
+			Expect(err).To(BeNil(), "Failed to install AzureClusterIdentity CRD")
+			err = runCommandPassThrough([]string{}, "kubectl", "wait", "--for=condition=established", "--timeout=90s", "crd/azureclusteridentities.infrastructure.cluster.x-k8s.io")
+			Expect(err).To(BeNil(), "Failed to verify AzureClusterIdentity CRD")
+		})
+
+		By("Create Azure Secret and AzureClusterIdentity)", func() {
+			err := runCommandPassThrough([]string{}, "kubectl", "apply", "-f", "../../utils/data/azure_cluster_credentials.yaml")
+			Expect(err).To(BeNil(), "Failed to create Azure credentials")
+		})
+	}
+
+}
+
+func (b RealGitopsTestRunner) DeleteIPCredentials(infrastructureProvider string) {
+	if infrastructureProvider == "AWS" {
+		_ = runCommandPassThrough([]string{}, "kubectl", "delete", "-f", "../../utils/data/aws_cluster_credentials.yaml")
+		_ = runCommandPassThrough([]string{}, "kubectl", "delete", "-f", "../../utils/data/infrastructure.cluster.x-k8s.io_awsclusterroleidentities.yaml")
+		_ = runCommandPassThrough([]string{}, "kubectl", "delete", "-f", "../../utils/data/infrastructure.cluster.x-k8s.io_awsclusterstaticidentities.yaml")
+
+	} else if infrastructureProvider == "AZURE" {
+		_ = runCommandPassThrough([]string{}, "kubectl", "delete", "-f", "../../utils/data/azure_cluster_credentials.yaml")
+		_ = runCommandPassThrough([]string{}, "kubectl", "delete", "-f", "../../utils/data/infrastructure.cluster.x-k8s.io_azureclusteridentities.yaml")
+	}
+}
+
+// This function generates multiple capitemplate files from a single capitemplate to be used as test data
+func generateTestCapiTemplates(templateCount int, templateFile string) (templateFiles []string, err error) {
+	// Read input capitemplate
+	contents, err := ioutil.ReadFile(fmt.Sprintf("../../utils/data/%s", templateFile))
+
+	if err != nil {
+		return templateFiles, err
+	}
+
+	// Prepare  data to insert into the template.
+	type TemplateInput struct {
+		Count int
+	}
+
+	// Create a new template and parse the letter into it.
+	t := template.Must(template.New("capi-template").Parse(string(contents)))
+
+	// Execute the template for each count.
+	for i := 0; i < templateCount; i++ {
+		input := TemplateInput{i}
+
+		fileName := fmt.Sprintf("%s%d", templateFile, i)
+
+		f, err := os.Create(path.Join("/tmp", fileName))
+		if err != nil {
+			return templateFiles, err
+		}
+		templateFiles = append(templateFiles, f.Name())
+
+		err = t.Execute(f, input)
+		if err != nil {
+			log.Println("executing template:", err)
+		}
+
+		f.Close()
+	}
+
+	return templateFiles, nil
+}

--- a/test/utils/data/upgrade-kind-config.yaml
+++ b/test/utils/data/upgrade-kind-config.yaml
@@ -1,4 +1,3 @@
-# kind-config.yaml
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
@@ -6,13 +5,8 @@ nodes:
   extraMounts:
     - hostPath: /var/run/docker.sock
       containerPath: /var/run/docker.sock
-- role: worker
   extraPortMappings:
   - containerPort: 30081
     hostPort: 30081
-    listenAddress: "0.0.0.0" # Optional, defaults to "0.0.0.0"
-    protocol: tcp # Optional, defaults to tcp
   - containerPort: 31491
     hostPort: 31491
-    listenAddress: "0.0.0.0" # Optional, defaults to "0.0.0.0"
-    protocol: tcp # Optional, defaults to tcp


### PR DESCRIPTION
- Added go-git-provider support for acceptance tests
- Split the utils.go big monolithic file into smaller manageable util files (utils.go, utils_runner.go, utils_gitops.go and utils_git.go)
- Refined capi cluster resources health check
- Improved some log messages for clarity
- Added CHECKPOINT_DISABLE env on all test jobs (To avoid interfering with the statistics that keep track of the number of downloads customers are making for Weave-GitOps)

closes #412 