### PR TITLE
Provide cache-dir for helm charts.

### DIFF
--- a/cmd/clusters-service/pkg/server/common_test.go
+++ b/cmd/clusters-service/pkg/server/common_test.go
@@ -44,20 +44,23 @@ func createClient(t *testing.T, clusterState ...runtime.Object) client.Client {
 }
 
 func createServer(t *testing.T, clusterState []runtime.Object, configMapName, namespace string, provider git.Provider, db *gorm.DB, ns string, hr *sourcev1beta1.HelmRepository) capiv1_protos.ClustersServiceServer {
-
 	c := createClient(t, clusterState...)
-
 	dc := discovery.NewDiscoveryClient(fakeclientset.NewSimpleClientset().Discovery().RESTClient())
 
-	s := NewClusterServer(logr.Discard(),
+	return NewClusterServer(
+		logr.Discard(),
 		&templates.ConfigMapLibrary{
 			Log:           logr.Discard(),
 			Client:        c,
 			ConfigMapName: configMapName,
 			Namespace:     namespace,
-		}, provider, kubefakes.NewFakeClientGetter(c), dc, db, ns, "weaveworks-charts", "")
-
-	return s
+		},
+		provider,
+		kubefakes.NewFakeClientGetter(c),
+		dc,
+		db,
+		ns,
+		"weaveworks-charts", t.TempDir())
 }
 
 func makeTestHelmRepository(base string, opts ...func(*sourcev1beta1.HelmRepository)) *sourcev1beta1.HelmRepository {


### PR DESCRIPTION
This prevents us writing out weaveworks-charts-default-charts.txt and
weaveworks-charts-default-index.yaml to the "current directory".

These were being written to `cmd/clusters-service/pkg/server` and they should not be.

```
-rw-r--r--   1 kevin  staff     13 11 Feb 09:14 weaveworks-charts-default-charts.txt
-rw-r--r--   1 kevin  staff    463 11 Feb 09:14 weaveworks-charts-default-index.yaml
```