### PR TITLE
fix: use "go install" instead of "go get" to install binaries

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -40,8 +40,8 @@ jobs:
     - name: Install dependencies
       run: |
         go mod download
-        go get github.com/wadey/gocovmerge
-        go get -u github.com/jstemmer/go-junit-report
+        go install github.com/wadey/gocovmerge@latest
+        go install -u github.com/jstemmer/go-junit-report@latest
         npm install -g junit-report-merger
     - name: Install goveralls
       env:


### PR DESCRIPTION
Fixes #780