### PR TITLE
Moved gitlab sas acceptance tests to nightly

### DIFF
--- a/.github/workflows/acceptance-test.yaml
+++ b/.github/workflows/acceptance-test.yaml
@@ -249,16 +249,11 @@ jobs:
           kind version
       - name: Install clusterctl
         run: |
-          curl -L https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.0.3/clusterctl-${{ inputs.os-name }}-amd64 -o clusterctl
+          curl -L https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.1.3/clusterctl-${{ inputs.os-name }}-amd64 -o clusterctl
           chmod +x ./clusterctl
           sudo mv ./clusterctl /usr/local/bin/clusterctl
           clusterctl version
-
-          # Workarond to override dowloading the cert-manager.yaml because upstream cert-manager repository path is not valid
-          cat > $HOME/.cluster-api/clusterctl.yaml <<- EOM
-          cert-manager:
-            url: "https://github.com/cert-manager/cert-manager/releases/latest/cert-manager.yaml"
-          EOM
+          
       - name: Set up ssh
         uses: ./.github/actions/setup-ssh
         with:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -61,16 +61,6 @@ jobs:
         gocovmerge .coverprofile cmd/event-writer/.coverprofile common/.coverprofile  cmd/clusters-service/.coverprofile > ${{ env.ARTEFACTS_BASE_DIR }}/merged-profiles    
         # Merge all junit test results
         jrm ${{ env.ARTEFACTS_BASE_DIR }}/combined-test-results.xml '${{ env.ARTEFACTS_BASE_DIR }}/*.xml'
-    # - name: Send coverage
-    #   run: |
-    #     # submit the coverage 1 by 1, seems important that they have a -flagname
-    #     goveralls -parallel -coverprofile=.coverprofile -service="GitHub Action" -flagname wks -repotoken $WGE_COVERALLS_TOKEN
-    #     (cd cmd/event-writer; goveralls -coverprofile=.coverprofile -flagname event-writer -parallel -service="GitHub Action" -repotoken $WGE_COVERALLS_TOKEN)
-    #     (cd common; goveralls -coverprofile=.coverprofile -flagname common -parallel -service="GitHub Action" -repotoken $WGE_COVERALLS_TOKEN)
-    #     (cd cmd/capi-serve; goveralls -coverprofile=.coverprofile -flagname capi-server -parallel -service="GitHub Action" -repotoken $WGE_COVERALLS_TOKEN)
-
-    #     # We've finished submitting the coverage
-    #     curl -k "https://coveralls.io/webhook?repo_token=$WGE_COVERALLS_TOKEN" -d "payload[build_num]=$GITHUB_RUN_NUMBER&payload[status]=done"
     - name: Store unit test coverage results
       uses: actions/upload-artifact@v2
       with:
@@ -85,34 +75,6 @@ jobs:
       runs-on: ubuntu-latest
       ref: 931b52e59deec59e61e0f2ed34690571b23079a3
   
-  acceptance-tests-gitlab:
-    needs: [build, coverage, gitops-binary]
-    uses: ./.github/workflows/acceptance-test.yaml
-    with:
-      runs-on: ubuntu-latest
-      os-name: linux
-      timeout-minutes: 90
-      focus-or-skip: "-ginkgo.skip='@gce|@eks'"
-      kubectl-version: "v1.22.0"
-      git-provider: gitlab
-      git-provider_hostname: gitlab.com
-      cluster_resource_set: true
-      management-cluster-kind: kind
-      gitops-bin-path: /usr/local/bin/gitops
-      database-type: sqlite
-      artifacts-base-dir: "/tmp/acceptance-test-gitlab"
-    secrets:
-      BUILD_BOT_USER: wge-build-bot
-      BUILD_BOT_PERSONAL_ACCESS_TOKEN: ${{ secrets.BUILD_BOT_PERSONAL_ACCESS_TOKEN }}
-      WGE_GITHUB_TOKEN: ${{ secrets.WGE_GITHUB_TOKEN }}
-      WGE_GIT_PROVIDER_PRIVATE_KEY: ${{ secrets.WGE_SAS_GITLAB_PRIVATE_KEY }}
-      WGE_GITLAB_TOKEN: ${{ secrets.WGE_SAS_GITLAB_TOKEN }}
-      WGE_GITLAB_ORG: ${{ secrets.WGE_SAS_GITLAB_ORG }}
-      WGE_GITLAB_USER: ${{ secrets.WGE_SAS_GITLAB_USER }}
-      WGE_GITLAB_PASSWORD: ${{ secrets.WGE_SAS_GITLAB_PASSWORD }}
-      WGE_GITLAB_CLIENT_ID: ${{ secrets.WGE_SAS_GITLAB_CLIENT_ID }}
-      WGE_GITLAB_CLIENT_SECRET: ${{ secrets.WGE_SAS_GITLAB_CLIENT_SECRET }}
-
   acceptance-tests-gitlab-on-prem:
     needs: [build, coverage, gitops-binary]
     uses: ./.github/workflows/acceptance-test.yaml
