### PR TITLE
Replace env variable values in profile annotations

### DIFF
--- a/cmd/clusters-service/pkg/server/template_response.go
+++ b/cmd/clusters-service/pkg/server/template_response.go
@@ -19,11 +19,18 @@ func ToTemplateResponse(t apitemplates.Template) *capiv1_proto.Template {
 	case gapiv1.Kind:
 		annotation = templates.GitOpsTemplateNameAnnotation
 	}
+
+	annotations, err := templates.RenderAnnotationValues(t.GetAnnotations())
+	if err != nil {
+		res := &capiv1_proto.Template{}
+		res.Error = fmt.Sprintf("Couldn't render template annotation values: %s", err.Error())
+	}
+
 	res := &capiv1_proto.Template{
 		Name:         t.GetName(),
 		Description:  t.GetSpec().Description,
 		Provider:     getProvider(t, annotation),
-		Annotations:  t.GetAnnotations(),
+		Annotations:  annotations,
 		Labels:       t.GetLabels(),
 		TemplateKind: templateKind,
 	}


### PR DESCRIPTION
Fixes #1192

**What changed?**
Profile annotation values with env variables are replaced with their value

The value was previously not rendered and was added as a string in the form `${VAR}`

**How did you validate the change?**
Manually tested by getting value returned in the FE with the replaced env variable value


