### PR TITLE
Retain template parameter ordering.

### DIFF
--- a/cmd/clusters-service/pkg/templates/params_test.go
+++ b/cmd/clusters-service/pkg/templates/params_test.go
@@ -19,8 +19,8 @@ func TestParamsFromTemplate(t *testing.T) {
 		},
 		{
 			"testdata/template2.yaml", []Param{
-				{Name: "AWS_NODE_MACHINE_TYPE", Options: []string{"big", "small"}},
 				{Name: "AWS_SSH_KEY_NAME", Description: "A description"},
+				{Name: "AWS_NODE_MACHINE_TYPE", Options: []string{"big", "small"}},
 				{Name: "CLUSTER_NAME"},
 			},
 		},

--- a/cmd/clusters-service/pkg/templates/processors_test.go
+++ b/cmd/clusters-service/pkg/templates/processors_test.go
@@ -58,12 +58,12 @@ func TestProcessor_Params(t *testing.T) {
 			filename: "testdata/template2.yaml",
 			want: []Param{
 				{
-					Name:    "AWS_NODE_MACHINE_TYPE",
-					Options: []string{"big", "small"},
-				},
-				{
 					Name:        "AWS_SSH_KEY_NAME",
 					Description: "A description",
+				},
+				{
+					Name:    "AWS_NODE_MACHINE_TYPE",
+					Options: []string{"big", "small"},
 				},
 				{
 					Name: "CLUSTER_NAME",
@@ -91,13 +91,13 @@ func TestProcessor_Params(t *testing.T) {
 					Options:     []string{},
 				},
 				{
-					Name: "S3_BUCKET_NAME",
-				},
-				{
 					Name:        "TEST_VALUE",
 					Description: "boolean string",
 					Required:    false,
 					Options:     []string{"true", "false"},
+				},
+				{
+					Name: "S3_BUCKET_NAME",
 				},
 			},
 		},
@@ -110,10 +110,9 @@ func TestProcessor_Params(t *testing.T) {
 					Required:    true,
 				},
 				{
-					Name:        "CONTROL_PLANE_MACHINE_COUNT",
-					Description: "Number of control planes",
+					Name:        "NAMESPACE",
+					Description: "Namespace to create the cluster in",
 					Required:    false,
-					Options:     []string{"1", "2", "3"},
 				},
 				{
 					Name:        "KUBERNETES_VERSION",
@@ -122,9 +121,10 @@ func TestProcessor_Params(t *testing.T) {
 					Options:     []string{"1.19.11", "1.21.1", "1.22.0", "1.23.3"},
 				},
 				{
-					Name:        "NAMESPACE",
-					Description: "Namespace to create the cluster in",
+					Name:        "CONTROL_PLANE_MACHINE_COUNT",
+					Description: "Number of control planes",
 					Required:    false,
+					Options:     []string{"1", "2", "3"},
 				},
 				{
 					Name:        "WORKER_MACHINE_COUNT",


### PR DESCRIPTION
**What changed?**
This orders the parsed template parameters by the position they are in in the list of parameters.

If a parameter is not declared in the params, but appears in a template fragment, then it will be sorted by name _after_ all the declared parameters.

**Why was this change made?**
Fixes #1843 

**How was this change implemented?**
Simple reordering after the maps have been calculated using the original ordering, with a fallback.

**How did you validate the change?**
Tests!

**Release notes**
Parameters should now appear in the form in the order in which they are specified in the template parameters list.