### PR TITLE
Add new relic logging in acceptance tests CI

### DIFF
--- a/.github/workflows/acceptance-test.yaml
+++ b/.github/workflows/acceptance-test.yaml
@@ -70,6 +70,11 @@ on:
         description: "GCE leaf cluster kubeconfig path (for connect cluster tests)"
         required: false
         type: string
+      enable-newrelic-logging:
+        description: "Enable sending logs to New Relic to search and query logs"
+        default: false
+        required: false
+        type: boolean
     secrets:
       WGE_CLUSTER_ADMIN_PASSWORD:
         description: "Cluster user admin password"
@@ -134,6 +139,9 @@ on:
       WGE_EKS_AWS_SECRET_ACCESS_KEY:
         description: "AWS user access key secret"
         required: false
+      NEWRELIC_LICENSE_KEY:
+        description: "License key of New Relic account"
+        required: false
 
 env:
   GO_CACHE_NAME: cache-go-modules
@@ -172,6 +180,7 @@ env:
   SELENIUM_DEBUG: true
   CHECKPOINT_DISABLE: 1
   WEAVE_GITOPS_FEATURE_TELEMETRY: "false"
+  NEWRELIC_LICENSE_KEY: ${{ secrets.NEWRELIC_LICENSE_KEY }}
 
 jobs:
   tests:
@@ -361,6 +370,11 @@ jobs:
           fi
 
           ./test/utils/scripts/mgmt-cluster-setup.sh  ${{ inputs.management-cluster-kind }} $(pwd) $CLUSTER_NAME $CLUSTER_REGION
+      - name: Setup newrelic logging
+        if: ${{ inputs.enable-newrelic-logging }}
+        run: |
+          export CLUSTER_NAME=management-${{ github.run_id }}-${{ github.run_number}}
+          ./test/utils/scripts/setup-newrelic-logging.sh
       - name: Run Acceptance tests
         run: |
           export CLUSTER_REPOSITORY=gitops-capi-template-${{ github.run_id }}-$(openssl rand -hex 8)

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -85,6 +85,7 @@ jobs:
       capi_provider: capd
       gitops-bin-path: /usr/local/bin/gitops
       test-artifact-name: smoke-tests-github
+      enable-newrelic-logging: true
     secrets:
       WGE_CLUSTER_ADMIN_PASSWORD: "${{ secrets.WGE_CLUSTER_ADMIN_PASSWORD }}"
       WGE_CLUSTER_ADMIN_PASSWORD_HASH: "${{ secrets.WGE_CLUSTER_ADMIN_PASSWORD_HASH }}"
@@ -97,6 +98,7 @@ jobs:
       WGE_GITHUB_MFA_KEY: ${{ secrets.WGE_GITHUB_MFA_KEY }}
       WGE_EKS_AWS_ACCESS_KEY_ID: ${{ secrets.WGE_EKS_AWS_ACCESS_KEY_ID }}
       WGE_EKS_AWS_SECRET_ACCESS_KEY: ${{ secrets.WGE_EKS_AWS_SECRET_ACCESS_KEY }}
+      NEWRELIC_LICENSE_KEY: ${{ secrets.NEWRELIC_LICENSE_KEY }}
 
   smoke-tests-gitlab:
     needs: [build, coverage]
@@ -115,6 +117,7 @@ jobs:
       capi_provider: capd
       gitops-bin-path: /usr/local/bin/gitops
       test-artifact-name: smoke-tests-gitlab
+      enable-newrelic-logging: true
     secrets:
       WGE_CLUSTER_ADMIN_PASSWORD: "${{ secrets.WGE_CLUSTER_ADMIN_PASSWORD }}"
       WGE_CLUSTER_ADMIN_PASSWORD_HASH: "${{ secrets.WGE_CLUSTER_ADMIN_PASSWORD_HASH }}"
