### PR TITLE
Add terraform definitions for our dev infra

### DIFF
--- a/cmd/clusters-service/app/server.go
+++ b/cmd/clusters-service/app/server.go
@@ -438,7 +438,7 @@ func RunInProcessGateway(ctx context.Context, addr string, setters ...Option) er
 		// Secure `/v1` and `/gitops/api` API routes
 		grpcHttpHandler = auth.WithAPIAuth(grpcHttpHandler, srv)
 		gitopsBrokerHandler = auth.WithAPIAuth(gitopsBrokerHandler, srv)
-		staticAssets = auth.WithAPIAuth(staticAssets, srv)
+		staticAssets = auth.WithWebAuth(staticAssets, srv)
 	}
 
 	commonMiddleware := func(mux http.Handler) http.Handler {

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,26 @@
+### Services
+
+#### Production
+- https://gitlab.git.dev.weave.works running on cluster `gitlab-01` on GKE, backed by [repo](https://github.com/wkp-example-org/gitlab-01)
+
+
+
+### How to run Terraform locally
+
+1. Authenticate with GCP using `gcloud`.
+
+```sh
+gcloud auth application-default login
+```
+
+2. Switch to the working directory of your choice and run Terraform.
+```sh
+cd ./environments/dev
+terraform init 
+terraform plan
+```
+
+3. View output variables (optional).
+```sh
+terraform output
+```

--- a/terraform/environments/dev/.terraform.lock.hcl
+++ b/terraform/environments/dev/.terraform.lock.hcl
@@ -1,0 +1,40 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "4.0.0"
+  constraints = "~> 4.0.0"
+  hashes = [
+    "h1:wHydn6CP2wkxUfcq4nRw2NdCc4+rERltXaNZ97U0zAo=",
+    "zh:02937cb37860b022e7d996726e7584ca23904baf7852d266f2dd7891ee088ae4",
+    "zh:259dd5790ec5f4e6814c9584c79834dce3d719e932ce662b21f13434e9441194",
+    "zh:2d230c8c92c3cb2c07471a4324d802c44365dcf99fe0d562cc737d1f964e9c1d",
+    "zh:380b04e78934519469e699c537516ae1674d15f77c6778c2738cd69374b661aa",
+    "zh:3d7121da1fa92166c9ea26f3c9839cef06833420d6c46978b4cbbfd0b5050791",
+    "zh:6b7f5a3b28ec3a631d689f599a39bfe98ca5b785353b01e374cff655b097a791",
+    "zh:7882291716d2d03df5ece721429770452db76c712fcff08964c3a7c0b639f703",
+    "zh:95250c5768610d69a28501f03176b6a05a5d5ac2ae317cb582d94b044b3272b3",
+    "zh:b16a622a76bee455c8b256d828f8a60515e1e9dad38420a4db1be9b9e16d474a",
+    "zh:c805822f0ba57e8063b6201e1f351aa4dbd5ad8886dedd25d809e5aeb9aa0259",
+    "zh:e1c3a0da5576aec4a48f897cd04b739c1f533cdb0005ce4c7f5bc45808b799b1",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "4.10.0"
+  constraints = "~> 4.10.0"
+  hashes = [
+    "h1:Hl5IzrNzeWfEy6AjNej2PlMTa3p+5T75tc9FV4FqCU0=",
+    "zh:007f591c02afb6228b81ff4d6325170664b45df56b4af74587f3230d6675f21c",
+    "zh:017943b592f959998855d2c664778da03f9319c3c117dabbe61c644bf7cfb64e",
+    "zh:0690b05c112e12bb5d2e69d0515ef6c0b330469e99fcb79a34790f105d988c2c",
+    "zh:07029ea70670b66ffe85ea9164e7ded98ca78a89deda9aab98f4bd0b810716cf",
+    "zh:0b2716d9e3fd0fb7c32f1c12636a20d0efff81fa6968e027e2b0e76f14ace71f",
+    "zh:448bfc0646072bab70e932bdb91cc7c99379f771c8c668ee04895e1edc195972",
+    "zh:877efd64688693a49df8591ec2487598faccbbe048787869b86c984a0943dbfb",
+    "zh:99f092f81a22a6e23c42f0d0f448ae56391c252edde4d8162d759e4dd130eb93",
+    "zh:c21f7e31b799b95819561e7c345a25e6f240ccc80c29de073724d0e9457ff293",
+    "zh:e380365592434f2c084b05420b7c234f81a3500ded432c7499742558b2f7f9d1",
+    "zh:f53b6c71b62de7912283f63064086ed7ee8bdef6142007cc0719aa1f6211b5ea",
+  ]
+}

--- a/terraform/environments/dev/demo-02.tf
+++ b/terraform/environments/dev/demo-02.tf
@@ -1,0 +1,27 @@
+module "demo_02" {
+  source = "../../modules/gke-cluster"
+
+  cluster_name = "demo-02"
+  region = "europe-north1"
+  location = "europe-north1-a"
+  machine_type = "n1-standard-2"
+}
+
+output "demo_02_endpoint" {
+  value = module.demo_02.endpoint
+}
+ 
+output "demo_02_client_certificate" {
+  value = module.demo_02.client_certificate
+  sensitive = true
+}
+
+output "demo_02_client_key" {
+  value = module.demo_02.client_key
+  sensitive = true
+}
+
+output "demo_02_cluster_ca_certificate" {
+  value = module.demo_02.cluster_ca_certificate
+  sensitive = true
+}

--- a/terraform/environments/dev/dex-01.tf
+++ b/terraform/environments/dev/dex-01.tf
@@ -1,0 +1,27 @@
+module "dex_01" {
+  source = "../../modules/gke-cluster"
+
+  cluster_name = "dex-01"
+  region = "europe-north1"
+  location = "europe-north1-a"
+  machine_type = "n1-standard-2"
+}
+
+output "dex_01_endpoint" {
+  value = module.dex_01.endpoint
+}
+ 
+output "dex_01_client_certificate" {
+  value = module.dex_01.client_certificate
+  sensitive = true
+}
+
+output "dex_01_client_key" {
+  value = module.dex_01.client_key
+  sensitive = true
+}
+
+output "dex_01_cluster_ca_certificate" {
+  value = module.dex_01.cluster_ca_certificate
+  sensitive = true
+}

--- a/terraform/environments/dev/dns.tf
+++ b/terraform/environments/dev/dns.tf
@@ -1,0 +1,22 @@
+# Zone delegation has been setup manually 
+# in the Weave Cloud dev account
+locals {
+  zone_id =  "Z038735537FBV7QQ5O394"
+  zone_name ="wge.dev.weave.works"
+}
+
+resource "aws_route53_record" "demo_02_ingress" {
+  zone_id = local.zone_id
+  name    = "demo-02"
+  type    = "A"
+  ttl     = "300"
+  records = ["35.228.235.99"]
+}
+
+resource "aws_route53_record" "dex_01_ingress" {
+  zone_id = local.zone_id
+  name    = "dex-01"
+  type    = "A"
+  ttl     = "300"
+  records = ["35.228.83.196"]
+}

--- a/terraform/environments/dev/terraform.tfvars
+++ b/terraform/environments/dev/terraform.tfvars
@@ -1,0 +1,2 @@
+project = "wks-tests"
+region  = "europe-west1"

--- a/terraform/environments/dev/versions.tf
+++ b/terraform/environments/dev/versions.tf
@@ -1,0 +1,32 @@
+terraform {
+  backend "gcs" {
+    bucket  = "weave-gitops-enterprise-terraform-state"
+    prefix  = "dev"
+  }
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 4.10.0"
+    }
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0.0"
+    }
+  }
+
+  required_version = ">= 1.1.5"
+}
+
+variable "project" {
+  description = "GCP project id"
+}
+
+variable "region" {
+  description = "GCP project region"
+}
+
+provider "google" {
+  project = var.project
+  region = var.region
+}

