### PR TITLE
gitops run: Update Created column width and time format

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/sirupsen/logrus v1.9.0
 	github.com/spf13/cobra v1.6.1
 	github.com/stretchr/testify v1.8.1
-	github.com/weaveworks/weave-gitops v0.12.0
+	github.com/weaveworks/weave-gitops v0.12.1-0.20221214145601-61f117c89cda
 	github.com/weaveworks/weave-gitops-enterprise-credentials v0.0.2
 	github.com/weaveworks/weave-gitops-enterprise/common v0.0.0
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1397,8 +1397,8 @@ github.com/weaveworks/progressive-delivery v0.0.0-20220915081124-d9f0c4063521 h1
 github.com/weaveworks/progressive-delivery v0.0.0-20220915081124-d9f0c4063521/go.mod h1:ib0H6jkIMkHnz/2BpE2Lvj/D6xwhiieiWjUwAcoZ+Oo=
 github.com/weaveworks/tf-controller/api v0.0.0-20220829140311-2391c1d66e7c h1:mbiOaxEammDTQX0wWZdJ6cfIgGqP7Zf3zyF+qbeTG0s=
 github.com/weaveworks/tf-controller/api v0.0.0-20220829140311-2391c1d66e7c/go.mod h1:I+QGICmh0CMNJnbJamO6+tfdHvOrceMQdYZcj2AzBVA=
-github.com/weaveworks/weave-gitops v0.12.0 h1:MC9jbQITE0GmmNbH7wN1B5bZE/DaREyXwwKF/fYexoo=
-github.com/weaveworks/weave-gitops v0.12.0/go.mod h1:ejNiyHsnDCv2GJpcdiq+DL7/u1h9g5a4IWyvQZ9WnIM=
+github.com/weaveworks/weave-gitops v0.12.1-0.20221214145601-61f117c89cda h1:fiK9zeIX0D3ilnvdBanAyl/12/+n8Hd7ODMUcRH95Ho=
+github.com/weaveworks/weave-gitops v0.12.1-0.20221214145601-61f117c89cda/go.mod h1:ejNiyHsnDCv2GJpcdiq+DL7/u1h9g5a4IWyvQZ9WnIM=
 github.com/weaveworks/weave-gitops-enterprise-credentials v0.0.2 h1:7jeiQehqmI4ds6YIq8TW1Vqhlb6V7G2BVRJ8VM3r99I=
 github.com/weaveworks/weave-gitops-enterprise-credentials v0.0.2/go.mod h1:6PMYg+VtSNePnP7EXyNG+/hNRNZ3r0mQtolIZU4s/J0=
 github.com/xanzy/go-gitlab v0.74.0 h1:Ha1cokbjn0PXy6B19t3W324dwM4AOT52fuHr7nERPrc=

--- a/ui-cra/package.json
+++ b/ui-cra/package.json
@@ -24,7 +24,7 @@
     "@types/react-syntax-highlighter": "^13.5.2",
     "@types/styled-components": "^5.1.9",
     "@weaveworks/progressive-delivery": "0.0.0-rc13",
-    "@weaveworks/weave-gitops": "0.12.0",
+    "@weaveworks/weave-gitops": "npm:@weaveworks/weave-gitops-main@0.12.0-21-g61f117c8",
     "classnames": "^2.3.1",
     "d3-scale": "4.0.0",
     "d3-time": "^3.0.0",

--- a/ui-cra/src/components/GitOpsRun/GitOpsRunTable.tsx
+++ b/ui-cra/src/components/GitOpsRun/GitOpsRunTable.tsx
@@ -77,9 +77,10 @@ const GitOpsRunTable: FC<Props> = ({ sessions }) => {
           {
             label: 'Created',
             value: ({ obj }) => (
-              <Timestamp time={obj.metadata.creationTimestamp} />
+              <Timestamp time={obj.metadata.creationTimestamp} hideSeconds />
             ),
             sortValue: ({ obj }) => obj.metadata.creationTimestamp,
+            minWidth: 175,
           },
         ]}
       />

--- a/ui-cra/yarn.lock
+++ b/ui-cra/yarn.lock
@@ -2335,10 +2335,10 @@
   resolved "https://npm.pkg.github.com/download/@weaveworks/progressive-delivery/0.0.0-rc13/2628159001f4812b90e068e64fae8de6b4e3f2b4#2628159001f4812b90e068e64fae8de6b4e3f2b4"
   integrity sha512-51ET/FrGwKcBUSqRTtaWTTuWQi/y51JQAFYMT6ctOLaiIXSopCyi3alf4aYDZ5TPFAIdOQapJMYiq2HVj5XxOQ==
 
-"@weaveworks/weave-gitops@0.12.0":
-  version "0.12.0"
-  resolved "https://npm.pkg.github.com/download/@weaveworks/weave-gitops/0.12.0/2665c14facd667663f1aebb19b306a423faea296#2665c14facd667663f1aebb19b306a423faea296"
-  integrity sha512-s/HNy74rHJfzQ6pVYk1XbfyXkj8aDd3+WFEYqCzKoL4t7sSOLicBpXepHdPalMV9vRUnGQL1G/CDwziH57Q/Pg==
+"@weaveworks/weave-gitops@npm:@weaveworks/weave-gitops-main@0.12.0-21-g61f117c8":
+  version "0.12.0-21-g61f117c8"
+  resolved "https://npm.pkg.github.com/download/@weaveworks/weave-gitops-main/0.12.0-21-g61f117c8/ab2b23f9e2cc70c3c04b1271b086479fd84ac311#ab2b23f9e2cc70c3c04b1271b086479fd84ac311"
+  integrity sha512-WDRLixsI8wl+KdC8BrQr8oKk0sIi+HVBIy2sZMcrl1jhR+VAptohRlADWncx2xhkhm5x+fsoLjVpVK3WHhErfg==
   dependencies:
     "@material-ui/core" "^4.12.3"
     "@material-ui/icons" "^4.11.2"


### PR DESCRIPTION
Closes #2068 

The updated acceptance criteria:
https://github.com/weaveworks/weave-gitops-enterprise/issues/2068#issuecomment-1346584083

- Added min width for the Created column of the GitOps Run sessions table (had to increase it a bit to fit the updated `less than a minute ago` string).
- Added displaying `less than a minute ago` text if the formatted time contains seconds (it can only contain the largest units, so only like `5 minutes ago` not `5 minutes and 30 seconds ago`).
- Pulled in the latest `main` from OSS.

Tested it, works as expected:

<img width="1510" alt="Screenshot 2022-12-14 at 13 37 12" src="https://user-images.githubusercontent.com/8824708/207600759-c43b617a-acd6-4302-ae59-1bb01dcc91bf.png">

<img width="1521" alt="Screenshot 2022-12-14 at 13 38 19" src="https://user-images.githubusercontent.com/8824708/207600767-ebe2e80c-e450-4a55-86ea-a608dfeec63e.png">

