### PR TITLE
Workaround for incorrect upstream cert-manager.yaml download path

### DIFF
--- a/.github/workflows/acceptance-test.yaml
+++ b/.github/workflows/acceptance-test.yaml
@@ -246,12 +246,19 @@ jobs:
          elif [ "$RUNNER_OS" == "macOS" ]; then
             brew install kind
         fi
+        kind version
     - name: Install clusterctl
       run: |
-        curl -L https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.0.0/clusterctl-${{ inputs.os-name }}-amd64 -o clusterctl
+        curl -L https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.0.3/clusterctl-${{ inputs.os-name }}-amd64 -o clusterctl
         chmod +x ./clusterctl
         sudo mv ./clusterctl /usr/local/bin/clusterctl
-        clusterctl version         
+        clusterctl version
+
+        # Workarond to override dowloading the cert-manager.yaml because upstream cert-manager repository path is not valid
+        cat > $HOME/.cluster-api/clusterctl.yaml <<- EOM
+        cert-manager:
+          url: "https://github.com/cert-manager/cert-manager/releases/latest/cert-manager.yaml"
+        EOM
     - name: Set up ssh
       uses: ./.github/actions/setup-ssh
       with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -221,7 +221,7 @@ jobs:
 
   smoke-tests:
     needs: [build]
-    uses: weaveworks/weave-gitops-enterprise/.github/workflows/acceptance-test.yaml@main
+    uses: weaveworks/weave-gitops-enterprise/.github/workflows/acceptance-test.yaml@cert-manager-version
     with:
       runs-on: ubuntu-latest
       os-name: linux
@@ -247,7 +247,7 @@ jobs:
 
   smoke-tests-gitlab:
     needs: [build]
-    uses: weaveworks/weave-gitops-enterprise/.github/workflows/acceptance-test.yaml@main
+    uses: weaveworks/weave-gitops-enterprise/.github/workflows/acceptance-test.yaml@cert-manager-version
     with:
       runs-on: ubuntu-latest
       os-name: linux
@@ -275,7 +275,7 @@ jobs:
 
   smoke-tests-gitlab-on-prem:
     needs: [build]
-    uses: weaveworks/weave-gitops-enterprise/.github/workflows/acceptance-test.yaml@main
+    uses: weaveworks/weave-gitops-enterprise/.github/workflows/acceptance-test.yaml@cert-manager-version
     with:
       runs-on: ubuntu-latest
       os-name: linux
@@ -303,7 +303,7 @@ jobs:
 
   acceptance-tests-github:
     needs: [build, lint, unit-tests, integration-tests, ui-integration-tests]
-    uses: weaveworks/weave-gitops-enterprise/.github/workflows/acceptance-test.yaml@main
+    uses: weaveworks/weave-gitops-enterprise/.github/workflows/acceptance-test.yaml@cert-manager-version
     with:
       runs-on: ubuntu-latest
       os-name: linux


### PR DESCRIPTION
- Put a workaround for downloading cert-manager.yaml file due to incorrect upstream cert-manager.yaml download path.