### PR TITLE
fix: Populate cluster/namespace list immediately

### DIFF
--- a/cmd/clusters-service/app/server.go
+++ b/cmd/clusters-service/app/server.go
@@ -349,6 +349,8 @@ func StartServer(ctx context.Context, log logr.Logger, tempDir string, p Params)
 		clientsFactoryScheme,
 	)
 	clusterClientsFactory.Start(ctx)
+	_ = clusterClientsFactory.UpdateClusters(ctx)
+	_ = clusterClientsFactory.UpdateNamespaces(ctx)
 
 	return RunInProcessGateway(ctx, "0.0.0.0:8000",
 		WithLog(log),

--- a/tools/dev-values-local.yaml.tpl
+++ b/tools/dev-values-local.yaml.tpl
@@ -2,3 +2,7 @@
 config:
   capi:
     repositoryURL: https://github.com/$GITHUB_USER/$GITHUB_REPO.git
+
+features:
+  progressiveDelivery:
+    enabled: true


### PR DESCRIPTION
Populate cluster/namespace list immediately. If we don't, a race condition will prevent the clients pool from being populated with the list of clusters.