### PR TITLE
Remove binary upload job from CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,7 +15,8 @@ on:
       WGE_S3_AWS_SECRET_ACCESS_KEY: { required: true }
       WGE_HELM_REPO_USERNAME: { required: false }
       WGE_HELM_REPO_PASSWORD: { required: false }
-      WEAVE_GITOPS_CLUSTERS_GITHUB_WORKLOAD_IDENTITY_PROVIDER: { required: false }
+      WEAVE_GITOPS_CLUSTERS_GITHUB_WORKLOAD_IDENTITY_PROVIDER:
+        { required: false }
       WEAVE_GITOPS_CLUSTERS_GITHUB_SERVICE_ACCOUNT: { required: false }
 
 env:
@@ -165,49 +166,3 @@ jobs:
       - name: Push images to docker registry
         run: |
           docker push docker.io/weaveworks/weave-gitops-enterprise-ui-server:$(./tools/image-tag)
-
-  gitops-binary:
-    runs-on: ${{matrix.os}}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macOS-latest]    
-    steps:
-    - name: Install Go
-      uses: actions/setup-go@v2
-      with:
-        go-version: 1.18.X
-    - name: Checkout code
-      uses: actions/checkout@v3
-    - name: Configure git for private modules
-      run: |
-        git config --global url."https://${GITHUB_BUILD_USERNAME}:${GITHUB_BUILD_TOKEN}@github.com".insteadOf "https://github.com"
-    - name: Install dependencies
-      run: |
-        go mod download
-    - name: Clean
-      run: make clean
-    - id: gitsha
-      run: |
-        gitsha=$(git rev-parse --short ${{ github.sha }})
-        echo "::set-output name=sha::$gitsha"
-    - name: build
-      run: |
-        make cmd/gitops/gitops
-        mv cmd/gitops/gitops cmd/gitops/gitops-${{matrix.os}}
-    - uses: actions/upload-artifact@v2
-      with:
-        name: gitops
-        path: cmd/gitops/gitops-${{matrix.os}}
-        retention-days: 7
-    - name: Configure AWS Credentials
-      if: ${{ (github.ref_name == 'main') && (github.event_name == 'push') }}
-      uses: aws-actions/configure-aws-credentials@v1
-      with:
-        aws-access-key-id: ${{ secrets.WGE_S3_AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.WGE_S3_AWS_SECRET_ACCESS_KEY }}
-        aws-region: eu-central-1
-    - name: Publish gitops binary to s3 
-      if: ${{ (github.ref_name == 'main') && (github.event_name == 'push') }}
-      run: |
-        aws s3 cp cmd/gitops/gitops-${{matrix.os}} s3://weaveworks-wkp/gitops/gitops-${{matrix.os}}
-        aws s3 cp cmd/gitops/gitops-${{matrix.os}} s3://weaveworks-wkp/gitops/gitops-${{matrix.os}}-${{steps.gitsha.outputs.sha}}


### PR DESCRIPTION
It was very gracious of us to test the Go compiler on linux and mac, but I don't think we need to build and upload binaries to S3 in addition to building a docker container. My understanding is that this is not a CLI, so it would not be run on a Mac anyhow.

This job flaked out on me once, hence the reason for this PR.