### PR TITLE
Add flag to skip GitLab tests if needed

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -119,6 +119,7 @@ jobs:
       GITHUB_ORG: ${{ secrets.WGE_GITHUB_ORG }}
       GITHUB_USER: ${{ secrets.WGE_GITHUB_USER }}
       GITLAB_TOKEN: ${{ secrets.WGE_GITLAB_TOKEN }}
+      SKIP_GITLAB_TESTS: 1
     steps:
       - id: cache-paths
         run: |

--- a/cmd/clusters-service/pkg/git/git_test.go
+++ b/cmd/clusters-service/pkg/git/git_test.go
@@ -178,6 +178,10 @@ func TestCreatePullRequestInGitHubUser(t *testing.T) {
 }
 
 func TestCreatePullRequestInGitLab(t *testing.T) {
+	if os.Getenv("SKIP_GITLAB_TESTS") != "" {
+		t.Skip("Skipping GitLab test")
+	}
+
 	// Create a client
 	client, err := gitlab.NewClient(os.Getenv("GITLAB_TOKEN"))
 	require.NoError(t, err)


### PR DESCRIPTION
We should remove `SKIP_GITLAB_TESTS` once we sort out #514 