@@ -129,6 +132,7 @@ jobs:
       WGE_GITLAB_CLIENT_SECRET: ${{ secrets.WGE_SAS_GITLAB_CLIENT_SECRET }}
       WGE_EKS_AWS_ACCESS_KEY_ID: ${{ secrets.WGE_EKS_AWS_ACCESS_KEY_ID }}
       WGE_EKS_AWS_SECRET_ACCESS_KEY: ${{ secrets.WGE_EKS_AWS_SECRET_ACCESS_KEY }}
+      NEWRELIC_LICENSE_KEY: ${{ secrets.NEWRELIC_LICENSE_KEY }}
 
   smoke-tests-gitlab-on-prem:
     needs: [build, coverage]
@@ -147,6 +151,7 @@ jobs:
       capi_provider: capd
       gitops-bin-path: /usr/local/bin/gitops
       test-artifact-name: smoke-tests-gitlab-on-prem
+      enable-newrelic-logging: true
     secrets:
       WGE_CLUSTER_ADMIN_PASSWORD: "${{ secrets.WGE_CLUSTER_ADMIN_PASSWORD }}"
       WGE_CLUSTER_ADMIN_PASSWORD_HASH: "${{ secrets.WGE_CLUSTER_ADMIN_PASSWORD_HASH }}"
@@ -161,6 +166,7 @@ jobs:
       WGE_GITLAB_CLIENT_SECRET: ${{ secrets.WGE_ON_PREM_GITLAB_CLIENT_SECRET }}
       WGE_EKS_AWS_ACCESS_KEY_ID: ${{ secrets.WGE_EKS_AWS_ACCESS_KEY_ID }}
       WGE_EKS_AWS_SECRET_ACCESS_KEY: ${{ secrets.WGE_EKS_AWS_SECRET_ACCESS_KEY }}
+      NEWRELIC_LICENSE_KEY: ${{ secrets.NEWRELIC_LICENSE_KEY }}
 
   smoke-test-results:
     if: ${{ always() }}

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -34,6 +34,7 @@ jobs:
       capi_provider: capd
       gitops-bin-path: /usr/local/bin/gitops      
       test-artifact-name: acceptance-tests-kind-gitlab-on-prem
+      enable-newrelic-logging: true
     secrets:
       WGE_CLUSTER_ADMIN_PASSWORD: "${{ secrets.WGE_CLUSTER_ADMIN_PASSWORD }}"
       WGE_CLUSTER_ADMIN_PASSWORD_HASH: "${{ secrets.WGE_CLUSTER_ADMIN_PASSWORD_HASH }}"
@@ -48,6 +49,7 @@ jobs:
       WGE_GITLAB_CLIENT_SECRET: ${{ secrets.WGE_ON_PREM_GITLAB_CLIENT_SECRET }}
       WGE_EKS_AWS_ACCESS_KEY_ID: ${{ secrets.WGE_EKS_AWS_ACCESS_KEY_ID }}
       WGE_EKS_AWS_SECRET_ACCESS_KEY: ${{ secrets.WGE_EKS_AWS_SECRET_ACCESS_KEY }}
+      NEWRELIC_LICENSE_KEY: ${{ secrets.NEWRELIC_LICENSE_KEY }}
 
   acceptance-tests-eks-github:
     needs: [build]
@@ -66,6 +68,7 @@ jobs:
       capi_provider: capa
       gitops-bin-path: /usr/local/bin/gitops      
       test-artifact-name: acceptance-tests-eks-github
+      enable-newrelic-logging: true
     secrets:
       WGE_CLUSTER_ADMIN_PASSWORD: "${{ secrets.WGE_CLUSTER_ADMIN_PASSWORD }}"
       WGE_CLUSTER_ADMIN_PASSWORD_HASH: "${{ secrets.WGE_CLUSTER_ADMIN_PASSWORD_HASH }}"