--- a/terraform/environments/prod/.terraform.lock.hcl
+++ b/terraform/environments/prod/.terraform.lock.hcl
@@ -1,0 +1,21 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "4.10.0"
+  constraints = "~> 4.10.0"
+  hashes = [
+    "h1:Hl5IzrNzeWfEy6AjNej2PlMTa3p+5T75tc9FV4FqCU0=",
+    "zh:007f591c02afb6228b81ff4d6325170664b45df56b4af74587f3230d6675f21c",
+    "zh:017943b592f959998855d2c664778da03f9319c3c117dabbe61c644bf7cfb64e",
+    "zh:0690b05c112e12bb5d2e69d0515ef6c0b330469e99fcb79a34790f105d988c2c",
+    "zh:07029ea70670b66ffe85ea9164e7ded98ca78a89deda9aab98f4bd0b810716cf",
+    "zh:0b2716d9e3fd0fb7c32f1c12636a20d0efff81fa6968e027e2b0e76f14ace71f",
+    "zh:448bfc0646072bab70e932bdb91cc7c99379f771c8c668ee04895e1edc195972",
+    "zh:877efd64688693a49df8591ec2487598faccbbe048787869b86c984a0943dbfb",
+    "zh:99f092f81a22a6e23c42f0d0f448ae56391c252edde4d8162d759e4dd130eb93",
+    "zh:c21f7e31b799b95819561e7c345a25e6f240ccc80c29de073724d0e9457ff293",
+    "zh:e380365592434f2c084b05420b7c234f81a3500ded432c7499742558b2f7f9d1",
+    "zh:f53b6c71b62de7912283f63064086ed7ee8bdef6142007cc0719aa1f6211b5ea",
+  ]
+}

