### PR TITLE
Link to terraform objects from reconciled object table

### DIFF
--- a/ui-cra/src/components/Applications/Kustomization.tsx
+++ b/ui-cra/src/components/Applications/Kustomization.tsx
@@ -31,6 +31,8 @@ function resolveLink(obj: string, params: any) {
       return formatURL(Routes.PipelineDetails, params);
     case 'ClusterDashboard':
       return formatClusterDashboardUrl(params.clusterName);
+    case 'Terraform':
+      return formatURL(Routes.TerraformDetail, params);
     default:
       return null;
   }


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Closes #1982 

Adding the terraform type to the link resolver function seems to work right away with linking to terraform objects from the details page. 

https://user-images.githubusercontent.com/65822698/207425758-daff84fe-ac91-4747-a0d6-f346736238f8.mov
