### PR TITLE
Fixes publishing helm-charts to main

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -48,7 +48,8 @@ jobs:
         run: |
           TAG=$(git describe --always --match "v*" --abbrev=7)
           # Zero fill out the number of commits since the last tag. This allows helm to do a proper sorting of semver rc tags which are sorted alphanumerically.
-          ZERO_FILLED_TAG=$(LAST_TAG=$(git describe --abbrev=0); N=$(git rev-list "$LAST_TAG".. --count); REF=$(git rev-parse --short=8 HEAD); printf "$LAST_TAG-%05d-g$REF" $N)
+          # Also the `r` is important as helm's and some other semver parsers do not allow the "rc" bit of the tag to start with a zero.
+          ZERO_FILLED_TAG=$(LAST_TAG=$(git describe --abbrev=0); N=$(git rev-list "$LAST_TAG".. --count); REF=$(git rev-parse --short=8 HEAD); printf "$LAST_TAG-r%05d-g$REF" $N)
           SEMVER_TAG=$(awk -F'v|-g' '{print $2}' <<< $ZERO_FILLED_TAG)
           echo "::set-output name=tag::$TAG"
           echo "::set-output name=zero_filled_tag::$ZERO_FILLED_TAG"


### PR DESCRIPTION
- Some semver parsers like helm's do not allow the "rc" bit of the tag to
  start with a zero

Interesting links
- https://github.com/Masterminds/semver/blob/49c09bfed6adcffa16482ddc5e5588cffff9883a/version.go#L103-L113
- https://github.com/semver/semver/issues/112#issuecomment-19342987