### PR TITLE
Fix test failing due to policy-agent version upgrade

### DIFF
--- a/.github/workflows/acceptance-test.yaml
+++ b/.github/workflows/acceptance-test.yaml
@@ -216,7 +216,7 @@ jobs:
           eksctl get clusters
       - name: Install flux
         run: |
-          curl --silent --location https://github.com/fluxcd/flux2/releases/download/v0.35.0/flux_0.35.0_${{ inputs.os-name }}_amd64.tar.gz | tar xz -C /tmp
+          curl --silent --location https://github.com/fluxcd/flux2/releases/download/v0.36.0/flux_0.36.0_${{ inputs.os-name }}_amd64.tar.gz | tar xz -C /tmp
           sudo mv /tmp/flux /usr/local/bin
           flux version --client
       - name: Install aws-cli

--- a/test/acceptance/test/pages/add_application_page.go
+++ b/test/acceptance/test/pages/add_application_page.go
@@ -56,7 +56,7 @@ func GetAddApplication(webDriver *agouti.Page, appNo ...int) *AddApplication {
 		Cluster:               app.Find(`[id="SELECT CLUSTER-input"]`),
 		RemoveApplication:     app.Find(`button#remove-application`),
 		CreateTargetNamespace: app.First(`input[type="checkbox"]`),
-		SourceHref:            webDriver.First(`div a[class*="Link"]`),
+		SourceHref:            app.FindByXPath(`div[contains(@class, "MuiGrid-container")]/div[2]`),
 	}
 }
 

