### PR TITLE
Add Canary and Pipeline links to automation detail pages

### DIFF
--- a/ui-cra/src/components/Applications/Kustomization.tsx
+++ b/ui-cra/src/components/Applications/Kustomization.tsx
@@ -1,6 +1,8 @@
 import {
+  formatURL,
   Kind,
   KustomizationDetail,
+  LinkResolverProvider,
   useGetObject,
 } from '@weaveworks/weave-gitops';
 import { routeTab } from '@weaveworks/weave-gitops/ui/components/KustomizationDetail';
@@ -18,6 +20,19 @@ type Props = {
   namespace: string;
   clusterName: string;
 };
+
+function resolveLink(obj: string, params: any) {
+  switch (obj) {
+    case 'Canary':
+      return formatURL(Routes.CanaryDetails, params);
+
+    case 'Pipeline':
+      return formatURL(Routes.PipelineDetails, params);
+
+    default:
+      return null;
+  }
+}
 
 const WGApplicationsKustomization: FC<Props> = ({
   name,
@@ -74,11 +89,22 @@ const WGApplicationsKustomization: FC<Props> = ({
           error ? [{ clusterName, namespace, message: error?.message }] : []
         }
       >
-        <KustomizationDetail
-          kustomization={kustomization}
-          customActions={[<EditButton resource={kustomization} />]}
-          customTabs={customTabs}
-        />
+        <LinkResolverProvider
+          resolver={(obj, params) => {
+            const resolved = resolveLink(obj, {
+              clusterName: params.clusterName,
+              namespace: params.namespace,
+              name: params.name,
+            });
+            return resolved || obj;
+          }}
+        >
+          <KustomizationDetail
+            kustomization={kustomization}
+            customActions={[<EditButton resource={kustomization} />]}
+            customTabs={customTabs}
+          />
+        </LinkResolverProvider>
       </ContentWrapper>
     </PageTemplate>
   );

--- a/ui-cra/src/components/ProgressiveDelivery/CanaryDetails/CanaryDetailsSection.tsx
+++ b/ui-cra/src/components/ProgressiveDelivery/CanaryDetails/CanaryDetailsSection.tsx
@@ -2,17 +2,18 @@ import { RouterTab, SubRouterTabs } from '@weaveworks/weave-gitops';
 import styled from 'styled-components';
 import { useCanaryStyle } from '../CanaryStyles';
 
-import CanaryStatus from '../SharedComponent/CanaryStatus';
 import {
   Automation,
   Canary,
 } from '@weaveworks/progressive-delivery/api/prog/types.pb';
+import { Routes } from '../../../utils/nav';
 import YamlView from '../../YamlView';
-import ListEvents from './Events/ListEvents';
 import { getProgressValue } from '../ListCanaries/Table';
-import ListManagedObjects from './ManagedObjects/ListManagedObjects';
+import CanaryStatus from '../SharedComponent/CanaryStatus';
 import { CanaryMetricsTable } from './Analysis/CanaryMetricsTable';
 import DetailsSection from './Details/DetailsSection';
+import ListEvents from './Events/ListEvents';
+import ListManagedObjects from './ManagedObjects/ListManagedObjects';
 
 const TitleWrapper = styled.h2`
   margin: 0px;
@@ -29,7 +30,7 @@ function CanaryDetailsSection({
   automation?: Automation;
 }) {
   const classes = useCanaryStyle();
-  const path = `/applications/delivery/${canary.targetDeployment?.uid}`;
+  const path = Routes.CanaryDetails;
   return (
     <>
       <TitleWrapper>{canary.name}</TitleWrapper>

--- a/ui-cra/src/components/ProgressiveDelivery/ListCanaries/Table/index.tsx
+++ b/ui-cra/src/components/ProgressiveDelivery/ListCanaries/Table/index.tsx
@@ -18,6 +18,7 @@ import { ReactComponent as ABIcon } from '../../../../assets/img/ab.svg';
 import { ReactComponent as BlueGreenIcon } from '../../../../assets/img/blue-green.svg';
 import { ReactComponent as CanaryIcon } from '../../../../assets/img/canary.svg';
 import { ReactComponent as MirroringIcon } from '../../../../assets/img/mirroring.svg';
+import { Routes } from '../../../../utils/nav';
 import { usePolicyStyle } from '../../../Policies/PolicyStyles';
 import { TableWrapper } from '../../../Shared';
 import CanaryStatus from '../../SharedComponent/CanaryStatus';
@@ -120,14 +121,11 @@ export const CanaryTable: FC<Props> = ({ canaries }) => {
             label: 'Name',
             value: (c: Canary) => (
               <Link
-                to={formatURL(
-                  `/applications/delivery/${c.targetDeployment?.uid}`,
-                  {
-                    clusterName: c.clusterName,
-                    namespace: c.namespace,
-                    name: c.name,
-                  },
-                )}
+                to={formatURL(Routes.CanaryDetails, {
+                  clusterName: c.clusterName,
+                  namespace: c.namespace,
+                  name: c.name,
+                })}
                 className={classes.canaryLink}
               >
                 {c.name}

--- a/ui-cra/src/utils/nav.ts
+++ b/ui-cra/src/utils/nav.ts
@@ -35,7 +35,7 @@ export enum Routes {
   Applications = '/applications',
   AddApplication = '/applications/create',
   Canaries = '/applications/delivery',
-  CanaryDetails = '/applications/delivery/:id',
+  CanaryDetails = '/applications/canary_details',
   Pipelines = '/applications/pipelines',
   PipelineDetails = '/applications/pipelines/details',
 


### PR DESCRIPTION
Closes #1661 

Adds links to Canary and Pipeline objects from the `ReconciledObjects` table. Screenshot of the URL that is generated:

![Screenshot from 2022-11-15 09-30-56](https://user-images.githubusercontent.com/2802257/201989366-b2190b4a-b404-493d-930d-c05158762a4b.png)

Also changes the canary details URL scheme to be more consistent with the rest of the app. Old URLs for the Canary details will 404.
