### PR TITLE
Waiting for enterprise controllers to become ready during setup

### DIFF
--- a/test/acceptance/test/cli_add_delete.go
+++ b/test/acceptance/test/cli_add_delete.go
@@ -177,7 +177,7 @@ func DescribeCliAddDelete(gitopsTestRunner GitopsTestRunner) {
 					templateFiles = append(capdTemplateFile, eksTemplateFile...)
 				})
 
-				cmd := fmt.Sprintf(`add cluster --from-template cluster-template-development-0 --set CLUSTER_NAME=%s --set NAMESPACE=%s --set KUBERNETES_VERSION=%s --set CONTROL_PLANE_MACHINE_COUNT=%s --set WORKER_MACHINE_COUNT=%s --branch %s --title %s --url %s --commit-message %s --description %s`,
+				cmd := fmt.Sprintf(`add cluster --from-template cluster-template-development-0 --set CLUSTER_NAME=%s --set NAMESPACE=%s --set KUBERNETES_VERSION=%s --set CONTROL_PLANE_MACHINE_COUNT=%s --set WORKER_MACHINE_COUNT=%s --set INSTALL_CRDS=true --branch %s --title %s --url %s --commit-message %s --description %s`,
 					capdClusterName, capdNamespace, capdK8version, controlPlaneMachineCount, workerMachineCount, capdPRBranch, capdPRTitle, git_repository_url, capdPRCommit, capdPRDescription)
 				stdOut, stdErr = runGitopsCommand(cmd, ASSERTION_30SECONDS_TIME_OUT)
 


### PR DESCRIPTION
**What changed?**
Added wait for enterprise controllers to become ready during initial management cluster setup

<!-- Tell your future self why have you made these changes -->
**Why was this change made?**
The management cluster setup occasionally fails due to resources not being available momentarily
```
+ helm upgrade --install ingress-nginx ingress-nginx/ingress-nginx --namespace ingress-nginx --create-namespace --version 4.0.18 --set controller.service.type=NodePort --set controller.service.nodePorts.https=30080 --set controller.extraArgs.v=4
	Release "ingress-nginx" does not exist. Installing it now.
	Error: Internal error occurred: failed calling webhook "admission.agent.weaveworks": failed to call webhook: Post "[https://policy-agent.flux-system.svc:443/admission?timeout=5s](https://policy-agent.flux-system.svc/admission?timeout=5s)": dial tcp 10.96.30.247:443: connect: connection refused
	+ kubectl wait --for=condition=Ready --timeout=120s -n ingress-nginx --all pod
	error: no matching resources found
```
<!--
Explain to your reviewers the key implementation points, including why you made
certain choices in favour of others. Highlight key areas of the code which need
extra attention, and also indicate which parts are less relevant (eg renaming,
refactoring, etc
-->
