### PR TITLE
Parse params from annotations.

### DIFF
--- a/cmd/clusters-service/pkg/templates/processors_test.go
+++ b/cmd/clusters-service/pkg/templates/processors_test.go
@@ -86,6 +86,13 @@ func TestProcessor_AllParamNames(t *testing.T) {
 				"WORKER_MACHINE_COUNT",
 			},
 		},
+		{
+			filename: "testdata/template-with-annotation-params.yaml",
+			want: []string{
+				"CLUSTER_NAME",
+				"TEST_PARAMETER",
+			},
+		},
 	}
 
 	for _, tt := range paramTests {

--- a/cmd/clusters-service/pkg/templates/testdata/template-with-annotation-params.yaml
+++ b/cmd/clusters-service/pkg/templates/testdata/template-with-annotation-params.yaml
@@ -1,0 +1,28 @@
+apiVersion: capi.weave.works/v1alpha1
+kind: CAPITemplate
+metadata:
+  name: cluster-template
+  annotations:
+    capi.weave.works/profile-0: '{"name": "prometheus", "version": "0.0.8", "values": "testing:\n ${TEST_PARAMETER}"}'
+spec:
+  description: this is test template 1
+  params:
+    - name: CLUSTER_NAME
+      description: This is used for the cluster naming.
+  resourcetemplates:
+  - apiVersion: cluster.x-k8s.io/v1alpha3
+    kind: Cluster
+    metadata:
+      name: "${CLUSTER_NAME}"
+    spec:
+      clusterNetwork:
+        pods:
+          cidrBlocks: ["192.168.0.0/16"]
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+        kind: AWSCluster
+        name: "${CLUSTER_NAME}"
+      controlPlaneRef:
+        kind: KubeadmControlPlane
+        apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
+        name: "${CLUSTER_NAME}-control-plane"


### PR DESCRIPTION
This updates the template parsing to parse annotations for parameters.

This means that variables that are solely declared in an annotation (as values.yaml) will appear in the form.