### PR TITLE
Pendo Agent for Enterprise New

### DIFF
--- a/.github/workflows/acceptance-test.yaml
+++ b/.github/workflows/acceptance-test.yaml
@@ -85,7 +85,7 @@ on:
         required: false
       WGE_GIT_PROVIDER_PRIVATE_KEY:
         description: "Key for accessing git provider e.g. github or gitlab"
-        required: false      
+        required: false
       WGE_GITHUB_TOKEN:
         description: "Token for accessing GitHub"
         required: false
@@ -166,11 +166,13 @@ env:
   CAPI_PROVIDER: ${{ inputs.capi_provider }}
   GITOPS_BIN_PATH: ${{ inputs.gitops-bin-path }}
   ARTIFACTS_BASE_DIR: "/tmp/acceptance-test-artifact"
-  TEST_ARTIFACT_NAME: ${{ inputs.test-artifact-name }}  
+  TEST_ARTIFACT_NAME: ${{ inputs.test-artifact-name }}
   EXP_CLUSTER_RESOURCE_SET: ${{ inputs.cluster_resource_set }}
   USE_GKE_GCLOUD_AUTH_PLUGIN: True
   SELENIUM_DEBUG: true
   CHECKPOINT_DISABLE: 1
+  WEAVE_GITOPS_FEATURE_TEST_ENVIRONMENT: "true"
+  WEAVE_GITOPS_FEATURE_TELEMETRY: "false"
 
 jobs:
   tests:
@@ -200,7 +202,7 @@ jobs:
           key: ${{ runner.os }}-go-build-${{ env.GO_CACHE_NAME }}-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-build-${{ env.GO_CACHE_NAME }}-
-      - name: setup aws credentials        
+      - name: setup aws credentials
         uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           aws-access-key-id: ${{ secrets.WGE_EKS_AWS_ACCESS_KEY_ID }}
@@ -275,7 +277,7 @@ jobs:
           sudo mv ./kubectl /usr/local/bin/kubectl
       - name: Install kind
         if: ${{ (runner.os == 'macOS') && (inputs.management-cluster-kind == 'kind') }}
-        run: |    
+        run: |
           brew update      
           brew install kind          
           kind version
@@ -326,7 +328,7 @@ jobs:
           wget --no-verbose https://chromedriver.storage.googleapis.com/105.0.5195.52/chromedriver_${{ inputs.os-name }}64.zip
           unzip chromedriver_linux64.zip
           sudo mv chromedriver /usr/local/bin
-          chromedriver --version         
+          chromedriver --version
       - name: Install chrome browser
         if: ${{ (runner.os == 'Linux') && (inputs.git-provider_hostname == 'gitlab.com') }}
         run: |

