### PR TITLE
Corrects gitopsclusters role name, required to read gitops-clusters

### DIFF
--- a/charts/mccp/templates/rbac/user_roles.yaml
+++ b/charts/mccp/templates/rbac/user_roles.yaml
@@ -76,7 +76,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: gitops-gitopscluster-reader
+  name: gitops-gitopsclusters-reader
 rules:
 - apiGroups: ["gitops.weave.works"]
   resources: ["gitopsclusters"]


### PR DESCRIPTION
Typo from #686 