### PR TITLE
Add Github clearing cache CI job

### DIFF
--- a/.github/actions/setup-ssh/action.yaml
+++ b/.github/actions/setup-ssh/action.yaml
@@ -8,7 +8,7 @@ runs:
   using: "composite"
   steps:
     - name: Set up ssh agent
-      uses: webfactory/ssh-agent@v0.5.2
+      uses: webfactory/ssh-agent@v0.7.0
       with:
         ssh-private-key: ${{ inputs.ssh-private-key }}
     - name: Add known_hosts

--- a/.github/workflows/acceptance-test.yaml
+++ b/.github/workflows/acceptance-test.yaml
@@ -179,10 +179,10 @@ jobs:
     steps:
       - id: go-cache-paths
         run: |
-          echo "::set-output name=go-build::$(go env GOCACHE)"
-          echo "::set-output name=go-mod::$(go env GOMODCACHE)"
+          echo "go-build=$(go env GOCACHE)" >> $GITHUB_OUTPUT
+          echo "go-mod=$(go env GOMODCACHE)" >> $GITHUB_OUTPUT
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: 1.18.x
       - name: Checkout code
@@ -192,7 +192,7 @@ jobs:
       - name: Go Build Cache
         env:
           GO_CACHE_NAME: cache-go-modules
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ${{ steps.go-cache-paths.outputs.go-build }}
@@ -202,7 +202,7 @@ jobs:
             ${{ runner.os }}-go-build-${{ env.GO_CACHE_NAME }}-
       - name: setup aws credentials
         if: ${{ inputs.management-cluster-kind == 'eks' }}
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           aws-access-key-id: ${{ secrets.WGE_EKS_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.WGE_EKS_AWS_SECRET_ACCESS_KEY }}
@@ -264,11 +264,11 @@ jobs:
         if: ${{ (runner.os == 'macOS') && (inputs.management-cluster-kind == 'kind') }}
         uses: docker-practice/actions-setup-docker@master
       - name: Install helm
-        uses: azure/setup-helm@v2.0
+        uses: azure/setup-helm@v3.3
         with:
           version: v3.8.2
       - name: Install kubectl
-        uses: Azure/setup-kubectl@v2.0
+        uses: Azure/setup-kubectl@v3.0
         with:
           version: ${{ inputs.kubectl-version }}
       - name: Install kind
@@ -312,7 +312,7 @@ jobs:
           tar -xf totp-cli-v1.1.17-${{ inputs.os-name }}-amd64.tar.gz
           mv ./totp-cli /usr/local/bin
       - name: Download gitops binary
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: gitops
           path: /tmp
@@ -372,11 +372,11 @@ jobs:
           go test ${{ inputs.label-filter }} -ginkgo.v -ginkgo.junit-report=${{ env.ARTIFACTS_BASE_DIR }}/${{ env.TEST_ARTIFACT_NAME }}.xml --timeout=99999s
       - name: Store test results
         if: ${{ always() }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ env.TEST_ARTIFACT_NAME }}
           path: ${{ env.ARTIFACTS_BASE_DIR }}
-          retention-days: 7
+          retention-days: 3
       - name: Reset management cluster
         if: ${{ always() }}
         continue-on-error: true

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -51,15 +51,15 @@ jobs:
           # It is also important to use 'v' to help with semver sorting. Any character after 'r' (for 'rc' tags) will work. 'v' just makes sense.
           ZERO_FILLED_TAG=$(LAST_TAG=$(git describe --abbrev=0); N=$(git rev-list "$LAST_TAG".. --count); REF=$(git rev-parse --short=8 HEAD); printf "$LAST_TAG-v%05d-g$REF" $N)
           SEMVER_TAG=$(awk -F'^v|-g' '{print $2}' <<< $ZERO_FILLED_TAG)
-          echo "::set-output name=tag::$TAG"
-          echo "::set-output name=zero_filled_tag::$ZERO_FILLED_TAG"
-          echo "::set-output name=semver_tag::$SEMVER_TAG"
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
+          echo "zero_filled_tag=$ZERO_FILLED_TAG" >> $GITHUB_OUTPUT
+          echo "semver_tag=$SEMVER_TAG" >> $GITHUB_OUTPUT
       - name: Install Helm v3
-        uses: azure/setup-helm@v1
+        uses: azure/setup-helm@v3.3
         with:
           version: v3.9.0
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           aws-access-key-id: ${{ secrets.WGE_S3_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.WGE_S3_AWS_SECRET_ACCESS_KEY }}
@@ -150,7 +150,7 @@ jobs:
         run: |
           make DOCKER_BUILDKIT=1 GITHUB_BUILD_TOKEN=${GITHUB_BUILD_TOKEN} cmd/clusters-service/.uptodate
       - name: Login to Docker Hub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: docker.io
           username: ${{ secrets.WGE_DOCKER_IO_USER }}