--- a/cmd/clusters-service/app/server.go
+++ b/cmd/clusters-service/app/server.go
@@ -72,6 +72,7 @@ import (
 	core "github.com/weaveworks/weave-gitops/pkg/server"
 	"github.com/weaveworks/weave-gitops/pkg/server/auth"
 	"github.com/weaveworks/weave-gitops/pkg/server/middleware"
+	"github.com/weaveworks/weave-gitops/pkg/telemetry"
 	"google.golang.org/grpc/metadata"
 	authv1 "k8s.io/api/authentication/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -434,6 +435,15 @@ func StartServer(ctx context.Context, log logr.Logger, tempDir string, p Params)
 	mgmtCluster, err := cluster.NewSingleCluster(p.Cluster, rest, clustersManagerScheme, cluster.DefaultKubeConfigOptions...)
 	if err != nil {
 		return fmt.Errorf("could not create mgmt cluster: %w", err)
+	}
+
+	if featureflags.Get("WEAVE_GITOPS_FEATURE_TELEMETRY") != "false" {
+		err := telemetry.InitTelemetry(ctx, mgmtCluster)
+		if err != nil {
+			// If there's an error turning on telemetry, that's not a
+			// thing that should interrupt anything else
+			log.Info("Couldn't enable telemetry", "error", err)
+		}
 	}
 
 	if p.UseK8sCachedClients {

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/sirupsen/logrus v1.9.0
 	github.com/spf13/cobra v1.6.1
 	github.com/stretchr/testify v1.8.1
-	github.com/weaveworks/weave-gitops v0.11.1-0.20221130135351-90e0a6ba98f1
+	github.com/weaveworks/weave-gitops v0.11.1-0.20221205135057-f418a074fab3
 	github.com/weaveworks/weave-gitops-enterprise-credentials v0.0.2
 	github.com/weaveworks/weave-gitops-enterprise/common v0.0.0
 	gopkg.in/yaml.v3 v3.0.1 // indirect
@@ -95,6 +95,7 @@ require (
 	github.com/containerd/console v1.0.3 // indirect
 	github.com/evanphx/json-patch/v5 v5.6.0 // indirect
 	github.com/fatih/camelcase v1.0.0 // indirect
+	github.com/fluxcd/notification-controller/api v0.29.1 // indirect
 	github.com/fluxcd/pkg/apis/event v0.2.0 // indirect
 	github.com/fvbommel/sortorder v1.0.1 // indirect
 	github.com/gobuffalo/flect v0.2.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -418,6 +418,8 @@ github.com/fluxcd/helm-controller/api v0.27.0 h1:Ha5eCS9Xchz+TkbtUNJ6WIeUXYBR/ZX
 github.com/fluxcd/helm-controller/api v0.27.0/go.mod h1:/qCtlP718rveiAL7Mova4fGAk0aZv2qyYQn87zcUNhs=
 github.com/fluxcd/kustomize-controller/api v0.31.0 h1:3KmZa/NYuC1zqc5Qp9jR3pxtkH5P/1UA513xUEJxkUY=
 github.com/fluxcd/kustomize-controller/api v0.31.0/go.mod h1:t2pqIe1SMzdZIAG/aietrg3XpRXmpcubf0uxDJOryEA=
+github.com/fluxcd/notification-controller/api v0.29.1 h1:gNLbJ18TprLPFVYNXpDRNOX42nzLBi/UYj/HPH19nAk=
+github.com/fluxcd/notification-controller/api v0.29.1/go.mod h1:Ve4SE6jeiGlyItvHa7/UpTPOVC6ac5K76Frv1P7hqLw=
 github.com/fluxcd/pkg/apis/acl v0.1.0 h1:EoAl377hDQYL3WqanWCdifauXqXbMyFuK82NnX6pH4Q=
 github.com/fluxcd/pkg/apis/acl v0.1.0/go.mod h1:zfEZzz169Oap034EsDhmCAGgnWlcWmIObZjYMusoXS8=
 github.com/fluxcd/pkg/apis/event v0.2.0 h1:cmAtkZfoEaNVYegI4SFM8XstdRAil3O9AoP+8fpbR34=
@@ -1128,8 +1130,6 @@ github.com/onsi/ginkgo v1.10.3/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+
 github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108oapk=
 github.com/onsi/ginkgo v1.16.4/go.mod h1:dX+/inL/fNMqNlz0e9LfyB9TswhZpCVdJM/Z6Vvnwo0=
 github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=
-github.com/onsi/ginkgo/v2 v2.5.0 h1:TRtrvv2vdQqzkwrQ1ke6vtXf7IK34RBUJafIy1wMwls=
-github.com/onsi/ginkgo/v2 v2.5.0/go.mod h1:Luc4sArBICYCS8THh8v3i3i5CuSZO+RaQRaJoeNwomw=
 github.com/onsi/ginkgo/v2 v2.5.1 h1:auzK7OI497k6x4OvWq+TKAcpcSAlod0doAH72oIN0Jw=
 github.com/onsi/ginkgo/v2 v2.5.1/go.mod h1:63DOGlLAH8+REH8jUGdL3YpCpu7JODesutUjdENfUAc=
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
@@ -1399,12 +1399,8 @@ github.com/weaveworks/progressive-delivery v0.0.0-20220915081124-d9f0c4063521 h1
 github.com/weaveworks/progressive-delivery v0.0.0-20220915081124-d9f0c4063521/go.mod h1:ib0H6jkIMkHnz/2BpE2Lvj/D6xwhiieiWjUwAcoZ+Oo=
 github.com/weaveworks/tf-controller/api v0.0.0-20220829140311-2391c1d66e7c h1:mbiOaxEammDTQX0wWZdJ6cfIgGqP7Zf3zyF+qbeTG0s=
 github.com/weaveworks/tf-controller/api v0.0.0-20220829140311-2391c1d66e7c/go.mod h1:I+QGICmh0CMNJnbJamO6+tfdHvOrceMQdYZcj2AzBVA=
-github.com/weaveworks/weave-gitops v0.11.1-0.20221125144216-383460e732d2 h1:8Ea81lNPiDJ5Hz+7lTYsFj5svqcZ1ETFMtUAxHrOIoY=
-github.com/weaveworks/weave-gitops v0.11.1-0.20221125144216-383460e732d2/go.mod h1:d5c1iK3Bsc5EldK/ylgVomLTE0GRnqS69bZJmbOPBW0=
-github.com/weaveworks/weave-gitops v0.11.1-0.20221128143520-4ab3382ed0c3 h1:Fvwg295P+kv3okFkv0x5KnTUBj4nXSOdi1FnY0YR1pk=
-github.com/weaveworks/weave-gitops v0.11.1-0.20221128143520-4ab3382ed0c3/go.mod h1:d5c1iK3Bsc5EldK/ylgVomLTE0GRnqS69bZJmbOPBW0=
-github.com/weaveworks/weave-gitops v0.11.1-0.20221130135351-90e0a6ba98f1 h1:A7DJju83ise73lQoVAOoh3VY7rVwzo7USGjtdblSzZc=
-github.com/weaveworks/weave-gitops v0.11.1-0.20221130135351-90e0a6ba98f1/go.mod h1:d5c1iK3Bsc5EldK/ylgVomLTE0GRnqS69bZJmbOPBW0=
+github.com/weaveworks/weave-gitops v0.11.1-0.20221205135057-f418a074fab3 h1:vnQ8vGPUTPqVPcz8WEIR50BxkW5NQzNwLqXxCg4KbVs=
+github.com/weaveworks/weave-gitops v0.11.1-0.20221205135057-f418a074fab3/go.mod h1:WB+FykmP+dD0rp7cGv7MZZDkFZWqzB0trfeDZnTjZVw=
 github.com/weaveworks/weave-gitops-enterprise-credentials v0.0.2 h1:7jeiQehqmI4ds6YIq8TW1Vqhlb6V7G2BVRJ8VM3r99I=
 github.com/weaveworks/weave-gitops-enterprise-credentials v0.0.2/go.mod h1:6PMYg+VtSNePnP7EXyNG+/hNRNZ3r0mQtolIZU4s/J0=
 github.com/xanzy/go-gitlab v0.74.0 h1:Ha1cokbjn0PXy6B19t3W324dwM4AOT52fuHr7nERPrc=

--- a/tools/dev-values-local.yaml.tpl
+++ b/tools/dev-values-local.yaml.tpl
@@ -6,3 +6,5 @@ config:
 extraEnvVars:
   - name: WEAVE_GITOPS_FEATURE_COST_ESTIMATION
     value: "${FEATURE_COST_ESTIMATION}"
+  - name: WEAVE_GITOPS_FEATURE_TELEMETRY
+    value: "false"

--- a/tools/dev-values.yaml
+++ b/tools/dev-values.yaml
@@ -19,6 +19,8 @@ enableTerraformUI: true
 extraEnvVars:
   - name: WEAVE_GITOPS_FEATURE_COST_ESTIMATION
     value: ""
+  - name: WEAVE_GITOPS_FEATURE_TELEMETRY
+    value: "false"
 
 extraEnvVarsSecret: ""
 

--- a/ui-cra/package.json
+++ b/ui-cra/package.json
@@ -24,7 +24,7 @@
     "@types/react-syntax-highlighter": "^13.5.2",
     "@types/styled-components": "^5.1.9",
     "@weaveworks/progressive-delivery": "0.0.0-rc13",
-    "@weaveworks/weave-gitops": "0.11.0",
+    "@weaveworks/weave-gitops": "npm:@weaveworks/weave-gitops-main@0.11.0-91-gf418a074",
     "classnames": "^2.3.1",
     "d3-scale": "4.0.0",
     "d3-time": "^3.0.0",

--- a/ui-cra/src/components/Applications/FluxRuntime.tsx
+++ b/ui-cra/src/components/Applications/FluxRuntime.tsx
@@ -33,7 +33,7 @@ const WGApplicationsFluxRuntime: FC = () => {
       ]}
     >
       <ContentWrapper errors={errors} loading={isLoading || crdsLoading}>
-        <FluxRuntime deployments={data?.deployments} crds={crds?.crds} supportMultipleFlux />
+        <FluxRuntime deployments={data?.deployments} crds={crds?.crds} />
       </ContentWrapper>
     </PageTemplate>
   );

--- a/ui-cra/src/components/Navigation.tsx
+++ b/ui-cra/src/components/Navigation.tsx
@@ -201,7 +201,7 @@ export const Navigation: FC = () => {
         {
           name: 'PIPELINES',
           link: Routes.Pipelines,
-          isVisible: !!flagsRes?.flags?.WEAVE_GITOPS_FEATURE_PIPELINES,
+          isVisible: !!flagsRes.flags.WEAVE_GITOPS_FEATURE_PIPELINES,
         },
         {
           name: 'DELIVERY',
@@ -216,7 +216,7 @@ export const Navigation: FC = () => {
       name: 'GITOPS RUN',
       link: Routes.GitOpsRun,
       icon: <GitOpsRun className="gitops-run" />,
-      isVisible: !!flagsRes?.flags?.WEAVE_GITOPS_FEATURE_RUN_UI,
+      isVisible: !!flagsRes.flags.WEAVE_GITOPS_FEATURE_RUN_UI,
     },
     {
       name: 'TEMPLATES',
@@ -227,7 +227,7 @@ export const Navigation: FC = () => {
       name: 'TERRAFORM',
       link: Routes.TerraformObjects,
       icon: <TerraformLogo />,
-      isVisible: !!flagsRes?.flags?.WEAVE_GITOPS_FEATURE_TERRAFORM_UI,
+      isVisible: !!flagsRes.flags.WEAVE_GITOPS_FEATURE_TERRAFORM_UI,
     },
     {
       name: 'FLUX RUNTIME',

--- a/ui-cra/src/components/Policies/PolicyDetails/HeaderSection.tsx
+++ b/ui-cra/src/components/Policies/PolicyDetails/HeaderSection.tsx
@@ -24,7 +24,7 @@ function HeaderSection({
 }: Policy) {
   const classes = usePolicyStyle();
   const { data } = useFeatureFlags();
-  const flags = data?.flags || {};
+  const flags = data.flags;
   const defaultHeaders: Array<SectionRowHeader> = [
     {
       rowkey: 'Policy ID',

--- a/ui-cra/src/components/Policies/Table/index.tsx
+++ b/ui-cra/src/components/Policies/Table/index.tsx
@@ -16,7 +16,7 @@ import Mode from '../Mode';
 
 interface CustomPolicy extends Policy {
   audit?: string;
-  enforce?: string
+  enforce?: string;
 }
 
 interface Props {
@@ -26,11 +26,11 @@ interface Props {
 export const PolicyTable: FC<Props> = ({ policies }) => {
   const classes = usePolicyStyle();
   const { data } = useFeatureFlags();
-  const flags = data?.flags || {};
+  const flags = data.flags;
 
-  policies.forEach((policy) => {
-    policy.audit = policy.modes?.includes('audit') ? 'audit' : ''
-    policy.enforce = policy.modes?.includes('admission') ? 'enforce' : ''
+  policies.forEach(policy => {
+    policy.audit = policy.modes?.includes('audit') ? 'audit' : '';
+    policy.enforce = policy.modes?.includes('admission') ? 'enforce' : '';
   });
 
   let initialFilterState = {
@@ -77,11 +77,13 @@ export const PolicyTable: FC<Props> = ({ policies }) => {
           },
           {
             label: 'Audit',
-            value: ({ audit }) => <Mode modeName={audit}/>,
+            value: ({ audit }) => <Mode modeName={audit} />,
           },
           {
             label: 'Enforce',
-            value: ({ enforce }) => <Mode modeName={enforce? 'admission': ''} />,
+            value: ({ enforce }) => (
+              <Mode modeName={enforce ? 'admission' : ''} />
+            ),
           },
           ...(flags.WEAVE_GITOPS_FEATURE_TENANCY === 'true'
             ? [{ label: 'Tenant', value: 'tenant' }]

--- a/ui-cra/src/components/ResponsiveDrawer.tsx
+++ b/ui-cra/src/components/ResponsiveDrawer.tsx
@@ -15,6 +15,7 @@ import {
   coreClient,
   CoreClientContextProvider,
   LinkResolverProvider,
+  Pendo,
   SignIn,
   theme as weaveTheme,
 } from '@weaveworks/weave-gitops';
@@ -174,6 +175,7 @@ const ResponsiveDrawer = () => {
         <CoreClientContextProvider api={coreClient}>
           <TerraformProvider api={Terraform}>
             <LinkResolverProvider resolver={resolver}>
+              <Pendo defaultTelemetryFlag="true" />
               <Switch>
                 <Route
                   component={() => (

--- a/ui-cra/src/components/Templates/Form/index.tsx
+++ b/ui-cra/src/components/Templates/Form/index.tsx
@@ -301,7 +301,7 @@ const ResourceForm: FC<ResourceFormProps> = ({ template, resource }) => {
   const isKustomizationsEnabled =
     annotations?.['templates.weave.works/kustomizations-enabled'] === 'true';
   const isCostEstimationEnabled =
-    featureFlagsData?.flags?.WEAVE_GITOPS_FEATURE_COST_ESTIMATION === 'true' &&
+    featureFlagsData.flags.WEAVE_GITOPS_FEATURE_COST_ESTIMATION === 'true' &&
     annotations?.['templates.weave.works/cost-estimation-enabled'] !== 'false';
 
   const { profiles, isLoading: profilesIsLoading } = useProfiles(

--- a/ui-cra/yarn.lock
+++ b/ui-cra/yarn.lock
@@ -2335,10 +2335,10 @@
   resolved "https://npm.pkg.github.com/download/@weaveworks/progressive-delivery/0.0.0-rc13/2628159001f4812b90e068e64fae8de6b4e3f2b4#2628159001f4812b90e068e64fae8de6b4e3f2b4"
   integrity sha512-51ET/FrGwKcBUSqRTtaWTTuWQi/y51JQAFYMT6ctOLaiIXSopCyi3alf4aYDZ5TPFAIdOQapJMYiq2HVj5XxOQ==
 
-"@weaveworks/weave-gitops@0.11.0":
-  version "0.11.0"
-  resolved "https://npm.pkg.github.com/download/@weaveworks/weave-gitops/0.11.0/f38302fdc30b1da68683a86313310c1e778810f6#f38302fdc30b1da68683a86313310c1e778810f6"
-  integrity sha512-WVy8Tn1dPn4UFKM1fOEVL44lyDsV0XmTu/mGeLetqoxNcysR4GNN7Kc2jkf/D9cOpcDnyVUISB7cVwhl1D2sFA==
+"@weaveworks/weave-gitops@npm:@weaveworks/weave-gitops-main@0.11.0-91-gf418a074":
+  version "0.11.0-91-gf418a074"
+  resolved "https://npm.pkg.github.com/download/@weaveworks/weave-gitops-main/0.11.0-91-gf418a074/93db0804a5f5f5008fcc018b6e9249d0701771de#93db0804a5f5f5008fcc018b6e9249d0701771de"
+  integrity sha512-oMZFyzri99HcFg6uyDWbI6Ee2I/UqbkWMZCMSPNxMN+sNdkD7CzIf7zDpqR8MasVlmP0gJVOLAO1SUBpYL04Ww==
   dependencies:
     "@material-ui/core" "^4.12.3"
     "@material-ui/icons" "^4.11.2"
@@ -2350,11 +2350,12 @@
     jest-canvas-mock "^2.4.0"
     jest-fail-on-console "^3.0.1"
     jest-worker "^27.5.1"
+    js-sha3 "0.8.0"
     lodash "^4.17.21"
     luxon "^1.27.0"
     mnemonic-browser "^0.0.1"
     postcss "^8.3.11"
-    query-string "^7.0.0"
+    query-string "^4.3.4"
     react "^17.0.2"
     react-dom "^17.0.2"
     react-lottie-player "^1.4.3"
@@ -7656,7 +7657,7 @@ nwsapi@^2.2.0:
   resolved "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz"
   integrity sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ==
 
-object-assign@^4.1.1:
+object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
   integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
@@ -8722,7 +8723,7 @@ quadprog@^1.6.1:
   resolved "https://registry.yarnpkg.com/quadprog/-/quadprog-1.6.1.tgz#1cd3b13700de9553ef939a6fa73d0d55ddb2f082"
   integrity sha512-fN5Jkcjlln/b3pJkseDKREf89JkKIyu6cKIVXisgL6ocKPQ0yTp9n6NZUAq3otEPPw78WZMG9K0o9WsfKyMWJw==
 
-query-string@*, query-string@^7.0.0, query-string@^7.0.1:
+query-string@*, query-string@^7.0.1:
   version "7.1.1"
   resolved "https://registry.npmjs.org/query-string/-/query-string-7.1.1.tgz"
   integrity sha512-MplouLRDHBZSG9z7fpuAAcI7aAYjDLhtsiVZsevsfaHWDS2IDdORKbSd1kWUA+V4zyva/HZoSfpwnYMMQDhb0w==
@@ -8731,6 +8732,14 @@ query-string@*, query-string@^7.0.0, query-string@^7.0.1:
     filter-obj "^1.1.0"
     split-on-first "^1.0.0"
     strict-uri-encode "^2.0.0"
+
+query-string@^4.3.4:
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-4.3.4.tgz#bbb693b9ca915c232515b228b1a02b609043dbeb"
+  integrity sha512-O2XLNDBIg1DnTOa+2XrIwSiXEV8h2KImXUnjhhn2+UsvZ+Es2uyd5CCRTNQlDGbzUQOW3aYCBx9rVA6dzsiY7Q==
+  dependencies:
+    object-assign "^4.1.0"
+    strict-uri-encode "^1.0.0"
 
 queue-microtask@^1.2.2:
   version "1.2.3"
@@ -9778,6 +9787,11 @@ stacktrace-js@^2.0.2:
   version "1.5.0"
   resolved "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz"
   integrity sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=
+
+strict-uri-encode@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
+  integrity sha512-R3f198pcvnB+5IpnBlRkphuE9n46WyVl8I39W/ZUTZLz4nqSP/oLYUrcnJrw462Ds8he4YKMov2efsTIw1BDGQ==
 
 strict-uri-encode@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
WIP, do not merge.

Closes #1941 

- Removed unneeded checks when using feature flags.

- Added `WEAVE_GITOPS_FEATURE_TELEMETRY` to the dev values.

- Turned telemetry off for the acceptance testing workflow.

- Added the `Pendo` component from WG OSS.

- Added initializing telemetry (because in OSS it was moved out of a call to `NewCoreServer`, so, now it must be called separately).

- Added a check for the telemetry feature flag.

- Removed the unused `supportMultipleFlux` prop (which probably became unused after one of the latest UI PRs in OSS).

- Pulled in the latest `main` branch from WG OSS.

Tested it locally, everything seems to work as expected.

Notes:

- For testing Pendo initialization with Tilt, you can turn telemetry on in `dev-values-local.yaml` with setting its value to the `true` string or just removing it from the dev value files (in enterprise. unlike OSS< telemetry is on by default unless it is explicitly set to `false` in the value files).

Then you can run the following code in the browser console, to make sure that Pendo was or was not initialized as expected:

```
console.log(window.pendo)
```

If telemetry is on, a Pendo object will be logged tot he console. If not, it should be undefined.