### PR TITLE
Handle invalid annotations.

### DIFF
--- a/cmd/clusters-service/pkg/templates/render.go
+++ b/cmd/clusters-service/pkg/templates/render.go
@@ -19,7 +19,12 @@ type RenderOptFunc func(uns *unstructured.Unstructured) error
 // to instruct flux *not* to prune these objects.
 func InjectPruneAnnotation(uns *unstructured.Unstructured) error {
 	if uns.GetKind() != "Cluster" && uns.GetKind() != "GitopsCluster" {
-		ann := uns.GetAnnotations()
+		// NOTE: This is doing the same thing as uns.GetAnnotations() but with
+		// error handling, GetAnnotations is unlikely to change behaviour.
+		ann, _, err := unstructured.NestedStringMap(uns.Object, "metadata", "annotations")
+		if err != nil {
+			return fmt.Errorf("failed trying to inject prune annotation: %w", err)
+		}
 		if ann == nil {
 			ann = make(map[string]string)
 		}

--- a/cmd/clusters-service/pkg/templates/render_test.go
+++ b/cmd/clusters-service/pkg/templates/render_test.go
@@ -92,13 +92,7 @@ apiVersion: cluster.x-k8s.io/v1alpha3
 kind: NotCluster
 metadata:
   name: testing
----
-apiVersion: controlplane.cluster.x-k8s.io/v1alpha4
-kind: KubeadmControlPlane
-metadata:
-  name: testing-control-plane
-spec:
-  replicas: 5`)
+`)
 	updated, err := processUnstructured(raw, InjectPruneAnnotation)
 	if err != nil {
 		t.Fatal(err)
@@ -115,6 +109,20 @@ metadata:
 	if diff := cmp.Diff(want, string(updated)); diff != "" {
 		t.Fatalf("rendering with option failed:\n%s", diff)
 	}
+}
+
+func TestInjectPruneAnnotation_invalid_yaml(t *testing.T) {
+	raw := []byte(`
+apiVersion: cluster.x-k8s.io/v1alpha3
+kind: NotCluster
+metadata:
+  name: testing
+  annotations:
+    test.annotation: true
+`)
+	_, err := processUnstructured(raw, InjectPruneAnnotation)
+
+	assert.ErrorContains(t, err, "failed trying to inject prune annotation: .metadata.annotations")
 }
 
 func TestRender_InjectPruneAnnotation(t *testing.T) {


### PR DESCRIPTION
The [GetAnnotations()](https://github.com/kubernetes/apimachinery/blob/v0.24.1/pkg/apis/meta/v1/unstructured/unstructured.go#L408) method on [unstructured.Unstructured](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured) values ignores [errors](https://github.com/kubernetes/apimachinery/blob/97e5df2d0258ac077093867fabf508c1fc31f53b/pkg/apis/meta/v1/unstructured/helpers.go#L166) in the annotations, which was resulting in getting a `nil` value back, and wiping the annotations.

If the annotations are not valid, this will be returned as an error when rendering the template.