### PR TITLE
Make CODEOWNERS more specific

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
-/ui-cra/Pipelines  @jpellizzari
+/ui-cra/src/components/Pipelines  @jpellizzari
 /ui-cra/src/components/ProgressiveDelivery  @jpellizzari


### PR DESCRIPTION
Attempting to scope down which parts I get notified on, since I don't really have any special insight on clusters stuff (for example)