### PR TITLE
make dev cluster creation more configurable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,7 @@ tilt_modules
 
 # build flag artifacts
 tools/core-files
+
+# ignore custom scripts and generated config
+/tools/custom/
+/tools/kind-config.yaml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,6 +92,21 @@ reconcile from a GitOps repository in your personal GitHub account. It will also
 create a file containing local settings such as your GitOps repository that the
 enterprise Helm chart will use in the next step.
 
+### Customizing your development environment
+
+#### Custom kind configuration
+
+The `reboot.sh` script has the capability to patch the default kind config
+using custom configuration provided in the `./tools/custom/` directory. Place
+any configuration you'd like in a file matching the pattern `kind-cluster-patch-*.yaml`
+in that directory and it will get merged into the base configuration.
+
+#### Custom scripts
+
+The `reboot.sh` script will execute all scripts it finds in `./tools/custom/` that
+match the file name pattern `*.sh` after creating the cluster and installing
+all components.
+
 ### Start environment
 
 To start the development environment, run

--- a/tools/dependencies.toml
+++ b/tools/dependencies.toml
@@ -25,3 +25,7 @@ binarypath="https://kind.sigs.k8s.io/dl/v${version}/kind-${goos}-${goarch}"
 [clusterctl]
 version="1.1.3"
 binarypath="https://github.com/kubernetes-sigs/cluster-api/releases/download/v${version}/clusterctl-${goos}-${goarch}"
+
+[yq]
+version="4.28.2"
+binarypath="https://github.com/mikefarah/yq/releases/download/v${version}/yq_${goos}_${goarch}"

--- a/tools/reboot.sh
+++ b/tools/reboot.sh
@@ -37,10 +37,17 @@ tool_check() {
 
 do_kind() {
   tool_check "kind"
+  tool_check "yq"
+
+  if [ -n "$(ls "$(dirname "$0")"/custom/kind-cluster-patch-*.yaml 2> /dev/null)" ] ; then
+      "${TOOLS}"/yq eval-all '. as $item ireduce ({}; . *d $item)' "$(dirname "$0")"/kind-cluster-with-extramounts.yaml "$(dirname "$0")"/custom/kind-cluster-patch-*.yaml > "$(dirname "$0")"/kind-config.yaml
+  else
+      cp "$(dirname "$0")"/kind-cluster-with-extramounts.yaml "$(dirname "$0")"/kind-config.yaml
+  fi
 
   ${TOOLS}/kind delete cluster --name "$KIND_CLUSTER_NAME"
   ${TOOLS}/kind create cluster --name "$KIND_CLUSTER_NAME" \
-    --config "$(dirname "$0")/kind-cluster-with-extramounts.yaml"
+    --config "$(dirname "$0")/kind-config.yaml"
 }
 
 do_capi(){
@@ -82,16 +89,29 @@ add_files_to_git(){
   mkdir -p "/tmp/$GITHUB_REPO/clusters/bases/networkpolicy"
   cp "$(dirname "$0")/git-files/wego-admin.yaml" "/tmp/$GITHUB_REPO/clusters/bases/rbac/wego-admin.yaml"
   cp "$(dirname "$0")/git-files/flux-system-networkpolicy.yaml" "/tmp/$GITHUB_REPO/clusters/bases/networkpolicy/flux-system-networkpolicy.yaml"
-  cd "/tmp/$GITHUB_REPO"
+  pushd "/tmp/$GITHUB_REPO"
   git add clusters/bases
   git commit -m "Add wego-admin role"
   git push origin main
+  popd
 }
 
 # Steps we ask you to do in https://docs.gitops.weave.works/docs/cluster-management/getting-started/
 follow_capi_user_guide(){
   add_files_to_git
   kubectl create secret generic my-pat --from-literal GITHUB_TOKEN="$GITHUB_TOKEN" --from-literal GITHUB_USER="$GITHUB_USER" --from-literal GITHUB_REPO="$GITHUB_REPO"
+}
+
+run_custom_scripts(){
+    pwd
+    echo "$(dirname "$0")"
+  for f in "$(dirname "$0")"/custom/*.sh ; do
+      echo "$f"
+      if [ -x "$f" ] ; then
+          echo executing "$f"
+          $f
+      fi
+  done
 }
 
 main() {
@@ -101,6 +121,7 @@ main() {
   do_flux
   create_local_values_file
   follow_capi_user_guide
+  run_custom_scripts
 }
 
 main


### PR DESCRIPTION
This is a two-fold change:

1. devs can now locally maintain YAML files containing kind
   configuration that are merged with the base file in
   ./tools/kind-cluster-with-extramounts.yaml. This lets devs add
   configuration such as custom containerd configuration.
2. devs can now run custom scripts as part of the reboot process by
   placing scripts into ./tools/custom/ that are run when the cluster
   is up. This lets you create resources automatically, e.g. Secrets
   used for SOPS.
