### PR TITLE
fix: empty namespace for clusterRef in response

### DIFF
--- a/pkg/pipelines/server/get.go
+++ b/pkg/pipelines/server/get.go
@@ -64,14 +64,14 @@ func (s *server) GetPipeline(ctx context.Context, msg *pb.GetPipelineRequest) (*
 			app.SetName(p.Spec.AppRef.Name)
 			app.SetNamespace(t.Namespace)
 			clusterName := s.cluster
+			clusterNamespace := p.Namespace
+			if t.ClusterRef != nil && t.ClusterRef.Namespace != "" {
+				clusterNamespace = t.ClusterRef.Namespace
+			}
 			if t.ClusterRef != nil {
-				ns := t.ClusterRef.Namespace
-				if ns == "" {
-					ns = p.Namespace
-				}
 				clusterName = types.NamespacedName{
 					Name:      t.ClusterRef.Name,
-					Namespace: ns,
+					Namespace: clusterNamespace,
 				}.String()
 			}
 
@@ -100,7 +100,7 @@ func (s *server) GetPipeline(ctx context.Context, msg *pb.GetPipelineRequest) (*
 				clusterRef = pb.ClusterRef{
 					Kind:      t.ClusterRef.Kind,
 					Name:      t.ClusterRef.Name,
-					Namespace: t.ClusterRef.Namespace,
+					Namespace: clusterNamespace,
 				}
 			}
 

--- a/pkg/pipelines/server/get_test.go
+++ b/pkg/pipelines/server/get_test.go
@@ -84,9 +84,12 @@ func TestGetPipeline(t *testing.T) {
 		})
 		require.NoError(t, err)
 
+		targetStatus := res.Pipeline.Status.Environments[envName].TargetsStatuses[0]
+
 		assert.Equal(t, p.Name, res.Pipeline.Name)
-		assert.Equal(t, res.Pipeline.Status.Environments[envName].TargetsStatuses[0].Workloads[0].Version, hr.Spec.Chart.Spec.Version)
-		assert.Equal(t, res.Pipeline.Status.Environments[envName].TargetsStatuses[0].Namespace, targetNamespace.Name)
+		assert.Equal(t, hr.Spec.Chart.Spec.Version, targetStatus.Workloads[0].Version)
+		assert.Equal(t, targetNamespace.Name, targetStatus.Namespace)
+		assert.Equal(t, pipelineNamespace.Name, targetStatus.ClusterRef.Namespace)
 	})
 
 	t.Run("invalid app ref", func(t *testing.T) {


### PR DESCRIPTION
**What changed?**
GetPipeline response always contain information about the namespace of a clusterRef. If it's not defined, it will fall back to the namespace of the pipeline.

<!-- Tell your future self why have you made these changes -->
**Why was this change made?**
Because of this issue: https://github.com/weaveworks/pipeline-controller/issues/127

**How was this change implemented?**
Added an extra if statement :laughing: 


**How did you validate the change?**
Extra tests were added.


**Release notes**
Nothing.


**Documentation Changes**
Nothing.


References:
* https://github.com/weaveworks/pipeline-controller/issues/127
