### PR TITLE
Turn on polling for terraform requests

### DIFF
--- a/ui-cra/src/components/Terraform/TerraformObjectList.tsx
+++ b/ui-cra/src/components/Terraform/TerraformObjectList.tsx
@@ -1,7 +1,7 @@
 import {
   DataTable,
   formatURL,
-  KubeStatusIndicator,
+  KubeStatusIndicator
 } from '@weaveworks/weave-gitops';
 
 import { Link } from 'react-router-dom';
@@ -73,7 +73,7 @@ function TerraformObjectList({ className }: Props) {
               },
               {
                 value: (tf: TerraformObject) => (
-                  <KubeStatusIndicator conditions={tf.conditions || []} />
+                  <KubeStatusIndicator conditions={tf.conditions || []} suspended={tf.suspended}/>
                 ),
                 label: 'Status',
               },

--- a/ui-cra/src/contexts/ProgressiveDelivery/index.tsx
+++ b/ui-cra/src/contexts/ProgressiveDelivery/index.tsx
@@ -2,17 +2,17 @@ import {
   GetCanaryResponse,
   ListCanariesResponse,
   ListCanaryObjectsResponse,
-  ProgressiveDeliveryService,
+  ProgressiveDeliveryService
 } from '@weaveworks/progressive-delivery';
 import _ from 'lodash';
 import React, { useContext } from 'react';
 import { useQuery } from 'react-query';
 import {
   ListEventsRequest,
-  ListEventsResponse,
+  ListEventsResponse
 } from '../../cluster-services/cluster_services.pb';
-import { EnterpriseClientContext } from '../EnterpriseClient';
 import { formatError } from '../../utils/formatters';
+import { EnterpriseClientContext } from '../EnterpriseClient';
 import useNotifications from './../../contexts/Notifications';
 
 interface Props {
@@ -113,6 +113,7 @@ export function useListEvents(req: ListEventsRequest) {
     () => api.ListEvents(req),
     {
       onError,
+      refetchInterval: 5000,
     },
   );
 }

--- a/ui-cra/src/contexts/Terraform/index.tsx
+++ b/ui-cra/src/contexts/Terraform/index.tsx
@@ -5,7 +5,7 @@ import { QueryClient, useQuery, useQueryClient } from 'react-query';
 import {
   GetTerraformObjectResponse,
   ListTerraformObjectsResponse,
-  Terraform,
+  Terraform
 } from '../../api/terraform/terraform.pb';
 import { formatError } from '../../utils/formatters';
 import useNotifications from './../../contexts/Notifications';
@@ -40,10 +40,8 @@ export function useListTerraformObjects() {
     [TERRAFORM_KEY],
     () => tf.ListTerraformObjects({}),
     {
-      // fetch once only
       retry: false,
-      cacheTime: Infinity,
-      staleTime: Infinity,
+      refetchInterval: 5000,
     },
   );
 }
@@ -65,7 +63,7 @@ export function useGetTerraformObjectDetail(
   return useQuery<GetTerraformObjectResponse, RequestError>(
     [TERRAFORM_KEY, clusterName, namespace, name],
     () => tf.GetTerraformObject({ name, namespace, clusterName }),
-    { onError, enabled },
+    { onError, enabled, refetchInterval: 5000 },
   );
 }
 


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Closes #1984 

<!--
Describe what has changed in this PR.
For UI changes also include a screenshot.
-->
Added a refetch interval of 5 seconds to terraform related requests, and the suspended prop to the object list table's status indicator
