### PR TITLE
UI: provide cluster namespace when fetching kubeconfig

### DIFF
--- a/ui-cra/src/components/Clusters/ClusterDashboard.tsx
+++ b/ui-cra/src/components/Clusters/ClusterDashboard.tsx
@@ -50,7 +50,7 @@ const ClusterDashboard = ({ clusterName }: Props) => {
   const history = useHistory();
 
   const handleClick = () =>
-    getKubeconfig(clusterName, `${clusterName}.kubeconfig`);
+    getKubeconfig(clusterName, currentCluster?.namespace || "", `${clusterName}.kubeconfig`);
 
   const info = [
     [

--- a/ui-cra/src/contexts/Clusters/Provider.tsx
+++ b/ui-cra/src/contexts/Clusters/Provider.tsx
@@ -61,8 +61,8 @@ const ClustersProvider: FC = ({ children }) => {
   );
 
   const getKubeconfig = useCallback(
-    (clusterName: string, filename: string) => {
-      request('GET', `/v1/clusters/${clusterName}/kubeconfig`, {
+    (clusterName: string, clusterNamespace: string, filename: string) => {
+      request('GET', `/v1/clusters/${clusterName}/kubeconfig?cluster_namespace=${clusterNamespace}`, {
         headers: {
           Accept: 'application/octet-stream',
         },

--- a/ui-cra/src/contexts/Clusters/index.tsx
+++ b/ui-cra/src/contexts/Clusters/index.tsx
@@ -18,7 +18,7 @@ interface ClustersContext {
     data: DeleteClustersPRRequestEnriched,
     token: string,
   ) => Promise<any>;
-  getKubeconfig: (clusterName: string, fileName: string) => void;
+  getKubeconfig: (clusterName: string, clusterNamespace: string, fileName: string) => void;
   getDashboardAnnotations: (cluster: GitopsClusterEnriched) => {
     [key: string]: string;
   };


### PR DESCRIPTION
When a cluster is created in a namespace that's different from the
default one ("default") then downloading the kubeconfig failed because
the UI didn't provide the cluster's namespace to the server.

With this change, the namespace is provided as a query parameter.
