### PR TITLE
Add turning analytics on during the first gitops CLI run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ TIME_NOW=$(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 CURRENT_DIR := $(shell pwd)
 UPTODATE := .uptodate
 GOOS := $(shell go env GOOS)
+TIER=enterprise
 ifeq ($(GOOS),linux)
 	cgo_ldflags=-linkmode external -w -extldflags "-static"
 else
@@ -195,4 +196,4 @@ tools/core-files/charts/gitops-server/Chart.yaml: tools/core-files/Makefile.$(CO
 	@curl --silent -o tools/core-files/charts/gitops-server/Chart.yaml https://raw.githubusercontent.com/weaveworks/weave-gitops/$(CORE_REVISION)/charts/gitops-server/Chart.yaml
 
 echo-ldflags: tools/core-files/charts/gitops-server/Chart.yaml tools/core-files/Makefile.$(CORE_REVISION)
-	@make --no-print-directory -f Makefile.core -C tools/core-files echo-ldflags VERSION="$(VERSION)-Enterprise-Edition-$(CORE_REVISION)"
+	@make --no-print-directory -f Makefile.core -C tools/core-files echo-ldflags VERSION="$(VERSION)-Enterprise-Edition-$(CORE_REVISION)" TIER="$(TIER)"

--- a/cmd/gitops/app/root/cmd.go
+++ b/cmd/gitops/app/root/cmd.go
@@ -22,6 +22,7 @@ import (
 	"github.com/weaveworks/weave-gitops/cmd/gitops/docs"
 	"github.com/weaveworks/weave-gitops/cmd/gitops/set"
 	"github.com/weaveworks/weave-gitops/cmd/gitops/version"
+	"github.com/weaveworks/weave-gitops/pkg/analytics"
 	analyticsconfig "github.com/weaveworks/weave-gitops/pkg/config"
 	"github.com/weaveworks/weave-gitops/pkg/kube"
 	"github.com/weaveworks/weave-gitops/pkg/utils"
@@ -93,9 +94,7 @@ func Command(client *adapters.HTTPClient) *cobra.Command {
 				os.Exit(1)
 			}
 
-			var gitopsConfig *analyticsconfig.GitopsCLIConfig
-
-			gitopsConfig, err = analyticsconfig.GetConfig(false)
+			gitopsConfig, err := analyticsconfig.GetConfig(false)
 			if err != nil {
 				seed := time.Now().UnixNano()
 
@@ -105,6 +104,10 @@ func Command(client *adapters.HTTPClient) *cobra.Command {
 				}
 
 				_ = analyticsconfig.SaveConfig(gitopsConfig)
+			}
+
+			if gitopsConfig.Analytics {
+				_ = analytics.TrackCommand(cmd, gitopsConfig.UserID)
 			}
 		},
 	}


### PR DESCRIPTION
Closes https://github.com/weaveworks/weave-gitops/issues/2843
Closes https://github.com/weaveworks/weave-gitops/issues/2452
Closes #1622 

- Added turning analytics on by default during the first gitops CLI run.
- Added tracking events with Pendo if analytics is on.