### PR TITLE
Flagger generated objects in Canary details should match other details views

### DIFF
--- a/ui-cra/src/components/ProgressiveDelivery/CanaryDetails/ManagedObjects/ManagedObjectsTable.tsx
+++ b/ui-cra/src/components/ProgressiveDelivery/CanaryDetails/ManagedObjects/ManagedObjectsTable.tsx
@@ -1,5 +1,11 @@
+import { UnstructuredObject } from '@weaveworks/progressive-delivery/api/prog/types.pb';
 import { CustomDataTable, TableWrapper } from '../../CanaryStyles';
-export const ManagedObjectsTable = ({ objects }: { objects: any[] }) => {
+import CanaryStatus from '../../SharedComponent/CanaryStatus';
+export const ManagedObjectsTable = ({
+  objects,
+}: {
+  objects: UnstructuredObject[];
+}) => {
   return (
     <TableWrapper id="objects-list">
       <CustomDataTable
@@ -11,8 +17,7 @@ export const ManagedObjectsTable = ({ objects }: { objects: any[] }) => {
           },
           {
             label: 'Type',
-            value: object =>
-              `${object.groupVersionKind.version}/${object.groupVersionKind.kind}`,
+            value: object => `${object.groupVersionKind.kind}`,
           },
           {
             label: 'Namespace',
@@ -20,11 +25,41 @@ export const ManagedObjectsTable = ({ objects }: { objects: any[] }) => {
           },
           {
             label: 'Status',
-            value: 'status',
+            value: ({ conditions }: UnstructuredObject) =>
+              !!conditions && conditions.length > 0 ? (
+                <CanaryStatus status={conditions[0].type || ''} />
+              ) : (
+                '--'
+              ),
+          },
+          {
+            label: 'Message',
+            value: ({ conditions }: UnstructuredObject) =>
+              !!conditions && conditions.length > 0
+                ? `${conditions[0].message}`
+                : '--',
           },
           {
             label: 'Images',
-            value: 'images',
+            value: ({ images }: UnstructuredObject) => (
+              <div
+                style={{
+                  display: 'flex',
+                  flexDirection: 'column',
+                }}
+              >
+                {images?.map((image, indx) => (
+                  <a
+                    target="_blank"
+                    rel="noreferrer"
+                    href={`https://${image}`}
+                    key={indx}
+                  >
+                    {image}
+                  </a>
+                ))}
+              </div>
+            ),
           },
         ]}
       />

--- a/ui-cra/src/components/ProgressiveDelivery/SharedComponent/CanaryStatus.tsx
+++ b/ui-cra/src/components/ProgressiveDelivery/SharedComponent/CanaryStatus.tsx
@@ -15,15 +15,15 @@ enum CanaryDeploymentStatus {
   Failed = 'Failed',
   Terminating = 'Terminating',
   Terminated = 'Terminated',
-  Ready = 'Succeeded',
+  Ready = 'Ready',
 }
 
 function CanaryStatus({
   status,
-  value,
+  value = { current: 0, total: 0 },
 }: {
   status: string;
-  value: { current: number; total: number };
+  value?: { current: number; total: number };
 }) {
   const classes = useCanaryStyle();
 
@@ -41,6 +41,7 @@ function CanaryStatus({
             );
           case CanaryDeploymentStatus.Succeeded:
           case CanaryDeploymentStatus.Initialized:
+          case CanaryDeploymentStatus.Ready:
             return (
               <>
                 <CheckCircle className={`${classes.statusReady}`} />
@@ -48,7 +49,8 @@ function CanaryStatus({
               </>
             );
           case CanaryDeploymentStatus.Progressing:
-            const current = value.current > value.total ? value.total : value.current;
+            const current =
+              value.current > value.total ? value.total : value.current;
             return (
               <>
                 <LinearProgress
@@ -59,7 +61,9 @@ function CanaryStatus({
                   }}
                   className={classes.statusProcessing}
                 />
-                <span className={classes.statusProcessingText}>{`${current} / ${value.total}`}</span>
+                <span
+                  className={classes.statusProcessingText}
+                >{`${current} / ${value.total}`}</span>
               </>
             );
           case CanaryDeploymentStatus.Failed:


### PR DESCRIPTION
it fixes https://github.com/weaveworks/weave-gitops-enterprise/issues/1150


Shows a few inconsistencies which would be good to address, all criteria below refer to changes in the Canary Object tab:
- [x] Type - remove the API version i.e. `v1/Deployment` to `Deployment`
- [x] Status - ensure consistent source of status message, i.e. "Current" vs "Ready : Deployment is available. Replicas 0"
- [x] Status - show appropriate health icon i.e. green tick
- [x] Images - add hyperlink

![image](https://user-images.githubusercontent.com/4614360/181109570-b4d0cbf8-0097-4490-a381-8f2c964705ff.png)
