### PR TITLE
Fixes an estimation panic if the template doesn't have any clusters

### DIFF
--- a/pkg/estimation/utils.go
+++ b/pkg/estimation/utils.go
@@ -45,6 +45,9 @@ func reduceEstimates(estimates map[string]*CostEstimate) *CostEstimate {
 			total += v.Low
 			currencies.Insert(v.Currency)
 		}
+		if len(currencies) == 0 {
+			return total, ""
+		}
 		return total, currencies.List()[0]
 	}(estimates)
 	highs := func(m map[string]*CostEstimate) float32 {

--- a/pkg/estimation/utils_test.go
+++ b/pkg/estimation/utils_test.go
@@ -24,6 +24,14 @@ func Test_reduceClusterEstimates(t *testing.T) {
 	}
 }
 
+func Test_reduceEmptyEstimates(t *testing.T) {
+	reduced := reduceEstimates(map[string]*CostEstimate{})
+	want := &CostEstimate{Low: 0, High: 0, Currency: ""}
+	if diff := cmp.Diff(want, reduced); diff != "" {
+		t.Fatalf("failed to reduce:\n%s", diff)
+	}
+}
+
 func Test_mergeStringMaps(t *testing.T) {
 	mergeMapsTests := []struct {
 		name     string


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Closes #1899 

<!--
Describe what has changed in this PR.
For UI changes also include a screenshot.
-->
**What changed?**

Guard against a panic if now clusters are found in the template


<!-- Tell your future self why have you made these changes -->
**Why was this change made?**

To avoid panic'ing on certain templates if cost estimation is enabled

<!--
Explain to your reviewers the key implementation points, including why you made
certain choices in favour of others. Highlight key areas of the code which need
extra attention, and also indicate which parts are less relevant (eg renaming,
refactoring, etc
-->
**How was this change implemented?**


<!--
How have you verified this change/product value? Tested locally?
Added integration/acceptance test(s)?
Unit tests are required.
-->
**How did you validate the change?**

- unit tests

<!--
Is it notable for release? e.g. schema updates, configuration or data migration
required? If so, please mention it.
-->
**Release notes**


<!--
Are there any documentation updates that should be made for these changes? We want to keep these sources up to date:
- user-guide: https://docs.gitops.weave.works
- internal docs: https://github.com/weaveworks/weave-gitops-enterprise/tree/main/docs
-->
**Documentation Changes**
