### PR TITLE
Fixes panic when encountering a list-clusters error

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,9 +1,7 @@
 on:
   push:
-    branches-ignore:
-      - "main"
-    tags-ignore:
-      - "*"
+    branches:
+      - main
   workflow_dispatch:
 
 name: deploy
@@ -23,8 +21,55 @@ jobs:
       WEAVE_GITOPS_CLUSTERS_GITHUB_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.WEAVE_GITOPS_CLUSTERS_GITHUB_WORKLOAD_IDENTITY_PROVIDER }}
       WEAVE_GITOPS_CLUSTERS_GITHUB_SERVICE_ACCOUNT: ${{ secrets.WEAVE_GITOPS_CLUSTERS_GITHUB_SERVICE_ACCOUNT }}
 
+  coverage:
+    runs-on: ubuntu-latest
+    env:
+      WGE_COVERALLS_TOKEN: ${{ secrets.WGE_COVERALLS_TOKEN }}
+      ARTEFACTS_BASE_DIR: /tmp/workspace/test
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.18.x
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Configure git for private modules
+        env:
+          GITHUB_BUILD_USERNAME: wge-build-bot
+          GITHUB_BUILD_TOKEN: ${{ secrets.BUILD_BOT_PERSONAL_ACCESS_TOKEN }}
+        run: git config --global url."https://${GITHUB_BUILD_USERNAME}:${GITHUB_BUILD_TOKEN}@github.com".insteadOf "https://github.com"
+      - name: Install dependencies
+        run: |
+          go mod download
+          go install github.com/wadey/gocovmerge@latest
+          go install github.com/jstemmer/go-junit-report@latest
+          npm install -g junit-report-merger
+      - name: Install goveralls
+        run: go install github.com/mattn/goveralls@v0.0.11
+      - name: Run unit tests
+        run: |
+          go version
+          mkdir -p ${{ env.ARTEFACTS_BASE_DIR }}
+
+          WKP_DEBUG=true go test -cover -coverprofile=.coverprofile ./cmd/... ./pkg/... | go-junit-report > ${{ env.ARTEFACTS_BASE_DIR }}/test-results.xml
+          cd ${{ github.workspace }}/common && go test -cover -coverprofile=.coverprofile ./... | go-junit-report > ${{ env.ARTEFACTS_BASE_DIR }}/common-results.xml
+          cd ${{ github.workspace }}/cmd/clusters-service && go test -cover -coverprofile=.coverprofile ./... | go-junit-report > ${{ env.ARTEFACTS_BASE_DIR }}/clusters-service-results.xml
+
+          cd ${{ github.workspace }}
+          # Merge all coverage results
+          gocovmerge .coverprofile common/.coverprofile  cmd/clusters-service/.coverprofile > ${{ env.ARTEFACTS_BASE_DIR }}/merged-profiles
+          # Merge all junit test results
+          jrm ${{ env.ARTEFACTS_BASE_DIR }}/combined-test-results.xml '${{ env.ARTEFACTS_BASE_DIR }}/*.xml'
+      - name: Store unit test coverage results
+        uses: actions/upload-artifact@v3
+        with:
+          name: unit-tests-artifacts
+          path: |
+            ${{ env.ARTEFACTS_BASE_DIR }}
+          retention-days: 1
+
   smoke-tests-github:
-    needs: [build]
+    needs: [build, coverage]
     uses: ./.github/workflows/acceptance-test.yaml
     with:
       runs-on: ubuntu-latest
@@ -51,9 +96,69 @@ jobs:
       WGE_GITHUB_PASSWORD: ${{ secrets.WGE_GITHUB_PASSWORD }}
       WGE_GITHUB_MFA_KEY: ${{ secrets.WGE_GITHUB_MFA_KEY }}
 