--- a/test/acceptance/test/pages/policies_page.go
+++ b/test/acceptance/test/pages/policies_page.go
@@ -15,6 +15,7 @@ type PoliciesPage struct {
 type PolicyInformation struct {
 	Name     *agouti.Selection
 	Category *agouti.Selection
+	Mode     *agouti.Selection
 	Tenant   *agouti.Selection
 	Severity *agouti.Selection
 	Cluster  *agouti.Selection
@@ -28,6 +29,7 @@ type PolicyDetailPage struct {
 	Tags            *agouti.MultiSelection
 	Severity        *agouti.Selection
 	Category        *agouti.Selection
+	Mode            *agouti.Selection
 	TargetedK8sKind *agouti.MultiSelection
 	Description     *agouti.Selection
 	HowToSolve      *agouti.Selection
@@ -47,10 +49,11 @@ func (p PoliciesPage) FindPolicyInList(policyName string) *PolicyInformation {
 	return &PolicyInformation{
 		Name:     policy.FindByXPath(`td[1]//a`),
 		Category: policy.FindByXPath(`td[2]`),
-		Tenant:   policy.FindByXPath(`td[3]`),
-		Severity: policy.FindByXPath(`td[4]`),
-		Cluster:  policy.FindByXPath(`td[5]`),
-		Age:      policy.FindByXPath(`td[6]`),
+		Mode:     policy.FindByXPath(`td[3]`),
+		Tenant:   policy.FindByXPath(`td[4]`),
+		Severity: policy.FindByXPath(`td[5]`),
+		Cluster:  policy.FindByXPath(`td[6]`),
+		Age:      policy.FindByXPath(`td[7]`),
 	}
 }
 
@@ -84,6 +87,7 @@ func GetPolicyDetailPage(webDriver *agouti.Page) *PolicyDetailPage {
 		Tags:            webDriver.All(`div[data-testid="Tags"] span`),
 		Severity:        webDriver.Find(`div[data-testid="Severity"]`),
 		Category:        webDriver.Find(`div[data-testid="Category"]`),
+		Mode:            webDriver.Find(`div[data-testid="Mode"]`),
 		TargetedK8sKind: webDriver.All(`div[data-testid="Targeted K8s Kind"] span`),
 		Description:     webDriver.FindByXPath(`//div[text()="Description:"]/following-sibling::*[1]`),
 		HowToSolve:      webDriver.FindByXPath(`//div[text()="How to solve:"]/following-sibling::*[1]`),

--- a/test/acceptance/test/ui_templates.go
+++ b/test/acceptance/test/ui_templates.go
@@ -528,10 +528,11 @@ func DescribeTemplates(gitopsTestRunner GitopsTestRunner) {
 						g.Expect(err).Should(gomega.Succeed())
 					}, ASSERTION_1MINUTE_TIME_OUT).ShouldNot(gomega.HaveOccurred(), "Failed to click 'Download' preview resources")
 					gomega.Eventually(preview.Close.Click).Should(gomega.Succeed())
-					fileList, _ := getArchiveFileList("/Users/saeed/Downloads/resources.zip")
+					fileList, _ := getArchiveFileList(path.Join(os.Getenv("HOME"), "Downloads", "resources.zip"))
 
 					previewResources := []string{
 						"cluster_definition.yaml",
+						path.Join("clusters", leafCluster.Namespace, leafCluster.Name, "clusters-bases-kustomization.yaml"),
 						path.Join("clusters", leafCluster.Namespace, leafCluster.Name, "profiles.yaml"),
 						path.Join("clusters", leafCluster.Namespace, leafCluster.Name, strings.Join([]string{podinfo.TargetNamespace, "namespace.yaml"}, "-")),
 						path.Join("clusters", leafCluster.Namespace, leafCluster.Name, strings.Join([]string{podinfo.Name, podinfo.Namespace, "kustomization.yaml"}, "-")),

--- a/test/utils/data/policies.yaml
+++ b/test/utils/data/policies.yaml
@@ -1,4 +1,4 @@
-apiVersion: pac.weave.works/v2beta1
+apiVersion: pac.weave.works/v2beta2
 kind: Policy
 metadata:
   name: weave.policies.container-running-as-root-acceptance-test
@@ -17,6 +17,7 @@ spec:
     ```
     https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
   category: weave.categories.pod-security
+  provider: kubernetes
   severity: high
   targets: {kinds: [Deployment, Job, ReplicationController, ReplicaSet, DaemonSet, StatefulSet, CronJob]}  
   tags: [pci-dss, cis-benchmark, mitre-attack, nist800-190, gdpr, default]
@@ -100,7 +101,7 @@ spec:
     	kinds[_] = kind
     }
 ---
-apiVersion: pac.weave.works/v2beta1
+apiVersion: pac.weave.works/v2beta2
 kind: Policy
 metadata:
   name: weave.policies.containers-read-only-root-filesystem-acceptance-test
@@ -121,6 +122,7 @@ spec:
     ```
     https://kubernetes.io/docs/concepts/policy/pod-security-policy/#volumes-and-file-systems
   category: weave.categories.pod-security
+  provider: kubernetes
   severity: high
   targets: {kinds: [Deployment, Job, ReplicationController, ReplicaSet, DaemonSet, StatefulSet, CronJob]}
   tags: [mitre-attack, nist800-190]
@@ -176,7 +178,7 @@ spec:
       kinds[_] = kind
     }
 ---
-apiVersion: pac.weave.works/v2beta1
+apiVersion: pac.weave.works/v2beta2
 kind: Policy
 metadata:
   name: weave.policies.container-image-pull-policy-acceptance-test
@@ -201,6 +203,7 @@ spec:
     ```
     https://kubernetes.io/docs/concepts/configuration/overview/#container-images
   category: weave.categories.software-supply-chain
+  provider: kubernetes
   severity: medium
   targets: {kinds: [Deployment, Job, ReplicationController, ReplicaSet, DaemonSet,
       StatefulSet, CronJob]}
@@ -256,7 +259,7 @@ spec:
       kinds[_] = kind
     }
 ---
-apiVersion: pac.weave.works/v2beta1
+apiVersion: pac.weave.works/v2beta2
 kind: Policy
 metadata:
   name: weave.policies.containers-running-with-privilege-escalation-acceptance-test
@@ -282,6 +285,7 @@ spec:
     ```
     https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
   category: weave.categories.pod-security
+  provider: kubernetes
   severity: high
   targets: {kinds: [Deployment, Job, ReplicationController, ReplicaSet, DaemonSet, StatefulSet, CronJob]}  
   tags: [pci-dss, cis-benchmark, mitre-attack, nist800-190, gdpr, default, soc2-type1]

--- a/test/utils/scripts/wego-enterprise.sh
+++ b/test/utils/scripts/wego-enterprise.sh
@@ -71,7 +71,6 @@ function setup {
   fi
   
   helm repo add wkpv3 https://s3.us-east-1.amazonaws.com/weaveworks-wkp/charts-v3/
-  helm repo add profiles-catalog https://raw.githubusercontent.com/weaveworks/weave-gitops-profile-examples/gh-pages
   helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
   helm repo add cert-manager https://charts.jetstack.io
   helm repo update  
@@ -80,7 +79,7 @@ function setup {
   helm upgrade --install \
     cert-manager cert-manager/cert-manager \
     --namespace cert-manager --create-namespace \
-    --version v1.9.1 \
+    --version v1.10.0 \
     --set installCRDs=true
   kubectl wait --for=condition=Ready --timeout=120s -n cert-manager --all pod
 
@@ -249,9 +248,8 @@ function reset {
   kubectl delete ClusterRoleBinding clusters-service-impersonator
   kubectl delete ClusterRole clusters-service-impersonator-role 
   kubectl delete crd capitemplates.capi.weave.works clusterbootstrapconfigs.capi.weave.works
-  # Delete policy agent
   kubectl delete ValidatingWebhookConfiguration policy-agent
-  kubectl delete namespaces policy-system  
+  kubectl delete namespaces flux-system
   # Delete capi provider
   if [ "$CAPI_PROVIDER" == "capa" ]; then
     clusterctl delete --infrastructure aws


### PR DESCRIPTION
- Fixed acceptance tests failing due to policy-agent version upgrade due addition of `Policy Mode' addition
- Fixed acceptance tests failing due to href locator change for add kustomization sources
- Fixed nightly tests failing due to not cleaning/deleting policy-agent after completion of test run on EKS and GKE