### PR TITLE
Run snyk CLI checks on PRs

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -104,3 +104,29 @@ jobs:
       WGE_GITLAB_PASSWORD: ${{ secrets.WGE_ON_PREM_GITLAB_PASSWORD }}
       WGE_GITLAB_CLIENT_ID: ${{ secrets.WGE_ON_PREM_GITLAB_CLIENT_ID }}
       WGE_GITLAB_CLIENT_SECRET: ${{ secrets.WGE_ON_PREM_GITLAB_CLIENT_SECRET }}
+
+  snyk-monitor:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Configure git for private modules
+        run: git config --global url."https://${GITHUB_BUILD_USERNAME}:${GITHUB_BUILD_TOKEN}@github.com".insteadOf "https://github.com"
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.17.x
+      - name: Setup snyk
+        uses: snyk/actions/setup@master
+      - name: Monitor dependencies & license problems with Snyk
+        # Throw an error if the error is "snyk couldn't run".
+        # Don't throw an error on "there are vulnerabilities", those
+        # are notified separately
+        run: |
+          exit_code=0
+          snyk monitor --all-projects --org=product-engineering-ly9 || exit_code=$?
+          if [ $exit_code -gt 1 ]; then
+            exit $exit_code
+          fi
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_API_TOKEN }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -365,3 +365,30 @@ jobs:
       WGE_GITHUB_USER: ${{ secrets.WGE_GITHUB_USER }}
       WGE_GITHUB_PASSWORD: ${{ secrets.WGE_GITHUB_PASSWORD }}
       WGE_GITHUB_MFA_KEY: ${{ secrets.WGE_GITHUB_MFA_KEY }}
+
+  snyk-checks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Configure git for private modules
+        env:
+          GITHUB_BUILD_USERNAME: wge-build-bot
+          GITHUB_BUILD_TOKEN: ${{ secrets.BUILD_BOT_PERSONAL_ACCESS_TOKEN }}
+        run: git config --global url."https://${GITHUB_BUILD_USERNAME}:${GITHUB_BUILD_TOKEN}@github.com".insteadOf "https://github.com"
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.18.x
+      - name: Setup snyk
+        uses: snyk/actions/setup@master
+      - name: Setup snyk prerequisites
+        run: |
+          npm install --global snyk-delta
+      - name: Look for new insecure dependencies or bad licenses
+        run: |
+          snyk test --org=product-engineering-ly9 --json --file=go.mod | snyk-delta
+          snyk test --org=product-engineering-ly9 --json --file=common/go.mod | snyk-delta
+          snyk test --org=product-engineering-ly9 --json --file=ui-cra/yarn.lock | snyk-delta
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_API_TOKEN }}


### PR DESCRIPTION
 We've previously had the webhooks configured, which runs license &
    dependency checks.
    
This replaces them with explicit CLI commands.
    
Why?
    
First, snyk isn't very good at go in general, and absolutely useless
    when invoked through the webhooks - the webhooks just goes through the
    go.sum file and reports everything in there as insecure, whether you
    use it or not. The CLI uses go.mod instead, which actually works.
    
Second, this uses snyk-delta to alert on _new_ problems, not just "all
problems". This isn't perfect - it is subject to race conditions, when
a new upstream problem is discovered, but the monitor hasn't run since - 
but it means a javascript engineer isn't stuck fixing go dependencies.