### PR TITLE
Give gitops-apps-reader read access to all objects

### DIFF
--- a/charts/mccp/templates/rbac/user_roles.yaml
+++ b/charts/mccp/templates/rbac/user_roles.yaml
@@ -24,33 +24,25 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-gitops-reader: "true"
     {{- end }}
 rules:
-  - apiGroups: [""]
-    resources: ["secrets", "pods", "services"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: ["apps"]
-    resources: ["deployments", "replicasets", "statefulsets"]
-    verbs: ["get", "list", "watch"]
+  - apiGroups: ["*"]
+    resources: ["*"]
+    verbs: [ "get", "list", "watch" ]
+
   - apiGroups: ["kustomize.toolkit.fluxcd.io"]
-    resources: ["kustomizations"]
+    resources: ["*"]
     verbs: ["get", "list", "watch", "patch"]
+
   - apiGroups: ["helm.toolkit.fluxcd.io"]
-    resources: ["helmreleases"]
+    resources: ["*"]
     verbs: ["get", "list", "watch", "patch"]
+
   - apiGroups: ["source.toolkit.fluxcd.io"]
-    resources: ["buckets", "helmcharts", "gitrepositories", "helmrepositories", "ocirepositories"]
+    resources: ["*"]
     verbs: ["get", "list", "watch", "patch"]
-  - apiGroups: [""]
-    resources: ["events"]
-    verbs: ["get", "watch", "list"]
-  - apiGroups: ["autoscaling"]
-    resources: ["horizontalpodautoscalers"]
-    verbs: ["get", "watch", "list"]
+
   - apiGroups: ["infra.contrib.fluxcd.io"]
-    resources: ["terraforms"]
+    resources: ["*"]
     verbs: ["get", "watch", "list", "patch"]
-  - apiGroups: ["apiextensions.k8s.io"]
-    resources: ["customresourcedefinitions"]
-    verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole


### PR DESCRIPTION
Related to https://github.com/weaveworks/weave-gitops/issues/2966

Gives the `gitops-apps-reader` role read access to all K8s objects. The objective here is to make the day 1 experience better by showing all object types in the WGE UI.