### PR TITLE
reduce verbosity

### DIFF
--- a/cmd/clusters-service/pkg/clusters/clusters.go
+++ b/cmd/clusters-service/pkg/clusters/clusters.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/go-logr/logr"
 	gitopsv1alpha1 "github.com/weaveworks/cluster-controller/api/v1alpha1"
+	"github.com/weaveworks/weave-gitops/core/logger"
 	"github.com/weaveworks/weave-gitops/pkg/kube"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -33,14 +34,13 @@ type CRDLibrary struct {
 }
 
 func (lib *CRDLibrary) Get(ctx context.Context, name string) (*gitopsv1alpha1.GitopsCluster, error) {
-	lib.Log.Info("Getting client from context")
 	cl, err := lib.ClientGetter.Client(ctx)
 	if err != nil {
 		return nil, err
 	}
 
 	cluster := gitopsv1alpha1.GitopsCluster{}
-	lib.Log.Info("Getting cluster", "cluster", name)
+	lib.Log.V(logger.LogLevelDebug).Info("Getting cluster", "cluster", name)
 	err = cl.Get(ctx, client.ObjectKey{
 		Namespace: lib.Namespace,
 		Name:      name,
@@ -49,19 +49,18 @@ func (lib *CRDLibrary) Get(ctx context.Context, name string) (*gitopsv1alpha1.Gi
 		lib.Log.Error(err, "Failed to get cluster", "cluster", name)
 		return nil, fmt.Errorf("error getting cluster %s/%s: %s", lib.Namespace, name, err)
 	}
-	lib.Log.Info("Got cluster", "cluster", name)
+	lib.Log.V(logger.LogLevelDebug).Info("Got cluster", "cluster", name)
 
 	return &cluster, nil
 }
 
 func (lib *CRDLibrary) List(ctx context.Context, listOptions client.ListOptions) (map[string]*gitopsv1alpha1.GitopsCluster, string, error) {
-	lib.Log.Info("Getting client from context")
 	cl, err := lib.ClientGetter.Client(ctx)
 	if err != nil {
 		return nil, "", err
 	}
 
-	lib.Log.Info("Querying namespace for Cluster resources", "namespace", lib.Namespace)
+	lib.Log.V(logger.LogLevelDebug).Info("Querying namespace for Cluster resources", "namespace", lib.Namespace)
 
 	clusterList := gitopsv1alpha1.GitopsClusterList{}
 	err = cl.List(ctx, &clusterList, client.InNamespace(lib.Namespace), &listOptions)
@@ -69,7 +68,7 @@ func (lib *CRDLibrary) List(ctx context.Context, listOptions client.ListOptions)
 		return nil, "", fmt.Errorf("error getting clusters: %s", err)
 	}
 
-	lib.Log.Info("Got clusters", "numberOfClusters", len(clusterList.Items))
+	lib.Log.V(logger.LogLevelDebug).Info("Got clusters", "numberOfClusters", len(clusterList.Items))
 
 	nextPageToken := clusterList.GetContinue()
 	result := map[string]*gitopsv1alpha1.GitopsCluster{}

--- a/cmd/clusters-service/pkg/templates/templates.go
+++ b/cmd/clusters-service/pkg/templates/templates.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/go-logr/logr"
+	"github.com/weaveworks/weave-gitops/core/logger"
 	"github.com/weaveworks/weave-gitops/pkg/kube"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -39,7 +40,7 @@ type ConfigMapLibrary struct {
 }
 
 func (lib *ConfigMapLibrary) List(ctx context.Context, templateKind string) (map[string]*templates.Template, error) {
-	lib.Log.Info("Querying Kubernetes for configmap", "namespace", lib.CAPINamespace, "configmapName", lib.ConfigMapName, "kind", templateKind)
+	lib.Log.V(logger.LogLevelDebug).Info("Querying Kubernetes for configmap", "namespace", lib.CAPINamespace, "configmapName", lib.ConfigMapName, "kind", templateKind)
 
 	templateConfigMap := &v1.ConfigMap{}
 	err := lib.Client.Get(ctx, client.ObjectKey{
@@ -51,7 +52,7 @@ func (lib *ConfigMapLibrary) List(ctx context.Context, templateKind string) (map
 	} else if err != nil {
 		return nil, fmt.Errorf("error getting configmap: %w", err)
 	}
-	lib.Log.Info("Got template configmap", "configmap", templateConfigMap)
+	lib.Log.V(logger.LogLevelDebug).Info("Got template configmap", "configmap", templateConfigMap)
 
 	tm, err := ParseConfigMap(*templateConfigMap)
 	if errors.IsNotFound(err) {
@@ -90,7 +91,6 @@ type CRDLibrary struct {
 }
 
 func (lib *CRDLibrary) Get(ctx context.Context, name, templateKind string) (*templates.Template, error) {
-	lib.Log.Info("Getting client from context")
 	cl, err := lib.ClientGetter.Client(ctx)
 	if err != nil {
 		return nil, err
@@ -100,7 +100,7 @@ func (lib *CRDLibrary) Get(ctx context.Context, name, templateKind string) (*tem
 
 	case capiv1.Kind:
 		var t capiv1.CAPITemplate
-		lib.Log.Info("Getting capitemplate", "template", name)
+		lib.Log.V(logger.LogLevelDebug).Info("Getting capitemplate", "template", name)
 		err = cl.Get(ctx, client.ObjectKey{
 			Namespace: lib.CAPINamespace,
 			Name:      name,
@@ -109,11 +109,11 @@ func (lib *CRDLibrary) Get(ctx context.Context, name, templateKind string) (*tem
 			lib.Log.Error(err, "Failed to get capitemplate", "template", name)
 			return nil, fmt.Errorf("error getting capitemplate %s/%s: %w", lib.CAPINamespace, name, err)
 		}
-		lib.Log.Info("Got capitemplate", "template", name)
+		lib.Log.V(logger.LogLevelDebug).Info("Got capitemplate", "template", name)
 		result = &t.Template
 	case gapiv1.Kind:
 		var t gapiv1.GitOpsTemplate
-		lib.Log.Info("Getting gitops template", "template", name)
+		lib.Log.V(logger.LogLevelDebug).Info("Getting gitops template", "template", name)
 		err = cl.Get(ctx, client.ObjectKey{
 			Namespace: lib.CAPINamespace,
 			Name:      name,
@@ -122,7 +122,7 @@ func (lib *CRDLibrary) Get(ctx context.Context, name, templateKind string) (*tem
 			lib.Log.Error(err, "Failed to get gitops template", "template", name)
 			return nil, fmt.Errorf("error getting gitops template %s/%s: %w", lib.CAPINamespace, name, err)
 		}
-		lib.Log.Info("Got gitops template", "template", name)
+		lib.Log.V(logger.LogLevelDebug).Info("Got gitops template", "template", name)
 		result = &t.Template
 	}
 
@@ -130,7 +130,6 @@ func (lib *CRDLibrary) Get(ctx context.Context, name, templateKind string) (*tem
 }
 
 func (lib *CRDLibrary) List(ctx context.Context, templateKind string) (map[string]*templates.Template, error) {
-	lib.Log.Info("Getting client from context")
 	cl, err := lib.ClientGetter.Client(ctx)
 	if err != nil {
 		return nil, err
@@ -139,24 +138,24 @@ func (lib *CRDLibrary) List(ctx context.Context, templateKind string) (map[strin
 	result := make(map[string]*templates.Template)
 	switch templateKind {
 	case capiv1.Kind:
-		lib.Log.Info("Querying namespace for CAPITemplate resources", "namespace", lib.CAPINamespace)
+		lib.Log.V(logger.LogLevelDebug).Info("Querying namespace for CAPITemplate resources", "namespace", lib.CAPINamespace)
 		capiTemplateList := capiv1.CAPITemplateList{}
 		err = cl.List(ctx, &capiTemplateList, client.InNamespace(lib.CAPINamespace))
 		if err != nil {
 			return nil, fmt.Errorf("error getting capitemplates: %w", err)
 		}
-		lib.Log.Info("Got capitemplates", "numberOfTemplates", len(capiTemplateList.Items))
+		lib.Log.V(logger.LogLevelDebug).Info("Got capitemplates", "numberOfTemplates", len(capiTemplateList.Items))
 		for i, ct := range capiTemplateList.Items {
 			result[ct.ObjectMeta.Name] = &capiTemplateList.Items[i].Template
 		}
 	case gapiv1.Kind:
-		lib.Log.Info("Querying namespace for GitOpsTemplate resources", "namespace", lib.CAPINamespace)
+		lib.Log.V(logger.LogLevelDebug).Info("Querying namespace for GitOpsTemplate resources", "namespace", lib.CAPINamespace)
 		list := gapiv1.GitOpsTemplateList{}
 		err = cl.List(ctx, &list, client.InNamespace(lib.CAPINamespace))
 		if err != nil {
 			return nil, fmt.Errorf("error getting gitops templates: %w", err)
 		}
-		lib.Log.Info("Got gitops templates", "numberOfTemplates", len(list.Items))
+		lib.Log.V(logger.LogLevelDebug).Info("Got gitops templates", "numberOfTemplates", len(list.Items))
 		for i, ct := range list.Items {
 			result[ct.ObjectMeta.Name] = &list.Items[i].Template
 		}


### PR DESCRIPTION
The logging is reduced by (1) removing unnecessary log messages and
(2) change the log level to "debug" for certain message that aren't
exactly necessary in a production environment.

closes weaveworks/weave-gitops#2333
