### PR TITLE
Fix wrong enum value for Kustomization fetching

### DIFF
--- a/ui-cra/src/components/Applications/Kustomization.tsx
+++ b/ui-cra/src/components/Applications/Kustomization.tsx
@@ -30,7 +30,7 @@ const WGApplicationsKustomization: FC<Props> = ({
   } = useGetObject<Kustomization>(
     name,
     namespace,
-    Kind.HelmRepository,
+    Kind.Kustomization,
     clusterName,
   );
   const { path } = useRouteMatch();


### PR DESCRIPTION
Fixes a bug introduced here: https://github.com/weaveworks/weave-gitops-enterprise/commit/461311a886bcd734ceaf7b470fd6c75ba2080e69#diff-9f88b09cce74633e89475ecd7c8f219796fd6752c530b0f24ff8fdb97d2f7e2eR33

The wrong `enum` value was used for fetching a `Kustomization`.