### PR TITLE
Fixed CI failing tests due to policy-agent namspace creation

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -82,7 +82,7 @@ jobs:
       runs-on: ubuntu-latest
       os-name: linux
       timeout-minutes: 90
-      label-filter: "-ginkgo.label-filter='!(application, leaf-policy)'"
+      label-filter: "-ginkgo.label-filter='!(application)'"
       kubectl-version: "v1.23.3"
       login_user_type: "cluster-user"
       git-provider: gitlab

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -30,7 +30,7 @@ jobs:
       runs-on: ubuntu-latest
       os-name: linux
       timeout-minutes: 90
-      label-filter: "-ginkgo.label-filter='!(capd)'"
+      label-filter: "-ginkgo.label-filter='!(capd, leaf-policy)'"
       kubectl-version: "v1.23.6"
       login_user_type: "oidc"
       git-provider: github
@@ -66,7 +66,7 @@ jobs:
       runs-on: macOS-latest
       os-name: darwin
       timeout-minutes: 90
-      label-filter: "-ginkgo.label-filter='!(upgrade, capd, kind-gitops-cluster)'"
+      label-filter: "-ginkgo.label-filter='!(upgrade, capd, kind-gitops-cluster, leaf-policy)'"
       kubectl-version: "v1.23.3"
       login_user_type: "cluster-user"
       git-provider: gitlab

--- a/test/acceptance/test/ui_policies.go
+++ b/test/acceptance/test/ui_policies.go
@@ -25,7 +25,7 @@ func installPolicyAgent(clusterName string) {
 	})
 
 	By(fmt.Sprintf("And install policy agent to %s cluster", clusterName), func() {
-		err := runCommandPassThrough("helm", "upgrade", "--install", "weave-policy-agent", "charts-profile/weave-policy-agent", "--version", "0.3.x", "--set", "accountId=weaveworks", "--set", "clusterId="+clusterName)
+		err := runCommandPassThrough("helm", "upgrade", "--install", "weave-policy-agent", "charts-profile/weave-policy-agent", "--namespace", "policy-system", "--create-namespace", "--version", "0.3.x", "--set", "accountId=weaveworks", "--set", "clusterId="+clusterName)
 		Expect(err).ShouldNot(HaveOccurred(), "Failed to install policy agent to leaf cluster: "+clusterName)
 	})
 }

--- a/test/acceptance/test/ui_violations.go
+++ b/test/acceptance/test/ui_violations.go
@@ -29,6 +29,8 @@ func DescribeViolations(gitopsTestRunner GitopsTestRunner) {
 
 			JustAfterEach(func() {
 				_ = gitopsTestRunner.KubectlDelete([]string{}, policiesYaml)
+				_ = gitopsTestRunner.KubectlDelete([]string{}, deploymentYaml)
+
 			})
 
 			It("Verify Violations can be monitored for violating resource", Label("integration", "violation"), func() {
@@ -41,7 +43,7 @@ func DescribeViolations(gitopsTestRunner GitopsTestRunner) {
 
 				By("Install violating Postgres deployment to the management cluster", func() {
 					Expect(waitForResource("policy", policyID, "default", "", ASSERTION_1MINUTE_TIME_OUT))
-					Expect(gitopsTestRunner.KubectlApply([]string{}, deploymentYaml)).ShouldNot(Succeed(), "Failed to install test Postgres deployment to management cluster")
+					Expect(gitopsTestRunner.KubectlApply([]string{}, deploymentYaml)).ShouldNot(Succeed(), "Test Postgres deployment should not be installed in the management cluster")
 				})
 
 				By("And wait for violations to be visibe on the dashboard", func() {

--- a/test/utils/scripts/wego-enterprise.sh
+++ b/test/utils/scripts/wego-enterprise.sh
@@ -219,6 +219,7 @@ function setup {
 
   # Install policy agent to enforce rego policies - (Installing policy agent after capi because capi violates some of thge policies and failed to install)
   helm upgrade --install weave-policy-agent profiles-catalog/weave-policy-agent \
+    --namespace policy-system --create-namespace \
     --version 0.3.x \
     --set accountId=weaveworks \
     --set clusterId=${MANAGEMENT_CLUSTER_CNAME}


### PR DESCRIPTION
- Creating namespace explicitly while installing policy-agent
- Enable leaf cluster policy test to run in Deploy job