### PR TITLE
Remove filter params from templates navigations

### DIFF
--- a/ui-cra/src/components/Clusters/index.tsx
+++ b/ui-cra/src/components/Clusters/index.tsx
@@ -271,8 +271,7 @@ const MCCP: FC<{
   const history = useHistory();
 
   const handleAddCluster = useCallback(() => {
-    const filtersValues = encodeURIComponent(`templateType: cluster_`);
-    history.push(`/templates?filters=${filtersValues}`);
+    history.push(`/templates`);
   }, [history]);
 
   const initialFilterState = {


### PR DESCRIPTION
- Remove filters params from templates navigation as templates has no labels yet and that break the user experience