### PR TITLE
Fix Terraform Detail Suspend Status

### DIFF
--- a/ui-cra/src/components/Terraform/TerraformObjectDetail.tsx
+++ b/ui-cra/src/components/Terraform/TerraformObjectDetail.tsx
@@ -118,7 +118,10 @@ function TerraformObjectDetail({ className, ...params }: Props) {
       <ContentWrapper loading={isLoading}>
         <div className={className}>
           <Box paddingBottom={3}>
-            <KubeStatusIndicator conditions={object?.conditions || []} />
+            <KubeStatusIndicator
+              conditions={object?.conditions || []}
+              suspended={object?.suspended}
+            />
           </Box>
           <Box paddingBottom={3}>
             <Flex>


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Closes #1983 

The `KubeStatusIndicator` component was missing the `suspended` prop. Added.

https://user-images.githubusercontent.com/65822698/205365068-712dbdd6-3f82-43b2-a458-cf1d7be159e4.mov