@@ -172,7 +172,7 @@ jobs:
         run: |
           make GITHUB_BUILD_TOKEN=${GITHUB_BUILD_TOKEN} ui-cra/.uptodate
       - name: Login to Docker Hub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: docker.io
           username: ${{ secrets.WGE_DOCKER_IO_USER }}
@@ -188,7 +188,7 @@ jobs:
         os: [ubuntu-latest, macOS-latest]    
     steps:
     - name: Install Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
         go-version: 1.18.X
     - name: Checkout code
@@ -204,19 +204,19 @@ jobs:
     - id: gitsha
       run: |
         gitsha=$(git rev-parse --short ${{ github.sha }})
-        echo "::set-output name=sha::$gitsha"
+        echo "sha=$gitsha" >> $GITHUB_OUTPUT
     - name: build
       run: |
         make cmd/gitops/gitops
         mv cmd/gitops/gitops cmd/gitops/gitops-${{matrix.os}}
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: gitops
         path: cmd/gitops/gitops-${{matrix.os}}
-        retention-days: 7
+        retention-days: 1
     - name: Configure AWS Credentials
       if: ${{ (github.ref_name == 'main') && (github.event_name == 'push') }}
-      uses: aws-actions/configure-aws-credentials@v1
+      uses: aws-actions/configure-aws-credentials@v1-node16
       with:
         aws-access-key-id: ${{ secrets.WGE_S3_AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.WGE_S3_AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -28,7 +28,7 @@ jobs:
       ARTEFACTS_BASE_DIR: /tmp/workspace/test
     steps:
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: 1.18.x
       - name: Checkout code
@@ -61,12 +61,12 @@ jobs:
           # Merge all junit test results
           jrm ${{ env.ARTEFACTS_BASE_DIR }}/combined-test-results.xml '${{ env.ARTEFACTS_BASE_DIR }}/*.xml'
       - name: Store unit test coverage results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: unit-tests-artifacts
           path: |
             ${{ env.ARTEFACTS_BASE_DIR }}
-          retention-days: 7
+          retention-days: 1
 
   smoke-tests-github:
     needs: [build, coverage]
@@ -179,7 +179,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: 1.17.x
       - name: Setup snyk

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -46,7 +46,7 @@ jobs:
       with:
         fetch-depth: 0
     - name: Setup Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
         go-version: 1.18.X
     - name: Configure git for private modules
@@ -61,7 +61,7 @@ jobs:
         echo "GORELEASER_PREVIOUS_TAG=$(git describe --abbrev=0 --tags $(git rev-list --tags --skip=1 --max-count=1))" >> $GITHUB_ENV
         echo "GORELEASER_CURRENT_TAG=$(git describe --abbrev=0 --tags)" >> $GITHUB_ENV
     - name: Configure AWS Credentials
-      uses: aws-actions/configure-aws-credentials@v1
+      uses: aws-actions/configure-aws-credentials@v1-node16
       with:
         aws-access-key-id: ${{ secrets.WGE_S3_AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.WGE_S3_AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/storage.yaml
+++ b/.github/workflows/storage.yaml
@@ -1,0 +1,28 @@
+on:
+  schedule:
+    - cron: "0 3 * * *"
+  workflow_dispatch:
+
+name: Claim storage
+jobs:
+  clear-cache:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clear cache
+        uses: actions/github-script@v6
+        with:
+          script: |
+            console.log("Cache clearing started")
+            const caches = await github.rest.actions.getActionsCacheList({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            })
+            for (const cache of caches.data.actions_caches) {
+              console.log(cache)    
+              github.rest.actions.deleteActionsCacheById({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                cache_id: cache.id,
+              })          
+            }
+            console.log("Cache clearing completed")

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,13 +19,13 @@ jobs:
     steps:
       - id: go-cache-paths
         run: |
-          echo "::set-output name=go-build::$(go env GOCACHE)"
-          echo "::set-output name=go-mod::$(go env GOMODCACHE)"
+          echo "go-build=$(go env GOCACHE)" >> $GITHUB_OUTPUT
+          echo "go-mod=$(go env GOMODCACHE)" >> $GITHUB_OUTPUT
       - name: echo ref
         run: |
           echo "${{ github.ref }}"
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: 1.18.x
       - name: Configure git for private modules
@@ -36,7 +36,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Go Build Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ${{ steps.go-cache-paths.outputs.go-build }}
@@ -56,10 +56,10 @@ jobs:
     steps:
       - id: go-cache-paths
         run: |
-          echo "::set-output name=go-build::$(go env GOCACHE)"
-          echo "::set-output name=go-mod::$(go env GOMODCACHE)"
+          echo "go-build=$(go env GOCACHE)" >> $GITHUB_OUTPUT
+          echo "go-mod=$(go env GOMODCACHE)" >> $GITHUB_OUTPUT
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: 1.18.x
       - name: Configure git for private modules
@@ -70,7 +70,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Go Build Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ${{ steps.go-cache-paths.outputs.go-build }}
@@ -109,11 +109,11 @@ jobs:
     steps:
       - id: cache-paths
         run: |
-          echo "::set-output name=dir::$(yarn cache dir)"
-          echo "::set-output name=go-build::$(go env GOCACHE)"
-          echo "::set-output name=go-mod::$(go env GOMODCACHE)"
+          echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
+          echo "go-build=$(go env GOCACHE)" >> $GITHUB_OUTPUT
+          echo "go-mod=$(go env GOMODCACHE)" >> $GITHUB_OUTPUT
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: 1.18.x
       - name: Configure git for private modules
@@ -124,7 +124,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Go Build Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ${{ steps.cache-paths.outputs.go-build }}
@@ -133,7 +133,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-${{ github.job }}-${{ env.GO_CACHE_NAME }}-
       - name: Yarn Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ steps.cache-paths.outputs.dir }}
           key: ${{ runner.os }}-${{ env.YARN_CACHE_NAME }}-${{ hashFiles('**/yarn.lock') }}
@@ -158,13 +158,13 @@ jobs:
     steps:
       - id: cache-paths
         run: |
-          echo "::set-output name=dir::$(yarn cache dir)"
-          echo "::set-output name=go-build::$(go env GOCACHE)"
-          echo "::set-output name=go-mod::$(go env GOMODCACHE)"
+          echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
+          echo "go-build=$(go env GOCACHE)" >> $GITHUB_OUTPUT
+          echo "go-mod=$(go env GOMODCACHE)" >> $GITHUB_OUTPUT
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Yarn Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ steps.cache-paths.outputs.dir }}
           key: ${{ runner.os }}-${{ env.YARN_CACHE_NAME }}-${{ hashFiles('**/yarn.lock') }}
