### PR TITLE
Ensure profile namespaces exist.

### DIFF
--- a/cmd/clusters-service/pkg/charts/values.go
+++ b/cmd/clusters-service/pkg/charts/values.go
@@ -249,6 +249,7 @@ func MakeHelmReleasesInLayers(clusterName, namespace string, installs []ChartIns
 			}
 			if install.Namespace != "" {
 				hr.Spec.TargetNamespace = install.Namespace
+				hr.Spec.Install.CreateNamespace = true
 			}
 			if layer.dependsOn != "" {
 				for _, v := range layerInstalls[layer.dependsOn] {

--- a/cmd/clusters-service/pkg/charts/values_test.go
+++ b/cmd/clusters-service/pkg/charts/values_test.go
@@ -275,6 +275,7 @@ func TestMakeHelmReleasesInLayers(t *testing.T) {
 			want: []*helmv2.HelmRelease{
 				makeTestHelmRelease("test-cluster-test-chart", "testing", hr.GetNamespace(), "test-chart", "0.0.1", func(hr *helmv2.HelmRelease) {
 					hr.Spec.TargetNamespace = "test-system"
+					hr.Spec.Install.CreateNamespace = true
 				}),
 			},
 		},

--- a/cmd/clusters-service/pkg/server/clusters_test.go
+++ b/cmd/clusters-service/pkg/server/clusters_test.go
@@ -498,6 +498,7 @@ spec:
       version: 0.0.1
   install:
     crds: CreateReplace
+    createNamespace: true
   interval: 1m0s
   targetNamespace: test-system
   values:


### PR DESCRIPTION
When installing a Profile into a non-default namespace, this marks the namespace for creation by the Helm Controller.

See https://fluxcd.io/docs/components/helm/helmreleases/#remote-clusters--cluster-api