### PR TITLE
Fixed nightly CLI tests failing due to extra column KIND in the output

### DIFF
--- a/test/acceptance/test/ui_templates.go
+++ b/test/acceptance/test/ui_templates.go
@@ -52,7 +52,7 @@ func waitForTemplatesToAppear(templateCpunt int) {
 		gomega.Eventually(func(g gomega.Gomega) {
 			g.Expect(webDriver.Refresh()).ShouldNot(gomega.HaveOccurred())
 			pages.WaitForPageToLoad(webDriver)
-			gomega.Eventually(templatesPage.TemplateHeader).Should(matchers.BeVisible())
+			g.Eventually(templatesPage.TemplateHeader).Should(matchers.BeVisible())
 			g.Eventually(templatesPage.CountTemplateRows).Should(gomega.Equal(templateCpunt))
 		}, ASSERTION_2MINUTE_TIME_OUT, POLL_INTERVAL_5SECONDS).ShouldNot(gomega.HaveOccurred(), "The number of template rows should be equal to number of templates created")
 	})

--- a/test/acceptance/test/utils.go
+++ b/test/acceptance/test/utils.go
@@ -509,3 +509,12 @@ func getArchiveFileList(archiveFile string) ([]string, error) {
 	}
 	return fileList, nil
 }
+
+func StringToLines(s string) (lines []string, err error) {
+	scanner := bufio.NewScanner(strings.NewReader(s))
+	for scanner.Scan() {
+		lines = append(lines, scanner.Text())
+	}
+	err = scanner.Err()
+	return
+}

--- a/test/utils/data/templates/miscellaneous/invalid-cluster-template.yaml
+++ b/test/utils/data/templates/miscellaneous/invalid-cluster-template.yaml
@@ -1,5 +1,5 @@
-apiVersion: capi.weave.works/v1alpha1
-kind: CAPITemplate
+apiVersion: templates.weave.works/v1alpha1
+kind: GitOpsTemplate
 metadata:
   name: invalid-cluster-template
   namespace: default


### PR DESCRIPTION
- Fixed failing nightly cli tests due to additional column `KIND` in the output.
- Updated couple of tests to have mix of `GitOpsTemplates` and `CapiTemplates`.