@@ -79,6 +82,7 @@ jobs:
       WGE_GITHUB_MFA_KEY: ${{ secrets.WGE_GITHUB_MFA_KEY }}
       WGE_EKS_AWS_ACCESS_KEY_ID: ${{ secrets.WGE_EKS_AWS_ACCESS_KEY_ID }}
       WGE_EKS_AWS_SECRET_ACCESS_KEY: ${{ secrets.WGE_EKS_AWS_SECRET_ACCESS_KEY }}
+      NEWRELIC_LICENSE_KEY: ${{ secrets.NEWRELIC_LICENSE_KEY }}
 
   acceptance-tests-gke-gitlab:
     needs: [build]
@@ -97,6 +101,7 @@ jobs:
       capi_provider: capg
       gitops-bin-path: /usr/local/bin/gitops
       test-artifact-name: acceptance-tests-gke-gitlab
+      enable-newrelic-logging: true
     secrets:
       WGE_CLUSTER_ADMIN_PASSWORD: "${{ secrets.WGE_CLUSTER_ADMIN_PASSWORD }}"
       WGE_CLUSTER_ADMIN_PASSWORD_HASH: "${{ secrets.WGE_CLUSTER_ADMIN_PASSWORD_HASH }}"
@@ -114,6 +119,7 @@ jobs:
       GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
       WGE_EKS_AWS_ACCESS_KEY_ID: ${{ secrets.WGE_EKS_AWS_ACCESS_KEY_ID }}
       WGE_EKS_AWS_SECRET_ACCESS_KEY: ${{ secrets.WGE_EKS_AWS_SECRET_ACCESS_KEY }}
+      NEWRELIC_LICENSE_KEY: ${{ secrets.NEWRELIC_LICENSE_KEY }}
 
   acceptance-test-results:
     if: ${{ always() }}

--- a/test/utils/scripts/setup-newrelic-logging.sh
+++ b/test/utils/scripts/setup-newrelic-logging.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+if [[ -z "$CLUSTER_NAME" ]]; then
+    echo "Ensure CLUSTER_NAME has been set"
+    exit 1
+fi
+
+if [[ -z "$NEWRELIC_LICENSE_KEY" ]]; then
+    echo "Ensure NEWRELIC_LICENSE_KEY has been set"
+    exit 1
+fi
+
+# Setup values.yaml for New Relic helm chart
+envsubst <<EOF > values.yaml
+global:
+    licenseKey: $NEWRELIC_LICENSE_KEY
+    cluster: $CLUSTER_NAME
+endpoint: https://log-api.eu.newrelic.com/log/v1
+
+EOF
+
+
+flux create source helm newrelic \
+    --namespace flux-system \
+    --url="https://helm-charts.newrelic.com" \
+    --interval=1m0s
+
+flux create helmrelease newrelic-logging \
+    --namespace=flux-system \
+    --interval=1m0s \
+    --source=HelmRepository/newrelic \
+    --chart=newrelic-logging \
+    --chart-version="1.12.0" \
+    --values=./values.yaml


### PR DESCRIPTION
Closes https://github.com/weaveworks/weaveworks-enablement/issues/29

<!--
Describe what has changed in this PR.
For UI changes also include a screenshot.
-->
**What changed?**
Added:
- New `setup-newrelic-logging` script to install New Relic logging helm release which sends K8s cluster pods logs to a configured new relic account.
- New step in acceptance-test workflow to run the `setup-newrelic-logging` script
- Configuration to enable/disable New Relic logging in acceptance-test workflow
- Enabling New Relic logging for nightly and smoke tests.

**Why was this change made?**
Based on the technical doc and the comments in this issue: https://github.com/weaveworks/weaveworks-enablement/issues/16

**How was this change implemented?**
- Added a `setup-newrelic-logging` script under `tests/utils/scripts/`
- Run the script from the CI workflow
**I saw this was the convention used in the CI workflows**

**How did you validate the change?**
Tested the script on a test cluster and the logs are sent to a test New Relic account. We would need to add a `NEWRELIC_LICENSE_KEY`  github secret before testing this in CI.