@@ -120,7 +82,7 @@ jobs:
       runs-on: ubuntu-latest
       os-name: linux
       timeout-minutes: 90
-      focus-or-skip: "-ginkgo.focus='@git'"
+      focus-or-skip: "-ginkgo.skip='@gce|@eks'"
       kubectl-version: "v1.22.0"
       git-provider: gitlab
       git-provider_hostname: gitlab.git.dev.weave.works

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -1,6 +1,6 @@
 on:
   schedule:
-    - cron: "10 0 * * *"
+    - cron: "10 0 * * 1-5"
   workflow_dispatch:
 
 name: nightly
@@ -45,7 +45,7 @@ jobs:
       BUILD_BOT_PERSONAL_ACCESS_TOKEN: ${{ secrets.BUILD_BOT_PERSONAL_ACCESS_TOKEN }}
       WGE_GIT_PROVIDER_PRIVATE_KEY: ${{ secrets.WGE_GITHUB_PRIVATE_KEY }}
       WGE_GITHUB_TOKEN: ${{ secrets.WGE_GITHUB_TOKEN }}
-      WGE_GITHUB_ORG: ${{ secrets.WGE_GITHUB_ORG }}
+      WGE_GITHUB_ORG: wge-org-test
       WGE_GITHUB_USER: ${{ secrets.WGE_GITHUB_USER }}
       WGE_GITHUB_PASSWORD: ${{ secrets.WGE_GITHUB_PASSWORD }}
       WGE_GITHUB_MFA_KEY: ${{ secrets.WGE_GITHUB_MFA_KEY }}
@@ -59,7 +59,7 @@ jobs:
       runs-on: macOS-latest
       ref: 931b52e59deec59e61e0f2ed34690571b23079a3
 
-  acceptance-tests-gke-gitlab-on-prem:
+  acceptance-tests-gke-gitlab:
     needs: [build, gitops-binary-macOs]
     uses: ./.github/workflows/acceptance-test.yaml
     with:
@@ -69,24 +69,24 @@ jobs:
       focus-or-skip: "-ginkgo.skip='@gce|@eks|@capd|@upgrade'"
       kubectl-version: "v1.22.0"
       git-provider: gitlab
-      git-provider_hostname: gitlab.git.dev.weave.works
+      git-provider_hostname: gitlab.com
       cluster_resource_set: false
       management-cluster-kind: gke
       gitops-bin-path: /usr/local/bin/gitops
       database-type: postgres
       gce-leaf-kubeconfig: "/tmp/gce-leaf-kubeconfig"
-      artifacts-base-dir: "/tmp/acceptance-test-gke-gitlab-on-prem"
+      artifacts-base-dir: "/tmp/acceptance-test-gke-gitlab"
     secrets:
       BUILD_BOT_USER: wge-build-bot
       BUILD_BOT_PERSONAL_ACCESS_TOKEN: ${{ secrets.BUILD_BOT_PERSONAL_ACCESS_TOKEN }}
-      WGE_GIT_PROVIDER_PRIVATE_KEY: ${{ secrets.WGE_ON_PREM_GITLAB_PRIVATE_KEY }}
+      WGE_GIT_PROVIDER_PRIVATE_KEY: ${{ secrets.WGE_SAS_GITLAB_PRIVATE_KEY }}
       WGE_GITHUB_TOKEN: ${{ secrets.WGE_GITHUB_TOKEN }}
