### PR TITLE
disable cost estimation by default in dev environments

### DIFF
--- a/tools/dev-values-local.yaml.tpl
+++ b/tools/dev-values-local.yaml.tpl
@@ -2,4 +2,7 @@
 config:
   capi:
     repositoryURL: https://github.com/$GITHUB_USER/$GITHUB_REPO.git
-    
+
+extraEnvVars:
+  - name: WEAVE_GITOPS_FEATURE_COST_ESTIMATION
+    value: "${FEATURE_COST_ESTIMATION}"

--- a/tools/dev-values.yaml
+++ b/tools/dev-values.yaml
@@ -18,7 +18,7 @@ enableTerraformUI: true
 
 extraEnvVars:
   - name: WEAVE_GITOPS_FEATURE_COST_ESTIMATION
-    value: "true"
+    value: ""
 
 extraEnvVarsSecret: ""
 


### PR DESCRIPTION
The feature requires the local environment to be prepared with an AWS account so we should disable it by default.

It can be enabled locally by setting the "FEATURE_COST_ESTIMATION" environment variable when running the `tools/reboot.sh` script, e.g. via the .envrc file.