--- a/terraform/environments/prod/gitlab-01.tf
+++ b/terraform/environments/prod/gitlab-01.tf
@@ -1,0 +1,27 @@
+module "gitlab_01" {
+  source = "../../modules/gke-cluster"
+
+  cluster_name = "gitlab-01"
+  region = var.region
+  location = "europe-west1-b"
+  machine_type = "n2-standard-4"
+}
+
+output "gitlab_01_endpoint" {
+  value = module.gitlab_01.endpoint
+}
+ 
+output "gitlab_01_client_certificate" {
+  value = module.gitlab_01.client_certificate
+  sensitive = true
+}
+
+output "gitlab_01_client_key" {
+  value = module.gitlab_01.client_key
+  sensitive = true
+}
+
+output "gitlab_01_cluster_ca_certificate" {
+  value = module.gitlab_01.cluster_ca_certificate
+  sensitive = true
+}

--- a/terraform/environments/prod/terraform.tfvars
+++ b/terraform/environments/prod/terraform.tfvars
@@ -1,0 +1,2 @@
+project = "wks-tests"
+region  = "europe-west1"

--- a/terraform/environments/prod/versions.tf
+++ b/terraform/environments/prod/versions.tf
@@ -1,0 +1,28 @@
+terraform {
+  backend "gcs" {
+    bucket  = "weave-gitops-enterprise-terraform-state"
+    prefix  = "prod"
+  }
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 4.10.0"
+    }
+  }
+
+  required_version = ">= 1.1.5"
+}
+
+variable "project" {
+  description = "GCP project id"
+}
+
+variable "region" {
+  description = "GCP project region"
+}
+
+provider "google" {
+  project = var.project
+  region = var.region
+}

--- a/terraform/modules/gke-cluster/main.tf
+++ b/terraform/modules/gke-cluster/main.tf
@@ -1,0 +1,58 @@
+resource "google_container_cluster" "cluster" {
+  name     = var.cluster_name
+  location = var.location
+  
+  # We can't create a cluster with no node pool defined, but we want to only use
+  # separately managed node pools. So we create the smallest possible default
+  # node pool and immediately delete it.
+  remove_default_node_pool = true
+  initial_node_count       = 1
+
+  master_auth {
+    client_certificate_config {
+      issue_client_certificate = true
+    }
+  }
+
+  network    = google_compute_network.vpc.name
+  subnetwork = google_compute_subnetwork.subnet.name
+}
+
+resource "google_container_node_pool" "cluster_nodes" {
+  name       = "${google_container_cluster.cluster.name}-node-pool"
+  location   = var.location
+  cluster    = google_container_cluster.cluster.name
+  node_count = var.node_count
+
+  node_config {
+    oauth_scopes = [
+      "https://www.googleapis.com/auth/logging.write",
+      "https://www.googleapis.com/auth/monitoring",
+    ]
+
+    # labels = {
+    #   env = var.project_id
+    # }
+
+    # preemptible  = true
+    machine_type = var.machine_type
+    tags         = ["gke-node", "${var.cluster_name}-gke"]
+    metadata = {
+      disable-legacy-endpoints = "true"
+    }
+  }
+}
+
+# VPC
+resource "google_compute_network" "vpc" {
+  name                    = "${var.cluster_name}-vpc"
+  auto_create_subnetworks = "false"
+}
+
+# Subnet
+resource "google_compute_subnetwork" "subnet" {
+  name          = "${var.cluster_name}-subnet"
+  region        = var.region
+  network       = google_compute_network.vpc.name
+  ip_cidr_range = "10.10.0.0/24"
+}

