### PR TITLE
Fix bug with secret key lookup.

### DIFF
--- a/cmd/clusters-service/pkg/server/clusters.go
+++ b/cmd/clusters-service/pkg/server/clusters.go
@@ -352,7 +352,7 @@ func (s *server) GetKubeconfig(ctx context.Context, msg *capiv1_proto.GetKubecon
 		return nil, fmt.Errorf("unable to get secret %q for Kubeconfig: %w", name, err)
 	}
 
-	val, ok := sec.Data["value"]
+	val, ok := kubeConfigFromSecret(sec)
 	if !ok {
 		return nil, fmt.Errorf("secret %q was found but is missing key %q", key, "value")
 	}
@@ -750,4 +750,16 @@ func getManagementCluster() (*capiv1_proto.GitopsCluster, error) {
 	}
 
 	return cluster, nil
+}
+
+func kubeConfigFromSecret(s corev1.Secret) ([]byte, bool) {
+	val, ok := s.Data["value.yaml"]
+	if ok {
+		return val, true
+	}
+	val, ok = s.Data["value"]
+	if ok {
+		return val, true
+	}
+	return nil, false
 }

--- a/cmd/clusters-service/pkg/server/clusters_test.go
+++ b/cmd/clusters-service/pkg/server/clusters_test.go
@@ -621,7 +621,7 @@ func TestGetKubeconfig(t *testing.T) {
 		{
 			name: "get kubeconfig as JSON",
 			clusterState: []runtime.Object{
-				makeSecret("dev-kubeconfig", "default", "value", "foo"),
+				makeSecret("dev-kubeconfig", "default", "value.yaml", "foo"),
 			},
 			clusterObjectsNamespace: "default",
 			req: &capiv1_protos.GetKubeconfigRequest{


### PR DESCRIPTION
Allow either `value` or `value.yaml` for the key in the secret that stores the kubeconfig.

In the documentation we say `value.yaml` but the code only supported `value`.

https://docs.gitops.weave.works/docs/cluster-management/managing-existing-clusters/#how-to-connect-a-cluster

Flux supports either https://github.com/fluxcd/kustomize-controller/blob/2aa69b61af40031394efee12051941a6660592de/controllers/kustomization_impersonation.go#L190