### PR TITLE
Change flux version in dependencies to v0.35.0

### DIFF
--- a/tools/dependencies.toml
+++ b/tools/dependencies.toml
@@ -1,5 +1,5 @@
 [flux]
-version="0.30.2"
+version="0.35.0"
 special_tarpath="https://github.com/fluxcd/flux2/releases/download/v${version}/flux_${version}_${goos}_${goarch}.tar.gz;flux"
 
 [envtest]


### PR DESCRIPTION

**What changed?**
Flux version upgraded from 0.30.2 to 0.35.0 in dependencies toml file

**Why was this change made?**
An old error appeared when starting local development environment, and so needed an updated flux version that included the fix for it
`Build Failed: kubernetes apply: error mapping source.toolkit.fluxcd.io/OCIRepository: no matches for kind "OCIRepository" in version "source.toolkit.fluxcd.io/v1beta2"`



