### PR TITLE
Fix CoreClient mock console errors

### DIFF
--- a/ui-cra/src/components/Applications/__tests__/__snapshots__/index.test.tsx.snap
+++ b/ui-cra/src/components/Applications/__tests__/__snapshots__/index.test.tsx.snap
@@ -1552,6 +1552,39 @@ exports[`Applications index test snapshots success 1`] = `
                             <h2
                               class=""
                             >
+                              Cluster
+                            </h2>
+                          </span>
+                          <span
+                            class="MuiTouchRipple-root"
+                          />
+                        </button>
+                        <div
+                          class="c23"
+                        />
+                        <div
+                          style="width: 16px;"
+                        />
+                      </div>
+                    </th>
+                    <th
+                      class="MuiTableCell-root MuiTableCell-head"
+                      scope="col"
+                    >
+                      <div
+                        class="c18"
+                      >
+                        <button
+                          class="MuiButtonBase-root MuiButton-root MuiButton-text c12 c31 MuiButton-colorInherit MuiButton-disableElevation"
+                          tabindex="0"
+                          type="button"
+                        >
+                          <span
+                            class="MuiButton-label"
+                          >
+                            <h2
+                              class=""
+                            >
                               Source
                             </h2>
                           </span>
@@ -1717,11 +1750,11 @@ exports[`Applications index test snapshots success 1`] = `
                 >
                   <tr
                     class="MuiTableRow-root c32"
-                    colspan="8"
+                    colspan="9"
                   >
                     <td
                       class="MuiTableCell-root MuiTableCell-body"
-                      colspan="8"
+                      colspan="9"
                     >
                       <div
                         class="c33"
@@ -1781,6 +1814,56 @@ exports[`Applications index test snapshots success 1`] = `
                     <ul
                       class="MuiList-root MuiList-padding"
                     >
+                      <li
+                        class="MuiListItem-root MuiListItem-gutters"
+                      >
+                        <ul
+                          class="MuiList-root MuiList-padding"
+                        >
+                          <li
+                            class="MuiListItem-root MuiListItem-gutters"
+                          >
+                            <div
+                              class="MuiListItemIcon-root"
+                            >
+                              <span
+                                aria-disabled="true"
+                                class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-48 MuiCheckbox-root MuiCheckbox-colorSecondary PrivateSwitchBase-disabled-50 Mui-disabled MuiIconButton-colorSecondary Mui-disabled Mui-disabled"
+                                tabindex="-1"
+                              >
+                                <span
+                                  class="MuiIconButton-label"
+                                >
+                                  <input
+                                    class="PrivateSwitchBase-input-51"
+                                    data-indeterminate="false"
+                                    disabled=""
+                                    id="clusterName"
+                                    type="checkbox"
+                                    value=""
+                                  />
+                                  <svg
+                                    aria-hidden="true"
+                                    class="MuiSvgIcon-root"
+                                    focusable="false"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <path
+                                      d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </div>
+                            <span
+                              class="c35 c42"
+                              color="neutral30"
+                            >
+                              cluster
+                            </span>
+                          </li>
+                        </ul>
+                      </li>
                       <li
                         class="MuiListItem-root MuiListItem-gutters"
                       >

--- a/ui-cra/src/utils/test-utils.tsx
+++ b/ui-cra/src/utils/test-utils.tsx
@@ -135,16 +135,17 @@ const defaultListObjectsResponse: ListObjectsResponse = {
 export class CoreClientMock {
   constructor() {
     this.ListObjects = this.ListObjects.bind(this);
+    this.GetFeatureFlags = this.GetFeatureFlags.bind(this);
   }
+  GetFeatureFlagsReturns: { flags: { [x: string]: string } } = {
+    flags: {
+      WEAVE_GITOPS_FEATURE_CLUSTER: 'true',
+    },
+  };
   ListObjectsReturns: { [kind: string]: ListObjectsResponse } = {};
 
   GetFeatureFlags() {
-    // FIXME: this is not working
-    return promisify({
-      flags: {
-        WEAVE_GITOPS_FEATURE_CLUSTER: 'true',
-      },
-    });
+    return promisify(this.GetFeatureFlagsReturns);
   }
 
   ListObjects(req: ListObjectsRequest) {


### PR DESCRIPTION
There were some console errors around `api.GetFeatureFlags` being undefined. Tests passed, but there was still console errors. One of the methods was unbound.

As a result, a snapshot needed to be re-rendered with an additional element.