### PR TITLE
[UI] Applications/Sources pages crash the UI if a cluster cannot be reached

### DIFF
--- a/ui-cra/src/components/ErrorBoundary.tsx
+++ b/ui-cra/src/components/ErrorBoundary.tsx
@@ -27,7 +27,7 @@ export default class ErrorBoundary extends React.Component<
       // You can render any custom fallback UI
       return (
         <PageTemplate documentTitle="Error">
-          <SectionHeader />
+          <SectionHeader path={[{ label: 'Error' }]} />
           <ContentWrapper>
             <h3>Something went wrong.</h3>
             <pre>{this.state.error?.message}</pre>

--- a/ui-cra/src/components/ResponsiveDrawer.tsx
+++ b/ui-cra/src/components/ResponsiveDrawer.tsx
@@ -159,7 +159,7 @@ const CoreWrapper = styled.div`
 
 const Page404 = () => (
   <PageTemplate documentTitle="WeGO · NotFound">
-    <SectionHeader />
+    <SectionHeader path={[{ label: 'Error' }]} />
     <ContentWrapper>
       <Lottie
         loop


### PR DESCRIPTION
Closes #911

Adapted `ErrorBoundary` Component from Core. See React example here: https://reactjs.org/docs/error-boundaries.html 

Instead of crashing it now shows: 

<img width="1440" alt="Screenshot 2022-06-07 at 13 16 20" src="https://user-images.githubusercontent.com/35202557/172391812-9a0f6862-fb83-4fda-9c16-984c7081b238.png">
