### PR TITLE
Bump sprig to the v3 versions.

### DIFF
--- a/cmd/clusters-service/pkg/templates/processors.go
+++ b/cmd/clusters-service/pkg/templates/processors.go
@@ -14,7 +14,7 @@ import (
 	processor "sigs.k8s.io/cluster-api/cmd/clusterctl/client/yamlprocessor"
 	"sigs.k8s.io/yaml"
 
-	"github.com/Masterminds/sprig"
+	"github.com/Masterminds/sprig/v3"
 	"github.com/weaveworks/weave-gitops-enterprise/cmd/clusters-service/api/templates"
 )
 


### PR DESCRIPTION
Closes #1958 

**What changed?**
This upgrades Sprig which will bring it into line with the version used in the Flux helm-controller.

<!-- Tell your future self why have you made these changes -->
**Why was this change made?**
Bring the functionality in our version into line with the version used in the Flux helm-controller.

<!--
Explain to your reviewers the key implementation points, including why you made
certain choices in favour of others. Highlight key areas of the code which need
extra attention, and also indicate which parts are less relevant (eg renaming,
refactoring, etc
-->
**How was this change implemented?**
Bump the dependency to the same version as used in https://github.com/fluxcd/helm-controller/blob/8d1afa69946faa6c1d849b9cb481c51a5a493c8c/go.mod#L50

(Which is the version used by Helm, it's an indirect dependency for helm-controller)

<!--
How have you verified this change/product value? Tested locally?
Added integration/acceptance test(s)?
Unit tests are required.
-->
**How did you validate the change?**
Tests are still passing.

<!--
Is it notable for release? e.g. schema updates, configuration or data migration
required? If so, please mention it.
-->
**Release notes**


<!--
Are there any documentation updates that should be made for these changes? We want to keep these sources up to date:
- user-guide: https://docs.gitops.weave.works
- internal docs: https://github.com/weaveworks/weave-gitops-enterprise/tree/main/docs
-->
**Documentation Changes**
