### PR TITLE
Add `gitops set config` and `gitops get config` commands from WG OSS.

### DIFF
--- a/cmd/gitops/app/get/cmd.go
+++ b/cmd/gitops/app/get/cmd.go
@@ -11,6 +11,7 @@ import (
 	"github.com/weaveworks/weave-gitops-enterprise/cmd/gitops/pkg/adapters"
 	"github.com/weaveworks/weave-gitops/cmd/gitops/config"
 	"github.com/weaveworks/weave-gitops/cmd/gitops/get/bcrypt"
+	configCmd "github.com/weaveworks/weave-gitops/cmd/gitops/get/config"
 )
 
 func Command(opts *config.Options, client *adapters.HTTPClient) *cobra.Command {
@@ -37,6 +38,7 @@ gitops get clusters`,
 	cmd.AddCommand(clusters.GetCommand(opts, client))
 	cmd.AddCommand(profiles.GetCommand(opts, client))
 	cmd.AddCommand(bcrypt.HashCommand(opts))
+	cmd.AddCommand(configCmd.ConfigCommand(opts))
 
 	return cmd
 }

--- a/cmd/gitops/app/root/cmd.go
+++ b/cmd/gitops/app/root/cmd.go
@@ -19,6 +19,7 @@ import (
 	"github.com/weaveworks/weave-gitops/cmd/gitops/check"
 	"github.com/weaveworks/weave-gitops/cmd/gitops/config"
 	"github.com/weaveworks/weave-gitops/cmd/gitops/docs"
+	"github.com/weaveworks/weave-gitops/cmd/gitops/set"
 	"github.com/weaveworks/weave-gitops/cmd/gitops/version"
 	"github.com/weaveworks/weave-gitops/pkg/kube"
 	"github.com/weaveworks/weave-gitops/pkg/utils"
@@ -113,6 +114,7 @@ func Command(client *adapters.HTTPClient) *cobra.Command {
 	rootCmd.AddCommand(docs.Cmd)
 	rootCmd.AddCommand(check.Cmd)
 	rootCmd.AddCommand(beta.GetCommand(options))
+	rootCmd.AddCommand(set.SetCommand(options))
 
 	return rootCmd
 }


### PR DESCRIPTION
Closes
https://github.com/weaveworks/weave-gitops/issues/2772
https://github.com/weaveworks/weave-gitops/issues/2811

- Added support for new WG OSS commands `gitops set config` and `gitops add config` in enterprise.

The user ID set with `gitops set config` will be used with Pendo analytics.

Please see the tickets' acceptance criteria for full examples of running the commands. But in general you can test the commands with `make cmd/gitops/gitops` and running:

```
gitops set config analytics true
gitops get config
```