@@ -186,11 +186,11 @@ jobs:
     steps:
       - id: cache-paths
         run: |
-          echo "::set-output name=dir::$(yarn cache dir)"
-          echo "::set-output name=go-build::$(go env GOCACHE)"
-          echo "::set-output name=go-mod::$(go env GOMODCACHE)"
+          echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
+          echo "go-build=$(go env GOCACHE)" >> $GITHUB_OUTPUT
+          echo "go-mod=$(go env GOMODCACHE)" >> $GITHUB_OUTPUT
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: 1.18.x
       - name: Configure git for private modules
@@ -201,7 +201,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Go Build Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ${{ steps.cache-paths.outputs.go-build }}
@@ -210,7 +210,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-${{ github.job }}-${{ env.GO_CACHE_NAME }}-
       - name: Yarn Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ steps.cache-paths.outputs.dir }}
           key: ${{ runner.os }}-${{ env.YARN_CACHE_NAME }}-${{ hashFiles('**/yarn.lock') }}
@@ -231,18 +231,18 @@ jobs:
           go test -v -ginkgo.v -run TestMccpUI -ginkgo.label-filter='!(integration, gce, eks, application, upgrade)'  -ginkgo.reportFile=${{ env.ARTIFACTS_BASE_DIR }}/acceptance-test-results.xml --timeout=99999s
       - name: Store integration test results
         if: ${{ always() }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ui-integration-test-artifacts
           path: ${{ env.ARTIFACTS_BASE_DIR }}
           retention-days: 1
       - name: Store test results
         if: ${{ always() }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ui-integration-tests
           path: ${{ env.ARTIFACTS_BASE_DIR }}
-          retention-days: 7
+          retention-days: 1
 
   snyk-checks:
     runs-on: ubuntu-latest
@@ -255,7 +255,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: 1.18.x
       - name: Setup snyk


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Closes

<!--
Describe what has changed in this PR.
For UI changes also include a screenshot.
-->
**What changed?**
- Added a scheduled CI job `claim storage` to clear/delete cache. Job should run daily at 3:00am
- Reduced the retention period of all artefacts to 1 days except for nightlies artefacts. Nightly artefacts are retained for 3 days for debugging test failures.
- Bump some of the Github actions version which uses Node.js 16. This will suppress the warnings around deprecated actions.

<!-- Tell your future self why have you made these changes -->
**Why was this change made?**
To recover the storage space on daily basis so that allowed maximum limit of Github storage space never reached.
