### PR TITLE
Fixes sources page

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/sirupsen/logrus v1.9.0
 	github.com/spf13/cobra v1.5.0
 	github.com/stretchr/testify v1.8.0
-	github.com/weaveworks/weave-gitops v0.9.4-rc.0.0.20220830183802-44cbabd49c37
+	github.com/weaveworks/weave-gitops v0.9.4-0.20220830111801-9b3233b17f18
 	github.com/weaveworks/weave-gitops-enterprise-credentials v0.0.2
 	github.com/weaveworks/weave-gitops-enterprise/common v0.0.0
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1281,8 +1281,8 @@ github.com/weaveworks/policy-agent/api v1.0.4 h1:dznn4I3+tfSniNbERFaAXOMpLsvwW+6
 github.com/weaveworks/policy-agent/api v1.0.4/go.mod h1:GbePwORMtByaPqKoD7xuY/oqdq8iagfh5R6NZS14+AA=
 github.com/weaveworks/progressive-delivery v0.0.0-20220808183836-c7c637e887d0 h1:49pW4S2L2fqQYGqqr/5Grps55RopEbQcepTnQeNZ+sE=
 github.com/weaveworks/progressive-delivery v0.0.0-20220808183836-c7c637e887d0/go.mod h1:XRrKv9SdRa6r/CGlT78c50dyxz+r9DWOiy09npLS3L8=
-github.com/weaveworks/weave-gitops v0.9.4-rc.0.0.20220830183802-44cbabd49c37 h1:l8Uwdmf9uJY/Y+6zrR9VrjDSp6bwWWgCGuD0MtsgqDw=
-github.com/weaveworks/weave-gitops v0.9.4-rc.0.0.20220830183802-44cbabd49c37/go.mod h1:nKwm4tgpK3kXXZegI3NPXqGEyDOHhZEv8slQL0S1mKM=
+github.com/weaveworks/weave-gitops v0.9.4-0.20220830111801-9b3233b17f18 h1:D2ogP9QYHrqWNu0T2Cc8an5PYgo1GAcEso/BEkvyQ2M=
+github.com/weaveworks/weave-gitops v0.9.4-0.20220830111801-9b3233b17f18/go.mod h1:sMWzafQ2wnXhNoL+aEbFPOrRPIz8DcqAzOAEn7kM0Zc=
 github.com/weaveworks/weave-gitops-enterprise-credentials v0.0.2 h1:7jeiQehqmI4ds6YIq8TW1Vqhlb6V7G2BVRJ8VM3r99I=
 github.com/weaveworks/weave-gitops-enterprise-credentials v0.0.2/go.mod h1:6PMYg+VtSNePnP7EXyNG+/hNRNZ3r0mQtolIZU4s/J0=
 github.com/xanzy/go-gitlab v0.69.0 h1:sPci9xHzlX+lcJvPqNu3y3BQpePuR2R694Bal4AeyB8=


### PR DESCRIPTION
- weave-gitops FE/BE got out of sync

Introduced in #1389 in the last commit or two.

This brings go.mod weave-gitops commit inline w/ the UI one https://github.com/weaveworks/weave-gitops-enterprise/blob/fixes-sources/ui-cra/yarn.lock#L2339