### PR TITLE
feature: Add pipeline CRD

### DIFF
--- a/charts/mccp/crds/pipelines.weave.works_pipelines.yaml
+++ b/charts/mccp/crds/pipelines.weave.works_pipelines.yaml
@@ -1,0 +1,212 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.9.2
+  creationTimestamp: null
+  name: pipelines.pipelines.weave.works
+spec:
+  group: pipelines.weave.works
+  names:
+    kind: Pipeline
+    listKind: PipelineList
+    plural: pipelines
+    singular: pipeline
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.appRef.kind
+      name: App Kind
+      type: string
+    - jsonPath: .spec.appRef.name
+      name: App Name
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Status
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Pipeline is the Schema for the pipelines API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              appRef:
+                description: AppRef denotes the name and type of the application that's
+                  governed by the pipeline.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  kind:
+                    description: Kind of the referent.
+                    enum:
+                    - HelmRelease
+                    type: string
+                  name:
+                    description: Name of the referent.
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+              environments:
+                description: Environments is a list of environments to which the pipeline's
+                  application is supposed to be deployed.
+                items:
+                  properties:
+                    name:
+                      description: Name defines the name of this environment. This
+                        is commonly something such as "dev" or "prod".
+                      type: string
+                    targets:
+                      description: Targets is a list of targets that are part of this
+                        environment. Each environment should have at least one target.
+                      items:
+                        properties:
+                          clusterRef:
+                            description: ClusterRef points to the cluster that's targeted
+                              by this target. If this field is not set, then the target
+                              is assumed to point to a Namespace on the cluster that
+                              the Pipeline resources resides on (i.e. a local target).
+                            properties:
+                              apiVersion:
+                                description: API version of the referent.
+                                type: string
+                              kind:
+                                description: Kind of the referent.
+                                enum:
+                                - GitopsCluster
+                                type: string
+                              name:
+                                description: Name of the referent.
+                                type: string
+                              namespace:
+                                description: Namespace of the referent, defaults to
+                                  the namespace of the Kubernetes resource object
+                                  that contains the reference.
+                                type: string
+                            required:
+                            - kind
+                            - name
+                            type: object
+                          namespace:
+                            description: Namespace denotes the namespace of this target
+                              on the referenced cluster. This is where the app pointed
+                              to by the environment's `appRef` is searched.
+                            type: string
+                        required:
+                        - namespace
+                        type: object
+                      type: array
+                  required:
+                  - name
+                  - targets
+                  type: object
+                type: array
+            required:
+            - appRef
+            - environments
+            type: object
+          status:
+            default:
+              observedGeneration: -1
+            properties:
+              conditions:
+                description: Conditions holds the conditions for the Pipeline.
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    type FooStatus struct{ // Represents the observations of a foo's
+                    current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: ObservedGeneration is the last observed generation.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}


### PR DESCRIPTION
This PR adds the pipeline CRD to the WGE chart so that it gets installed by default. This allows anyone installing WGE to be able to use the pipelines feature immediately after enabling the feature via the `enablePipelines` chart value.

We considered installing this conditionally but this is [not supported](https://github.com/helm/helm/issues/7083) by Helm.

We may remove this in the future as and when we'll need to deploy the pipeline controller. However, the controller is not needed right now.