+  smoke-tests-gitlab:
+    needs: [build, coverage]
+    uses: ./.github/workflows/acceptance-test.yaml
+    with:
+      runs-on: ubuntu-latest
+      os-name: linux
+      timeout-minutes: 60
+      label-filter: "-ginkgo.label-filter='smoke'"
+      kubectl-version: "v1.22.0"
+      login_user_type: "cluster-user"
+      git-provider: gitlab
+      git-provider_hostname: gitlab.com
+      cluster_resource_set: true
+      management-cluster-kind: kind
+      capi_provider: capd
+      gitops-bin-path: /usr/local/bin/gitops
+      test-artifact-name: smoke-tests-gitlab
+    secrets:
+      WGE_CLUSTER_ADMIN_PASSWORD: "${{ secrets.WGE_CLUSTER_ADMIN_PASSWORD }}"
+      WGE_CLUSTER_ADMIN_PASSWORD_HASH: "${{ secrets.WGE_CLUSTER_ADMIN_PASSWORD_HASH }}"
+      WGE_DEX_CLIENT_SECRET: ${{ secrets.WGE_DEX_CLIENT_SECRET }}
+      WGE_GITHUB_TOKEN: ${{ secrets.WGE_GITHUB_TOKEN }}
+      WGE_GIT_PROVIDER_PRIVATE_KEY: ${{ secrets.WGE_SAS_GITLAB_PRIVATE_KEY }}
+      WGE_GITLAB_TOKEN: ${{ secrets.WGE_SAS_GITLAB_TOKEN }}
+      WGE_GITLAB_ORG: ${{ secrets.WGE_SAS_GITLAB_ORG }}
+      WGE_GITLAB_USER: ${{ secrets.WGE_SAS_GITLAB_USER }}
+      WGE_GITLAB_PASSWORD: ${{ secrets.WGE_SAS_GITLAB_PASSWORD }}
+      WGE_GITLAB_CLIENT_ID: ${{ secrets.WGE_SAS_GITLAB_CLIENT_ID }}
+      WGE_GITLAB_CLIENT_SECRET: ${{ secrets.WGE_SAS_GITLAB_CLIENT_SECRET }}
+
+  smoke-tests-gitlab-on-prem:
+    needs: [build, coverage]
+    uses: ./.github/workflows/acceptance-test.yaml
+    with:
+      runs-on: ubuntu-latest
+      os-name: linux
+      timeout-minutes: 60
+      label-filter: "-ginkgo.label-filter='smoke'"
+      kubectl-version: "v1.23.3"
+      login_user_type: "oidc"
+      git-provider: gitlab
+      git-provider_hostname: gitlab.git.dev.weave.works
+      cluster_resource_set: true
+      management-cluster-kind: kind
+      capi_provider: capd
+      gitops-bin-path: /usr/local/bin/gitops
+      test-artifact-name: smoke-tests-gitlab-on-prem
+    secrets:
+      WGE_CLUSTER_ADMIN_PASSWORD: "${{ secrets.WGE_CLUSTER_ADMIN_PASSWORD }}"
+      WGE_CLUSTER_ADMIN_PASSWORD_HASH: "${{ secrets.WGE_CLUSTER_ADMIN_PASSWORD_HASH }}"
+      WGE_DEX_CLIENT_SECRET: ${{ secrets.WGE_DEX_CLIENT_SECRET }}
+      WGE_GITHUB_TOKEN: ${{ secrets.WGE_GITHUB_TOKEN }}
+      WGE_GIT_PROVIDER_PRIVATE_KEY: ${{ secrets.WGE_ON_PREM_GITLAB_PRIVATE_KEY }}
+      WGE_GITLAB_TOKEN: ${{ secrets.WGE_ON_PREM_GITLAB_TOKEN }}
+      WGE_GITLAB_ORG: ${{ secrets.WGE_ON_PREM_GITLAB_ORG }}
+      WGE_GITLAB_USER: ${{ secrets.WGE_ON_PREM_GITLAB_USER }}
+      WGE_GITLAB_PASSWORD: ${{ secrets.WGE_ON_PREM_GITLAB_PASSWORD }}
+      WGE_GITLAB_CLIENT_ID: ${{ secrets.WGE_ON_PREM_GITLAB_CLIENT_ID }}
+      WGE_GITLAB_CLIENT_SECRET: ${{ secrets.WGE_ON_PREM_GITLAB_CLIENT_SECRET }}
+
   smoke-test-results:
     if: ${{ always() }}
-    needs: [smoke-tests-github]
+    needs: [smoke-tests-github, smoke-tests-gitlab, smoke-tests-gitlab-on-prem]
     uses: ./.github/workflows/publish-test-results.yaml
     with:
       runs-on: ubuntu-latest
@@ -62,3 +167,32 @@ jobs:
       slack-notification: false
     secrets:
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+
+  snyk-monitor:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Configure git for private modules
+        env:
+          GITHUB_BUILD_USERNAME: wge-build-bot
+          GITHUB_BUILD_TOKEN: ${{ secrets.BUILD_BOT_PERSONAL_ACCESS_TOKEN }}
+        run: git config --global url."https://${GITHUB_BUILD_USERNAME}:${GITHUB_BUILD_TOKEN}@github.com".insteadOf "https://github.com"
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Install Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.17.x
+      - name: Setup snyk
+        uses: snyk/actions/setup@master
+      - name: Monitor dependencies & license problems with Snyk
+        # Throw an error if the error is "snyk couldn't run".
+        # Don't throw an error on "there are vulnerabilities", those
+        # are notified separately
+        run: |
+          exit_code=0
+          snyk monitor --all-projects --org=product-engineering-ly9 || exit_code=$?
+          if [ $exit_code -gt 1 ]; then
+            exit $exit_code
+          fi
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_API_TOKEN }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,7 +1,9 @@
 on:
   push:
-    branches:
-      - main
+    branches-ignore:
+      - "main"
+    tags-ignore:
+      - "*"
   workflow_dispatch:
 
 concurrency:
@@ -268,3 +270,4 @@ jobs:
           snyk test --org=product-engineering-ly9 --json --file=ui-cra/yarn.lock | snyk-delta
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_API_TOKEN }}
+


### PR DESCRIPTION
github-smoke failing consistently:
- run https://github.com/weaveworks/weave-gitops-enterprise/actions/runs/3321603964/jobs/5489575886
- error: ```  Expected
      <string>: 
  to match regular expression
      <string>: accountId: ""```

This fixes the test and github passes smoke now:
- https://github.com/weaveworks/weave-gitops-enterprise/actions/runs/3322020766/jobs/5492384445
- full `deploy` run: https://github.com/weaveworks/weave-gitops-enterprise/actions/runs/3323152886

Also moves temporary git checkout location to /tmp away from $HOME for safety