### PR TITLE
Fix screenshot archiving for ui-integration-tests

### DIFF
--- a/test/integration/test/ui_integration_test.go
+++ b/test/integration/test/ui_integration_test.go
@@ -303,12 +303,10 @@ func TestMccpUI(t *testing.T) {
 	RegisterFailHandler(Fail)
 	// Screenshot on fail
 	RegisterFailHandler(gomegaFail)
-	// Screenshots
-	ARTIFACTS_BASE_DIR := acceptancetest.GetEnv("ARTIFACTS_BASE_DIR", "/tmp/gitops-test/")
-	_ = os.RemoveAll(ARTIFACTS_BASE_DIR)
-	_ = os.MkdirAll(path.Join(ARTIFACTS_BASE_DIR, acceptancetest.SCREENSHOTS_DIR_NAME), 0700)
 	// WKP-UI can be a bit slow
 	SetDefaultEventuallyTimeout(acceptancetest.ASSERTION_5MINUTE_TIME_OUT)
+
+	acceptancetest.SetupTestEnvironment()
 
 	// Load up the acceptance test suite
 	mccpRunner := acceptancetest.DatabaseGitopsTestRunner{Client: cl}


### PR DESCRIPTION
The ui-integration-tests uses the acceptance tests' screenshot functionality, but as it wasn't initializing the acceptance tests' global variables they just ended up in the local directory, which isn't part of the stored artefacts.

This calls SetupTestEnvironment to initialize those variables from env vars, so they go to the correct directory, and removes the artefact cleanup code that's already in SetupTestEnvironment.