### PR TITLE
update semver tag pattern to use 'v' instead of 'r'

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -48,6 +48,7 @@ jobs:
           TAG=$(git describe --always --match "v*" --abbrev=7)
           # Zero fill out the number of commits since the last tag. This allows helm to do a proper sorting of semver rc tags which are sorted alphanumerically.
           # Also the `v` is important as helm's and some other semver parsers do not allow the "rc" bit of the tag to start with a zero.
+          # It is also important to use 'v' to help with semver sorting. Any character after 'r' (for 'rc' tags) will work. 'v' just makes sense.
           ZERO_FILLED_TAG=$(LAST_TAG=$(git describe --abbrev=0); N=$(git rev-list "$LAST_TAG".. --count); REF=$(git rev-parse --short=8 HEAD); printf "$LAST_TAG-v%05d-g$REF" $N)
           SEMVER_TAG=$(awk -F'^v|-g' '{print $2}' <<< $ZERO_FILLED_TAG)
           echo "::set-output name=tag::$TAG"


### PR DESCRIPTION
closes #1504

Update semver tag pattern to resolve issue where latest non-rc release was not being deployed.  Updated patterns looks like this.

```bash
ZERO_FILLED_TAG=$(LAST_TAG=$(git describe --abbrev=0); N=$(git rev-list "$LAST_TAG".. --count); REF=$(git rev-parse --short=8 HEAD); printf "$LAST_TAG-v%05d-g$REF" $N)

echo $ZERO_FILLED_TAG
v0.9.4-v00015-g41d21db5

SEMVER_TAG=$(awk -F'^v|-g' '{print $2}' <<< $ZERO_FILLED_TAG)

echo $SEMVER_TAG     
0.9.4-v00015
```