### PR TITLE
Allow configuration of the delimiters in templates.

### DIFF
--- a/cmd/clusters-service/pkg/templates/processors.go
+++ b/cmd/clusters-service/pkg/templates/processors.go
@@ -18,6 +18,14 @@ import (
 	"github.com/weaveworks/weave-gitops-enterprise/cmd/clusters-service/api/templates"
 )
 
+// TemplateDelimiterAnnotation can be added to a Template to change the Go
+// template delimiter.
+//
+// It's assumed to be a string with "left,right"
+// By default the delimiters are the standard Go templating delimiters:
+// {{ and }}.
+const TemplateDelimiterAnnotation string = "templates.weave.works/delimiters"
+
 var templateFuncs template.FuncMap = makeTemplateFunctions()
 
 // Processor is a generic template parser/renderer.
@@ -40,7 +48,7 @@ func NewProcessorForTemplate(t templates.Template) (*TemplateProcessor, error) {
 	case "", templates.RenderTypeEnvsubst:
 		return &TemplateProcessor{Processor: NewEnvsubstTemplateProcessor(), Template: t}, nil
 	case templates.RenderTypeTemplating:
-		return &TemplateProcessor{Processor: NewTextTemplateProcessor(), Template: t}, nil
+		return &TemplateProcessor{Processor: NewTextTemplateProcessor(t), Template: t}, nil
 
 	}
 
@@ -177,17 +185,19 @@ func (p TemplateProcessor) RenderTemplates(vars map[string]string, opts ...Rende
 }
 
 // NewTextTemplateProcessor creates and returns a new TextTemplateProcessor.
-func NewTextTemplateProcessor() *TextTemplateProcessor {
-	return &TextTemplateProcessor{}
+func NewTextTemplateProcessor(t templates.Template) *TextTemplateProcessor {
+	return &TextTemplateProcessor{template: t}
 }
 
 // TextProcessor is an implementation of the Processor interface that uses Go's
 // text/template to render templates.
 type TextTemplateProcessor struct {
+	template templates.Template
 }
 
 func (p *TextTemplateProcessor) Render(tmpl []byte, values map[string]string) ([]byte, error) {
-	parsed, err := template.New("capi-template").Funcs(templateFuncs).Parse(string(tmpl))
+	left, right := p.templateDelims()
+	parsed, err := template.New("capi-template").Funcs(templateFuncs).Delims(left, right).Parse(string(tmpl))
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse template: %w", err)
 	}
@@ -198,6 +208,16 @@ func (p *TextTemplateProcessor) Render(tmpl []byte, values map[string]string) ([
 	}
 
 	return out.Bytes(), nil
+}
+
+func (p *TextTemplateProcessor) templateDelims() (string, string) {
+	ann, ok := p.template.GetAnnotations()[TemplateDelimiterAnnotation]
+	if ok {
+		if elems := strings.Split(ann, ","); len(elems) == 2 {
+			return elems[0], elems[1]
+		}
+	}
+	return "{{", "}}"
 }
 
 var paramsRE = regexp.MustCompile(`{{.*\.params\.([A-Za-z0-9_]+).*}}`)

--- a/cmd/clusters-service/pkg/templates/render_test.go
+++ b/cmd/clusters-service/pkg/templates/render_test.go
@@ -574,20 +574,6 @@ func TestRender_unknown_parameter(t *testing.T) {
 	assert.ErrorContains(t, err, "missing required parameter: CLUSTER_NAME")
 }
 
-func writeMultiDoc(t *testing.T, objs [][]byte) string {
-	t.Helper()
-	var out bytes.Buffer
-	for _, v := range objs {
-		if _, err := out.Write([]byte("---\n")); err != nil {
-			t.Fatal(err)
-		}
-		if _, err := out.Write(v); err != nil {
-			t.Fatal(err)
-		}
-	}
-	return out.String()
-}
-
 func TestInjectLabels(t *testing.T) {
 	raw := []byte(`
 apiVersion: cluster.x-k8s.io/v1alpha3
@@ -672,4 +658,18 @@ metadata:
 	if diff := cmp.Diff(want, converted); diff != "" {
 		t.Fatalf("failed to convert to unstructured:\n%s", diff)
 	}
+}
+
+func writeMultiDoc(t *testing.T, objs [][]byte) string {
+	t.Helper()
+	var out bytes.Buffer
+	for _, v := range objs {
+		if _, err := out.Write([]byte("---\n")); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := out.Write(v); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return out.String()
 }

--- a/cmd/clusters-service/pkg/templates/testdata/text-template4.yaml
+++ b/cmd/clusters-service/pkg/templates/testdata/text-template4.yaml
@@ -1,0 +1,35 @@
+apiVersion: capi.weave.works/v1alpha1
+kind: CAPITemplate
+metadata:
+  name: cluster-template-1
+  annotations:
+     templates.weave.works/delimiters: "<<,>>" 
+spec:
+  description: this is test template 1
+  renderType: templating
+  params:
+  - name: CLUSTER_NAME
+    description: This is used for the cluster naming.
+    options: []
+    required: true
+  - name: NAMESPACE
+    required: true
+  - name: CONTROL_PLANE_MACHINE_COUNT
+    required: true
+  - name: KUBERNETES_VERSION
+    required: true
+  resourcetemplates:
+  - apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    kind: KubeadmControlPlane
+    metadata:
+      name: "<< .params.CLUSTER_NAME >>-control-plane"
+      namespace: "<< .params.NAMESPACE >>"
+    spec:
+      machineTemplate:
+        infrastructureRef:
+          apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+          kind: DockerMachineTemplate
+          name: "<< .params.CLUSTER_NAME >>-control-plane"
+          namespace: "<< .params.NAMESPACE >>"
+      replicas: << .params.CONTROL_PLANE_MACHINE_COUNT >>
+      version: "<< .params.KUBERNETES_VERSION >>"


### PR DESCRIPTION
This allows optional configuration of the template delimiters in the event that the defaults {{ and }} are incompatible with the templates.

**What changed?**
An optional annotation on templates to configure the left and right delimiters.

**Why was this change made?**
To simplify escaping `{{` in YAML.

**How was this change implemented?**
```yaml
kind: CAPITemplate
metadata:
  annotations:
    templates.weave.works/delimiters: "${{,}}"
```

**How did you validate the change?**
Tests!

**Release notes**
Support for changing the template delimiters.

**Documentation Changes**
If you need to alter the template delimiters, perhaps because you have a CAPI template that needs `{{` for templating you can change the delimiters by adding an annotation to your template.

```yaml
kind: CAPITemplate
metadata:
  annotations:
    templates.weave.works/delimiters: "${{,}}"
```
This needs to be a comma-separated pair of delimiters, the defaults are `{{` and `}}`.