### PR TITLE
default to Pipeline Namespace when querying target cluster

### DIFF
--- a/internal/grpctesting/grpctesting.go
+++ b/internal/grpctesting/grpctesting.go
@@ -38,7 +38,7 @@ func MakeFactoryWithObjects(objects ...client.Object) (client.Client, *clustersm
 	return k8s, factory
 }
 
-func MakeClustersManager(k8s client.Client) *clustersmngrfakes.FakeClustersManager {
+func MakeClustersManager(k8s client.Client, clusters ...string) *clustersmngrfakes.FakeClustersManager {
 	clientsPool := &clustersmngrfakes.FakeClientsPool{}
 
 	clientsPool.ClientsReturns(map[string]client.Client{"Default": k8s})
@@ -46,8 +46,17 @@ func MakeClustersManager(k8s client.Client) *clustersmngrfakes.FakeClustersManag
 		if s == "" {
 			return nil, clustersmngr.ClusterNotFoundError{Cluster: ""}
 		}
+		if len(clusters) == 0 {
+			return k8s, nil
+		}
 
-		return k8s, nil
+		for _, cluster := range clusters {
+			if cluster == s {
+				return k8s, nil
+			}
+		}
+
+		return nil, clustersmngr.ClusterNotFoundError{Cluster: s}
 	}
 
 	nsMap := map[string][]v1.Namespace{"Default": {}}

--- a/pkg/pipelines/server/get.go
+++ b/pkg/pipelines/server/get.go
@@ -50,9 +50,13 @@ func (s *server) GetPipeline(ctx context.Context, msg *pb.GetPipelineRequest) (*
 
 			clusterName := fetcher.ManagementClusterName
 			if t.ClusterRef != nil {
+				ns := t.ClusterRef.Namespace
+				if ns == "" {
+					ns = p.Namespace
+				}
 				clusterName = types.NamespacedName{
 					Name:      t.ClusterRef.Name,
-					Namespace: t.ClusterRef.Namespace,
+					Namespace: ns,
 				}.String()
 			}
 

--- a/pkg/pipelines/server/get_test.go
+++ b/pkg/pipelines/server/get_test.go
@@ -2,6 +2,7 @@ package server_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	helm "github.com/fluxcd/helm-controller/api/v2beta1"
@@ -13,16 +14,19 @@ import (
 	pb "github.com/weaveworks/weave-gitops-enterprise/pkg/api/pipelines"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func TestGetPipeline(t *testing.T) {
 	ctx := context.Background()
 
-	kclient, factory := grpctesting.MakeFactoryWithObjects()
-	serverClient := pipetesting.SetupServer(t, factory, kclient)
+	kclient := fake.NewClientBuilder().WithScheme(grpctesting.BuildScheme()).Build()
 
 	pipelineNamespace := pipetesting.NewNamespace(ctx, t, kclient)
 	targetNamespace := pipetesting.NewNamespace(ctx, t, kclient)
+
+	factory := grpctesting.MakeClustersManager(kclient, "management", fmt.Sprintf("%s/cluster-1", pipelineNamespace.Name))
+	serverClient := pipetesting.SetupServer(t, factory, kclient)
 
 	hr := createHelmRelease(ctx, t, kclient, "app-1", targetNamespace.Name)
 
@@ -51,6 +55,26 @@ func TestGetPipeline(t *testing.T) {
 			Kind:       "GitopsCluster",
 			Name:       "cluster-1",
 			Namespace:  pipelineNamespace.Name,
+		}
+		require.NoError(t, kclient.Create(ctx, p))
+
+		res, err := serverClient.GetPipeline(context.Background(), &pb.GetPipelineRequest{
+			Name:      p.Name,
+			Namespace: pipelineNamespace.Name,
+		})
+		require.NoError(t, err)
+
+		assert.Equal(t, p.Name, res.Pipeline.Name)
+		assert.Equal(t, res.Pipeline.Status.Environments[envName].TargetsStatuses[0].Workloads[0].Version, hr.Spec.Chart.Spec.Version)
+		assert.Equal(t, res.Pipeline.Status.Environments[envName].TargetsStatuses[0].Namespace, targetNamespace.Name)
+	})
+
+	t.Run("cluster ref without Namespace", func(t *testing.T) {
+		p := newPipeline("pipe-3", pipelineNamespace.Name, targetNamespace.Name, envName, hr)
+		p.Spec.Environments[0].Targets[0].ClusterRef = &ctrl.CrossNamespaceClusterReference{
+			APIVersion: ctrl.GroupVersion.String(),
+			Kind:       "GitopsCluster",
+			Name:       "cluster-1",
 		}
 		require.NoError(t, kclient.Create(ctx, p))
 


### PR DESCRIPTION
I had to change the MakeClustersManager func a little so that it's now
possible to pass a list of known clusters to it. If that list is
non-empty then the given cluster name is checked to be in that list
and if it isn't, an error is returned. This is closer to the behaviour
of the actual client and let me implement the unit test properly.

fixes #1748
