### PR TITLE
Adds some default user-roles to the helm-chart

### DIFF
--- a/charts/mccp/templates/rbac/user_roles.yaml
+++ b/charts/mccp/templates/rbac/user_roles.yaml
@@ -1,0 +1,75 @@
+{{- if .Values.rbac.userRoles.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: gitops-apps-reader
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list"]
+  - apiGroups: ["apps"]
+    resources: ["deployments", "replicasets", "pods"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["kustomize.toolkit.fluxcd.io"]
+    resources: ["kustomizations"]
+    verbs: ["get", "list", "patch"]
+  - apiGroups: ["helm.toolkit.fluxcd.io"]
+    resources: ["helmreleases"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["get", "watch", "list"]
+  - apiGroups: ["source.toolkit.fluxcd.io"]
+    resources: ["buckets", "helmcharts", "gitrepositories", "helmrepositories"]
+    verbs: ["get", "list", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: gitops-configmaps-reader
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: gitops-templates-reader
+rules:
+  - apiGroups: ["capi.weave.works"]
+    resources: ["capitemplates"]
+    verbs: ["get", "watch", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: gitops-identities-reader
+rules:
+  - apiGroups: ["infrastructure.cluster.x-k8s.io"]
+    resources:
+      [
+        "awsclusterstaticidentities",
+        "awsclusterroleidentities",
+        "azureclusteridentities",
+      ]
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: gitops-secrets-reader
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: gitops-policies-reader
+rules:
+  - apiGroups: ["pac.weave.works"]
+    resources: ["policies"]
+    verbs: ["get", "list"]
+{{- end }}

--- a/charts/mccp/values.yaml
+++ b/charts/mccp/values.yaml
@@ -77,6 +77,10 @@ tls:
   # if no tls secret is specified then we generate it in-mem in the server
   secretName: ""
 
+rbac:
+  userRoles:
+    create: true
+
 service:
   type: ClusterIP
   ports:

--- a/test/utils/data/rbac-auth.yaml
+++ b/test/utils/data/rbac-auth.yaml
@@ -1,55 +1,3 @@
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: apps-reader
-  namespace: flux-system
-rules:
-  - apiGroups: [""]
-    resources: ["pods" ]
-    verbs: [ "get", "list" ]
-  - apiGroups: ["apps"]
-    resources: [ "deployments", "replicasets", "pods" ]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: ["kustomize.toolkit.fluxcd.io"]
-    resources: ["kustomizations"]
-    verbs: ["get", "list", "patch"]
-  - apiGroups: ["helm.toolkit.fluxcd.io"]
-    resources: [ "helmreleases" ]
-    verbs: [ "get", "list" ]
-  - apiGroups: [""]
-    resources: ["events"]
-    verbs: ["get", "watch", "list"]
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: sources-reader
-  namespace: flux-system
-rules:
-  - apiGroups: ["source.toolkit.fluxcd.io"]
-    resources: ["buckets", "helmcharts", "gitrepositories", "helmrepositories"]
-    verbs: ["get", "list", "patch"]
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: configmaps-reader
-  namespace: flux-system
-rules:
-  - apiGroups: [""]
-    resources: ["configmaps"]
-    verbs: ["get", "list", "watch"]
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  namespace: default
-  name: templates-reader
-rules:
-- apiGroups: ["capi.weave.works"]
-  resources: ["capitemplates"]
-  verbs: ["get", "watch", "list"]
-
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -64,8 +12,8 @@ subjects:
   name: "team-pesto@weave.works"
   apiGroup: rbac.authorization.k8s.io
 roleRef:
-  kind: Role
-  name: templates-reader
+  kind: ClusterRole
+  name: gitops-templates-reader
   apiGroup: rbac.authorization.k8s.io
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -81,7 +29,7 @@ subjects:
   name: "team-pesto@weave.works"
   apiGroup: rbac.authorization.k8s.io
 roleRef:
-  kind: Role
+  kind: ClusterRole
   name: sources-reader
   apiGroup: rbac.authorization.k8s.io
 ---
@@ -98,8 +46,8 @@ subjects:
   name: "team-pesto@weave.works"
   apiGroup: rbac.authorization.k8s.io
 roleRef:
-  kind: Role
-  name: apps-reader
+  kind: ClusterRole
+  name: gitops-apps-reader
   apiGroup: rbac.authorization.k8s.io
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -115,37 +63,10 @@ subjects:
   name: "team-pesto@weave.works"
   apiGroup: rbac.authorization.k8s.io
 roleRef:
-  kind: Role
-  name: configmaps-reader
+  kind: ClusterRole
+  name: gitops-configmaps-reader
   apiGroup: rbac.authorization.k8s.io
 
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: identities-reader
-rules:
-- apiGroups: ["infrastructure.cluster.x-k8s.io"]
-  resources: ["awsclusterstaticidentities", "awsclusterroleidentities", "azureclusteridentities"]
-  verbs: ["get", "list"]
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: secrets-reader
-rules:
-  - apiGroups: [""]
-    resources: ["secrets"]
-    verbs: ["get", "list", "create"]
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: policies-reader
-rules:
-  - apiGroups: ["pac.weave.works"]
-    resources: ["policies"]
-    verbs: ["get", "list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -160,7 +81,7 @@ subjects:
   apiGroup: rbac.authorization.k8s.io
 roleRef:
   kind: ClusterRole
-  name: identities-reader
+  name: gitops-identities-reader
   apiGroup: rbac.authorization.k8s.io
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -176,7 +97,7 @@ subjects:
   apiGroup: rbac.authorization.k8s.io
 roleRef:
   kind: ClusterRole
-  name: secrets-reader
+  name: gitops-secrets-reader
   apiGroup: rbac.authorization.k8s.io
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -192,6 +113,5 @@ subjects:
   apiGroup: rbac.authorization.k8s.io
 roleRef:
   kind: ClusterRole
-  name: policies-reader
+  name: gitops-policies-reader
   apiGroup: rbac.authorization.k8s.io
-


### PR DESCRIPTION
- Makes it a bit easier for people to get started
- ClusterRoles for now, prefix w/ `gitops-` to try and avoid collisions as they're not in a namespace
- allow them to be disabled in values.yaml