### PR TITLE
Disable policy-agent persistence by default

### DIFF
--- a/charts/mccp/values.yaml
+++ b/charts/mccp/values.yaml
@@ -97,10 +97,8 @@ policy-agent:
   enabled: false
   accountId: ""
   clusterId: ""
-  # FIXME: default needs to be fixed upstream in policy-agent chart
-  # https://github.com/weaveworks/policy-agent/issues/67
   persistence:
-    storageClassName: "standard"
+    enabled: false
 
 ingress:
   enabled: false


### PR DESCRIPTION
- Choosing a default storageClassName is hard
- Needs user to get involved and configure
- GKE docs dont' even talk about "standard" (says use "standard-rwo") and
  there are permission issues writing to it.

Fixes: #1361 