### PR TITLE
Freeze helm version for CI test jobs

### DIFF
--- a/.github/workflows/acceptance-test.yaml
+++ b/.github/workflows/acceptance-test.yaml
@@ -211,6 +211,7 @@ jobs:
         run: |
           curl --silent --location "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp
           sudo mv /tmp/eksctl /usr/local/bin
+          eksctl version
           eksctl get clusters
       - name: Install flux
         run: |
@@ -227,6 +228,7 @@ jobs:
           elif [ "$RUNNER_OS" == "macOS" ]; then
               brew install aws-iam-authenticator
           fi
+          aws-iam-authenticator version
       - name: Authenticate to Google Cloud
         if: ${{ inputs.management-cluster-kind == 'gke' }}
         uses: google-github-actions/auth@v0.4.4
@@ -245,6 +247,10 @@ jobs:
       - name: Install docker
         if: ${{ (runner.os == 'macOS') && (inputs.management-cluster-kind == 'kind') }}
         uses: docker-practice/actions-setup-docker@master
+      - name: Install helm
+        uses: azure/setup-helm@v2.0
+        with:
+          version: v3.8.2
       - name: Install kubectl
         uses: Azure/setup-kubectl@v2.0
         with:

--- a/test/acceptance/test/ui_applications.go
+++ b/test/acceptance/test/ui_applications.go
@@ -206,7 +206,7 @@ func DescribeApplications(gitopsTestRunner GitopsTestRunner) {
 					Expect(graph.SourceGit).Should(BeVisible(), fmt.Sprintf("Failed to verify %s Graph/Source", appName))
 					Expect(graph.Kustomization).Should(BeVisible(), fmt.Sprintf("Failed to verify %s Graph/Kustomization", appName))
 					Expect(graph.Deployment).Should(BeVisible(), fmt.Sprintf("Failed to verify %s Graph/Deployment", appName))
-					Expect(graph.ReplicaSet).Should(BeVisible(), fmt.Sprintf("Failed to verify %s Graph/ReplicaSet", appName))
+					Expect(graph.ReplicaSet).Should(BeFound(), fmt.Sprintf("Failed to verify %s Graph/ReplicaSet", appName))
 					Expect(graph.Pod.At(0)).Should(BeFound(), fmt.Sprintf("Failed to verify %s Graph/Pod", appName))
 				})
 

--- a/test/acceptance/test/utils_gitops.go
+++ b/test/acceptance/test/utils_gitops.go
@@ -307,12 +307,19 @@ func generateGitopsClutermanifest(clusterName string, nameSpace string, bootstra
 
 func createNamespace(namespaces []string) {
 	for _, namespace := range namespaces {
-		_ = runCommandPassThrough("sh", "-c", fmt.Sprintf(`kubectl create namespace %s`, namespace))
+		err := runCommandPassThrough("sh", "-c", fmt.Sprintf(`kubectl create namespace %s`, namespace))
+		if err != nil {
+			// 2nd attempt to create namespace
+			_ = runCommandPassThrough("sh", "-c", fmt.Sprintf(`kubectl create namespace %s`, namespace))
+		}
 	}
 }
 
 func deleteNamespace(namespaces []string) {
 	for _, namespace := range namespaces {
-		_ = runCommandPassThrough("sh", "-c", fmt.Sprintf(`kubectl delete namespace %s`, namespace))
+		err := runCommandPassThrough("sh", "-c", fmt.Sprintf(`kubectl delete namespace %s`, namespace))
+		if err != nil {
+			_ = runCommandPassThrough("sh", "-c", fmt.Sprintf(`kubectl delete namespace %s`, namespace))
+		}
 	}
 }


### PR DESCRIPTION
- Fixed helm version to v3.8.2for CI test jobs. Latest helm version v3.9.0 is not compatible with EKS.
- Allow 2nd attempt for tests to create namespace.