### PR TITLE
UI 1817 disable create target name space if name space is flux system

### DIFF
--- a/ui-cra/src/components/Applications/Add/form/Partials/AppFields.tsx
+++ b/ui-cra/src/components/Applications/Add/form/Partials/AppFields.tsx
@@ -183,16 +183,14 @@ const AppFields: FC<{
     const { value } = event?.target;
 
     let currentAutomation = [...formData.clusterAutomations];
+    currentAutomation[index] = {
+      ...automation,
+      [fieldName as string]: value,
+    };
     if (fieldName === 'target_namespace' && value === 'flux-system') {
       currentAutomation[index] = {
-        ...automation,
+        ...currentAutomation[index],
         createNamespace: false,
-        [fieldName as string]: value,
-      };
-    } else {
-      currentAutomation[index] = {
-        ...automation,
-        [fieldName as string]: value,
       };
     }
 


### PR DESCRIPTION
- Resolve #1817 

What Changes: 
- Disable the target checkbox if target namespace field is = `flux-system`
- Add tooltip when checkbox is disabled