### PR TITLE
Gives wego-admin a ClusterRoleBinding for reading apps

### DIFF
--- a/charts/mccp/templates/rbac/admin_role_bindings.yaml
+++ b/charts/mccp/templates/rbac/admin_role_bindings.yaml
@@ -1,9 +1,8 @@
 {{- if .Values.rbac.adminUserRoleBindings.create -}}
 apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
+kind: ClusterRoleBinding
 metadata:
   name: wego-admin-read-apps
-  namespace: flux-system
 subjects:
 - kind: User
   name: "wego-admin"


### PR DESCRIPTION
- To get around an issue where the MC-querier thinks it already has access, after we added a ClusterRoleBinding for events. (#905).

This might be a bug in core, not 100% sure yet, https://github.com/weaveworks/weave-gitops-enterprise/issues/907

Also brings us slightly closer to the defaults in the wg helm-chart (goal of #751 )