### PR TITLE
Add CoreContextProvider to UI

### DIFF
--- a/ui-cra/package.json
+++ b/ui-cra/package.json
@@ -24,7 +24,7 @@
     "@types/react-dom": "^17.0.0",
     "@types/react-router-dom": "^5.1.7",
     "@types/styled-components": "^5.1.9",
-    "@weaveworks/weave-gitops": "0.7.0",
+    "@weaveworks/weave-gitops": "0.7.0-patch1",
     "classnames": "^2.3.1",
     "d3-scale": "4.0.0",
     "d3-time": "^3.0.0",

--- a/ui-cra/src/App.tsx
+++ b/ui-cra/src/App.tsx
@@ -1,22 +1,22 @@
-import React, { FC } from 'react';
-import { BrowserRouter } from 'react-router-dom';
-import { QueryClient, QueryClientProvider } from 'react-query';
-import { muiTheme } from './muiTheme';
-import { MuiThemeProvider } from '@material-ui/core/styles';
 import '@fortawesome/fontawesome-free/css/all.css';
-import { createGlobalStyle, ThemeProvider } from 'styled-components';
-
+import { MuiThemeProvider } from '@material-ui/core/styles';
 import {
-  theme,
-  coreClient,
-  applicationsClient,
-  FeatureFlagsContextProvider,
   AppContextProvider,
+  applicationsClient,
+  coreClient,
+  CoreClientContextProvider,
+  FeatureFlagsContextProvider,
+  theme,
 } from '@weaveworks/weave-gitops';
-import ProximaNova from './fonts/proximanova-regular.woff';
-import RobotoMono from './fonts/roboto-mono-regular.woff';
+import React, { FC } from 'react';
+import { QueryClient, QueryClientProvider } from 'react-query';
+import { BrowserRouter } from 'react-router-dom';
+import { createGlobalStyle, ThemeProvider } from 'styled-components';
 import Background from './assets/img/background.svg';
 import ResponsiveDrawer from './components/ResponsiveDrawer';
+import ProximaNova from './fonts/proximanova-regular.woff';
+import RobotoMono from './fonts/roboto-mono-regular.woff';
+import { muiTheme } from './muiTheme';
 
 const GlobalStyle = createGlobalStyle`
   /* https://github.com/weaveworks/wkp-ui/pull/283#discussion_r339958886 */
@@ -69,15 +69,14 @@ const App: FC = () => {
       <MuiThemeProvider theme={muiTheme}>
         <BrowserRouter basename={process.env.PUBLIC_URL}>
           <QueryClientProvider client={queryClient}>
-            <GlobalStyle />
-            <AppContextProvider
-              applicationsClient={applicationsClient}
-              coreClient={coreClient}
-            >
-              <FeatureFlagsContextProvider>
-                <ResponsiveDrawer />
-              </FeatureFlagsContextProvider>
-            </AppContextProvider>
+            <CoreClientContextProvider api={coreClient}>
+              <GlobalStyle />
+              <AppContextProvider applicationsClient={applicationsClient}>
+                <FeatureFlagsContextProvider>
+                  <ResponsiveDrawer />
+                </FeatureFlagsContextProvider>
+              </AppContextProvider>
+            </CoreClientContextProvider>
           </QueryClientProvider>
         </BrowserRouter>
       </MuiThemeProvider>

--- a/ui-cra/yarn.lock
+++ b/ui-cra/yarn.lock
@@ -2261,10 +2261,10 @@
     "@typescript-eslint/types" "5.13.0"
     eslint-visitor-keys "^3.0.0"
 
-"@weaveworks/weave-gitops@0.7.0":
-  version "0.7.0"
-  resolved "https://npm.pkg.github.com/download/@weaveworks/weave-gitops/0.7.0/0d6b35ce1bc7975d11f070b8a426789ba2f6179a6ec5d212cc01b7eddf622fb1#cf83b9918af7d478529538e00c647c549ac18819"
-  integrity sha512-86aDtBTM0areZfkGizAx2bzGQC9I5+O7kfNpnwEwZij3vkBj4hMwc14f2ZCDayn7lJA79XMx0TLX93e+VfAQIA==
+"@weaveworks/weave-gitops@0.7.0-patch1":
+  version "0.7.0-patch1"
+  resolved "https://npm.pkg.github.com/download/@weaveworks/weave-gitops/0.7.0-patch1/242e2b01015029b01df43ab4cd501327f92e692b7d3a63e4bd34482d6755f5cb#6dd7ca8b5c3998df4be801a5f97374597410d281"
+  integrity sha512-EdmZiUM9KGnyEkl/PecLkPItxH40yc+ZkA49bquOSJXdAROvqBe9W2rONgTj7UILTX+m4/gLkLEdPsBVnoQ8ew==
   dependencies:
     "@material-ui/core" "^4.12.3"
     "@material-ui/icons" "^4.11.2"


### PR DESCRIPTION
Fixes an issue where api methods are undefined.

This would have been caught whenever the EE team went to use a new version of `Core`. A linting error would have been thrown and the resolution would have been fairly straightforward.

Note: I do not have a local environment in which to test this, so I will need @AlinaGoaga or @foot to give it ago for me, if you wouldn't mind.