### PR TITLE
add config for service annotations on helm chart

### DIFF
--- a/charts/mccp/templates/clusters-service/service.yaml
+++ b/charts/mccp/templates/clusters-service/service.yaml
@@ -4,6 +4,10 @@ kind: Service
 metadata:
   name: clusters-service
   namespace: {{ .Release.Namespace | quote }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   selector:
     app: clusters-service

--- a/charts/mccp/values.yaml
+++ b/charts/mccp/values.yaml
@@ -79,6 +79,7 @@ service:
   loadBalancerSourceRanges: []
   externalTrafficPolicy: ""
   healthCheckNodePort: 0
+  annotations: {}
 
 cluster-controller:
   enabled: true


### PR DESCRIPTION
Add support for custom annotations on the `clusters-service` service.

This is needed in order to specify various cloud provider settings including load-balancer config.  For example
```
beta.cloud.google.com/backend-config: '{"default": "default-lb-backend-config"}'
networking.gke.io/v1beta1.FrontendConfig: default-lb-frontend-config
```