### PR TITLE
Fixes applying prune annotation based on Kind

### DIFF
--- a/cmd/clusters-service/pkg/templates/templates.go
+++ b/cmd/clusters-service/pkg/templates/templates.go
@@ -53,6 +53,8 @@ func (lib *CRDLibrary) Get(ctx context.Context, name, templateKind string) (temp
 			lib.Log.Error(err, "Failed to get capitemplate", "template", name)
 			return nil, fmt.Errorf("error getting capitemplate %s/%s: %w", lib.CAPINamespace, name, err)
 		}
+		// https://github.com/kubernetes-sigs/controller-runtime/issues/1517#issuecomment-844703142
+		t.SetGroupVersionKind(capiv1.GroupVersion.WithKind(capiv1.Kind))
 		lib.Log.V(logger.LogLevelDebug).Info("Got capitemplate", "template", name)
 		return &t, nil
 
@@ -67,6 +69,8 @@ func (lib *CRDLibrary) Get(ctx context.Context, name, templateKind string) (temp
 			lib.Log.Error(err, "Failed to get gitops template", "template", name)
 			return nil, fmt.Errorf("error getting gitops template %s/%s: %w", lib.CAPINamespace, name, err)
 		}
+		// https://github.com/kubernetes-sigs/controller-runtime/issues/1517#issuecomment-844703142
+		t.SetGroupVersionKind(gapiv1.GroupVersion.WithKind(gapiv1.Kind))
 		lib.Log.V(logger.LogLevelDebug).Info("Got gitops template", "template", name)
 		return &t, nil
 	}

--- a/test/acceptance/test/utils.go
+++ b/test/acceptance/test/utils.go
@@ -367,6 +367,8 @@ func DumpClusterInfo(testName string) {
 }
 
 func DumpConfigRepo(testName string) {
+	logger.Info("Dumping git-repo...")
+
 	repoPath := "/tmp/config-repo"
 	archiveRepoPath := path.Join(artifacts_base_dir, "config-repo")
 	archivedPath := path.Join(archiveRepoPath, testName+".tar.gz")


### PR DESCRIPTION
- controller-runtime/client-go doesn't set the GVK on .Get()
  - Seems to be an upstream issue in client-go https://github.com/kubernetes-sigs/controller-runtime/issues/1517
- Works okay for `.List()`

Tested?
- Manually against a real cluster, bug doesn't appear with the fakeclient.