--- a/terraform/modules/gke-cluster/outputs.tf
+++ b/terraform/modules/gke-cluster/outputs.tf
@@ -1,0 +1,24 @@
+output "master_version" {
+  description = "The Kubernetes master version."
+  value       = google_container_cluster.cluster.master_version
+}
+
+output "endpoint" {
+  description = "The IP address of the cluster master."
+  value       = google_container_cluster.cluster.endpoint
+}
+
+output "client_certificate" {
+  description = "Public certificate used by clients to authenticate to the cluster endpoint."
+  value       = base64decode(google_container_cluster.cluster.master_auth.0.client_certificate)
+}
+
+output "client_key" {
+  description = "Private key used by clients to authenticate to the cluster endpoint."
+  value       = base64decode(google_container_cluster.cluster.master_auth.0.client_key)
+}
+
+output "cluster_ca_certificate" {
+  description = "The public certificate that is the root of trust for the cluster."
+  value       = base64decode(google_container_cluster.cluster.master_auth.0.cluster_ca_certificate)
+}

--- a/terraform/modules/gke-cluster/variables.tf
+++ b/terraform/modules/gke-cluster/variables.tf
@@ -1,0 +1,23 @@
+variable "region" {
+  default     = "europe-west1"
+  description = "GCP region"
+}
+
+variable "location" {
+  default     = "europe-west1-b"
+  description = "GCP location"
+}
+
+variable "cluster_name" {
+    description = "The name of the cluster"
+}
+
+variable "node_count" {
+  default     = 1
+  description = "The number of the GKE nodes per region"
+}
+
+variable "machine_type" {
+  default = "n1-standard-1"
+  description = "GCP machine type"
+}

--- a/terraform/setup/.terraform.lock.hcl
+++ b/terraform/setup/.terraform.lock.hcl
@@ -1,0 +1,20 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version = "4.10.0"
+  hashes = [
+    "h1:Hl5IzrNzeWfEy6AjNej2PlMTa3p+5T75tc9FV4FqCU0=",
+    "zh:007f591c02afb6228b81ff4d6325170664b45df56b4af74587f3230d6675f21c",
+    "zh:017943b592f959998855d2c664778da03f9319c3c117dabbe61c644bf7cfb64e",
+    "zh:0690b05c112e12bb5d2e69d0515ef6c0b330469e99fcb79a34790f105d988c2c",
+    "zh:07029ea70670b66ffe85ea9164e7ded98ca78a89deda9aab98f4bd0b810716cf",
+    "zh:0b2716d9e3fd0fb7c32f1c12636a20d0efff81fa6968e027e2b0e76f14ace71f",
+    "zh:448bfc0646072bab70e932bdb91cc7c99379f771c8c668ee04895e1edc195972",
+    "zh:877efd64688693a49df8591ec2487598faccbbe048787869b86c984a0943dbfb",
+    "zh:99f092f81a22a6e23c42f0d0f448ae56391c252edde4d8162d759e4dd130eb93",
+    "zh:c21f7e31b799b95819561e7c345a25e6f240ccc80c29de073724d0e9457ff293",
+    "zh:e380365592434f2c084b05420b7c234f81a3500ded432c7499742558b2f7f9d1",
+    "zh:f53b6c71b62de7912283f63064086ed7ee8bdef6142007cc0719aa1f6211b5ea",
+  ]
+}

--- a/terraform/setup/main.tf
+++ b/terraform/setup/main.tf
@@ -1,0 +1,17 @@
+variable "project" {
+  description = "GCP project id"
+}
+
+variable "location" {
+  description = "GCP project location"
+}
+
+provider "google" {
+  project = var.project
+}
+
+resource "google_storage_bucket" "terraform_state" {
+  name     = "weave-gitops-enterprise-terraform-state"
+  location = var.location
+}
+

--- a/terraform/setup/terraform.tfvars
+++ b/terraform/setup/terraform.tfvars
@@ -1,0 +1,2 @@
+project = "wks-tests"
+location = "EUROPE-WEST1"


### PR DESCRIPTION
- Created a bucket (currently unencrypted) to store state
- Added a simple `gke-cluster` module to allow us to easily provision new clusters.
- Added definitions for `gitlab-01`, `dex-01` and `demo-02` clusters under a new domain.