-      WGE_GITLAB_TOKEN: ${{ secrets.WGE_ON_PREM_GITLAB_TOKEN }}
-      WGE_GITLAB_ORG: ${{ secrets.WGE_ON_PREM_GITLAB_ORG }}
-      WGE_GITLAB_USER: ${{ secrets.WGE_ON_PREM_GITLAB_USER }}
-      WGE_GITLAB_PASSWORD: ${{ secrets.WGE_ON_PREM_GITLAB_PASSWORD }}
-      WGE_GITLAB_CLIENT_ID: ${{ secrets.WGE_ON_PREM_GITLAB_CLIENT_ID }}
-      WGE_GITLAB_CLIENT_SECRET: ${{ secrets.WGE_ON_PREM_GITLAB_CLIENT_SECRET }}
+      WGE_GITLAB_TOKEN: ${{ secrets.WGE_SAS_GITLAB_TOKEN }}
+      WGE_GITLAB_ORG: ${{ secrets.WGE_SAS_GITLAB_ORG }}
+      WGE_GITLAB_USER: ${{ secrets.WGE_SAS_GITLAB_USER }}
+      WGE_GITLAB_PASSWORD: ${{ secrets.WGE_SAS_GITLAB_PASSWORD }}
+      WGE_GITLAB_CLIENT_ID: ${{ secrets.WGE_SAS_GITLAB_CLIENT_ID }}
+      WGE_GITLAB_CLIENT_SECRET: ${{ secrets.WGE_SAS_GITLAB_CLIENT_SECRET }}
       GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
       GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
       WGE_ACCEPTANCE_GCE_KUBECONFIG: ${{ secrets.WGE_ACCEPTANCE_GCE_KUBECONFIG }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -87,16 +87,6 @@ jobs:
         run: |
           go version
           make unit-tests-with-coverage
-    # - name: Send coverage
-    #   run: |
-    #     # submit the coverage 1 by 1, seems important that they have a -flagname
-    #     goveralls -parallel -coverprofile=.coverprofile -service="GitHub Action" -flagname wks -repotoken $WGE_COVERALLS_TOKEN
-    #     (cd cmd/event-writer; goveralls -coverprofile=.coverprofile -flagname event-writer -parallel -service="GitHub Action" -repotoken $WGE_COVERALLS_TOKEN)
-    #     (cd common; goveralls -coverprofile=.coverprofile -flagname common -parallel -service="GitHub Action" -repotoken $WGE_COVERALLS_TOKEN)
-    #     (cd cmd/capi-serve; goveralls -coverprofile=.coverprofile -flagname capi-server -parallel -service="GitHub Action" -repotoken $WGE_COVERALLS_TOKEN)
-
-    #     # We've finished submitting the coverage
-    #     curl -k "https://coveralls.io/webhook?repo_token=$WGE_COVERALLS_TOKEN" -d "payload[build_num]=$GITHUB_RUN_NUMBER&payload[status]=done"
 
   build:
     uses: ./.github/workflows/build.yaml
@@ -116,7 +106,7 @@ jobs:
       GO_CACHE_NAME: cache-go-modules
       YARN_CACHE_NAME: cache-yarn
       GITHUB_TOKEN: ${{ secrets.WGE_GITHUB_TOKEN }}
-      GITHUB_ORG: ${{ secrets.WGE_GITHUB_ORG }}
+      GITHUB_ORG: wge-org-test
       GITHUB_USER: ${{ secrets.WGE_GITHUB_USER }}
       GITLAB_TOKEN: ${{ secrets.WGE_ON_PREM_GITLAB_TOKEN }}
       GIT_PROVIDER_HOSTNAME: gitlab.git.dev.weave.works
@@ -254,7 +244,7 @@ jobs:
       BUILD_BOT_PERSONAL_ACCESS_TOKEN: ${{ secrets.BUILD_BOT_PERSONAL_ACCESS_TOKEN }}
       WGE_GIT_PROVIDER_PRIVATE_KEY: ${{ secrets.WGE_GITHUB_PRIVATE_KEY }}
       WGE_GITHUB_TOKEN: ${{ secrets.WGE_GITHUB_TOKEN }}
-      WGE_GITHUB_ORG: ${{ secrets.WGE_GITHUB_ORG }}
+      WGE_GITHUB_ORG: wge-org-test
       WGE_GITHUB_USER: ${{ secrets.WGE_GITHUB_USER }}
       WGE_GITHUB_PASSWORD: ${{ secrets.WGE_GITHUB_PASSWORD }}
       WGE_GITHUB_MFA_KEY: ${{ secrets.WGE_GITHUB_MFA_KEY }}
@@ -342,7 +332,7 @@ jobs:
       BUILD_BOT_PERSONAL_ACCESS_TOKEN: ${{ secrets.BUILD_BOT_PERSONAL_ACCESS_TOKEN }}
       WGE_GIT_PROVIDER_PRIVATE_KEY: ${{ secrets.WGE_GITHUB_PRIVATE_KEY }}
       WGE_GITHUB_TOKEN: ${{ secrets.WGE_GITHUB_TOKEN }}
-      WGE_GITHUB_ORG: ${{ secrets.WGE_GITHUB_ORG }}
+      WGE_GITHUB_ORG: wge-org-test
       WGE_GITHUB_USER: ${{ secrets.WGE_GITHUB_USER }}
       WGE_GITHUB_PASSWORD: ${{ secrets.WGE_GITHUB_PASSWORD }}
       WGE_GITHUB_MFA_KEY: ${{ secrets.WGE_GITHUB_MFA_KEY }}


### PR DESCRIPTION
- Move gitlab acceptance test suite run to nightly
- Make nightly to run only on week days (Mon-Fri)
- Update clusterctl version to v1.1.3 (upstream cert manager is fixed in this version)
- Remove dead/commented workflow jobs
- Temporary rename the github bot org name until the original name becomes available