### PR TITLE
Pendo: Track if users are coming from OSS or Ent and latest version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/sirupsen/logrus v1.9.0
 	github.com/spf13/cobra v1.6.1
 	github.com/stretchr/testify v1.8.1
-	github.com/weaveworks/weave-gitops v0.13.0
+	github.com/weaveworks/weave-gitops v0.13.1-0.20221223114702-174de8846d9f
 	github.com/weaveworks/weave-gitops-enterprise-credentials v0.0.2
 	github.com/weaveworks/weave-gitops-enterprise/common v0.0.0
 	gopkg.in/yaml.v3 v3.0.1 // indirect
@@ -55,7 +55,7 @@ require (
 	github.com/maxbrunsfeld/counterfeiter/v6 v6.5.0
 	github.com/mkmik/multierror v0.3.0
 	github.com/onsi/ginkgo/v2 v2.5.1
-	github.com/spf13/viper v1.12.0
+	github.com/spf13/viper v1.13.0
 	github.com/weaveworks/cluster-controller v1.4.1
 	github.com/weaveworks/go-checkpoint v0.0.0-20220223124739-fd9899e2b4f2
 	github.com/weaveworks/policy-agent/api v1.0.5-0.20221109123742-b4c76a211b34
@@ -279,7 +279,7 @@ require (
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.0.3-0.20220114050600-8b9d41f48198 // indirect
 	github.com/pelletier/go-toml v1.9.5 // indirect
-	github.com/pelletier/go-toml/v2 v2.0.1 // indirect
+	github.com/pelletier/go-toml/v2 v2.0.5 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_model v0.3.0 // indirect
@@ -295,7 +295,7 @@ require (
 	github.com/spf13/cast v1.5.0 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/src-d/gcfg v1.4.0 // indirect
-	github.com/subosito/gotenv v1.3.0 // indirect
+	github.com/subosito/gotenv v1.4.1 // indirect
 	github.com/tomwright/dasel v1.22.1 // indirect
 	github.com/weaveworks/tf-controller/api v0.0.0-20221220150320-3d0f3743ccb4
 	github.com/xanzy/ssh-agent v0.3.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1154,8 +1154,8 @@ github.com/pelletier/go-toml v1.9.3/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCko
 github.com/pelletier/go-toml v1.9.4/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3ve8=
 github.com/pelletier/go-toml v1.9.5/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
-github.com/pelletier/go-toml/v2 v2.0.1 h1:8e3L2cCQzLFi2CR4g7vGFuFxX7Jl1kKX8gW+iV0GUKU=
-github.com/pelletier/go-toml/v2 v2.0.1/go.mod h1:r9LEWfGN8R5k0VXJ+0BkIe7MYkRdwZOjgMj2KwnJFUo=
+github.com/pelletier/go-toml/v2 v2.0.5 h1:ipoSadvV8oGUjnUbMub59IDPPwfxF694nG/jwbMiyQg=
+github.com/pelletier/go-toml/v2 v2.0.5/go.mod h1:OMHamSCAODeSsVrwwvcJOaoN0LIUIaFVNZzmWyNfXas=
 github.com/peterbourgon/diskv v2.0.1+incompatible h1:UBdAOUP5p4RWqPBg048CAvpKN+vxiaj6gdUUzhl4XmI=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/phayes/checkstyle v0.0.0-20170904204023-bfd46e6a821d/go.mod h1:3OzsM7FXDQlpCiw2j81fOmAwQLnZnLGXVKUzeKQXIAw=
@@ -1318,8 +1318,8 @@ github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DMA2s=
 github.com/spf13/viper v1.8.1/go.mod h1:o0Pch8wJ9BVSWGQMbra6iw0oQ5oktSIBaujf1rJH9Ns=
 github.com/spf13/viper v1.9.0/go.mod h1:+i6ajR7OX2XaiBkrcZJFK21htRk7eDeLg7+O6bhUPP4=
-github.com/spf13/viper v1.12.0 h1:CZ7eSOd3kZoaYDLbXnmzgQI5RlciuXBMA+18HwHRfZQ=
-github.com/spf13/viper v1.12.0/go.mod h1:b6COn30jlNxbm/V2IqWiNWkJ+vZNiMNksliPCiuKtSI=
+github.com/spf13/viper v1.13.0 h1:BWSJ/M+f+3nmdz9bxB+bWX28kkALN2ok11D0rSo8EJU=
+github.com/spf13/viper v1.13.0/go.mod h1:Icm2xNL3/8uyh/wFuB1jI7TiTNKp8632Nwegu+zgdYw=
 github.com/src-d/gcfg v1.4.0 h1:xXbNR5AlLSA315x2UO+fTSSAXCDf+Ar38/6oyGbDKQ4=
 github.com/src-d/gcfg v1.4.0/go.mod h1:p/UMsR43ujA89BJY9duynAwIpvqEujIH/jFlfL7jWoI=
 github.com/ssgreg/nlreturn/v2 v2.2.1/go.mod h1:E/iiPB78hV7Szg2YfRgyIrk1AD6JVMTRkkxBiELzh2I=
@@ -1343,8 +1343,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
-github.com/subosito/gotenv v1.3.0 h1:mjC+YW8QpAdXibNi+vNWgzmgBH4+5l5dCXv8cNysBLI=
-github.com/subosito/gotenv v1.3.0/go.mod h1:YzJjq/33h7nrwdY+iHMhEOEEbW0ovIz0tB6t6PwAXzs=
+github.com/subosito/gotenv v1.4.1 h1:jyEFiXpy21Wm81FBN71l9VoMMV8H8jG+qIK3GCpY6Qs=
+github.com/subosito/gotenv v1.4.1/go.mod h1:ayKnFf/c6rvx/2iiLrJUk1e6plDbT3edrFNGqEflhK0=
 github.com/sylvia7788/contextcheck v1.0.4/go.mod h1:vuPKJMQ7MQ91ZTqfdyreNKwZjyUg6KO+IebVyQDedZQ=
 github.com/tcnksm/go-gitconfig v0.1.2 h1:iiDhRitByXAEyjgBqsKi9QU4o2TNtv9kPP3RgPgXBPw=
 github.com/tcnksm/go-gitconfig v0.1.2/go.mod h1:/8EhP4H7oJZdIPyT+/UIsG87kTzrzM4UsLGSItWYCpE=
@@ -1390,8 +1390,8 @@ github.com/weaveworks/templates-controller v0.1.1 h1:+L2td92fTTmRXsIML5xU8JRlU/V
 github.com/weaveworks/templates-controller v0.1.1/go.mod h1:iLs/20GkUY94KzDhRvmctwun7yX3SGJWs8q0gbTu53I=
 github.com/weaveworks/tf-controller/api v0.0.0-20221220150320-3d0f3743ccb4 h1:RRpzQlhbEC5WjL0jaMEvGUSZ8EsxzdqSSzginwSBTyc=
 github.com/weaveworks/tf-controller/api v0.0.0-20221220150320-3d0f3743ccb4/go.mod h1:VK60b9WR7XEK1DvQNOpKEOlIQ56Qcy5KlAIFksQmUxI=
-github.com/weaveworks/weave-gitops v0.13.0 h1:K5ErGgB5AlmMipRKNpoWWIUeS6RPyet3HonuRCIN0yc=
-github.com/weaveworks/weave-gitops v0.13.0/go.mod h1:nKG4yfaKlp77hPJX+PsOT6ilQA2Z0JGLXpqq3+/ieQo=
+github.com/weaveworks/weave-gitops v0.13.1-0.20221223114702-174de8846d9f h1:SpyeXHmUyc1R8ThdhlF7dzUJZuksdbGIbeNi2nQJd0w=
+github.com/weaveworks/weave-gitops v0.13.1-0.20221223114702-174de8846d9f/go.mod h1:OMe1/WP1fLE1N5eg6x20GB8f2fhj7GUotXe45+l1XQ0=
 github.com/weaveworks/weave-gitops-enterprise-credentials v0.0.2 h1:7jeiQehqmI4ds6YIq8TW1Vqhlb6V7G2BVRJ8VM3r99I=
 github.com/weaveworks/weave-gitops-enterprise-credentials v0.0.2/go.mod h1:6PMYg+VtSNePnP7EXyNG+/hNRNZ3r0mQtolIZU4s/J0=
 github.com/xanzy/go-gitlab v0.76.0 h1:mkmuB27RDVZY/iXR61pEUfIqJ15Iivfu1kc3KZtBICI=

--- a/ui-cra/package.json
+++ b/ui-cra/package.json
@@ -24,7 +24,7 @@
     "@types/react-syntax-highlighter": "^13.5.2",
     "@types/styled-components": "^5.1.9",
     "@weaveworks/progressive-delivery": "0.0.0-rc13",
-    "@weaveworks/weave-gitops": "0.13.0",
+    "@weaveworks/weave-gitops": "npm:@weaveworks/weave-gitops-main@0.13.0-16-g174de884",
     "classnames": "^2.3.1",
     "d3-scale": "4.0.0",
     "d3-time": "^3.0.0",

--- a/ui-cra/src/components/Applications/__tests__/__snapshots__/index.test.tsx.snap
+++ b/ui-cra/src/components/Applications/__tests__/__snapshots__/index.test.tsx.snap
@@ -95,6 +95,11 @@ exports[`Applications index test snapshots loading 1`] = `
   width: 16px;
 }
 
+.c14 {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
 .c10.MuiButton-root {
   height: 32px;
   font-size: 12px;
@@ -110,11 +115,6 @@ exports[`Applications index test snapshots loading 1`] = `
 .c10.MuiButton-outlined {
   padding: 8px 12px;
   border-color: #d8d8d8;
-}
-
-.c14 {
-  -webkit-text-decoration: none;
-  text-decoration: none;
 }
 
 .c5 {
@@ -705,6 +705,15 @@ exports[`Applications index test snapshots success 1`] = `
   width: 16px;
 }
 
+.c22 {
+  padding: 4px;
+}
+
+.c42 {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
 .c10.MuiButton-root {
   height: 32px;
   font-size: 12px;
@@ -731,10 +740,6 @@ exports[`Applications index test snapshots success 1`] = `
 
 .c19.MuiButton-text {
   padding: 0;
-}
-
-.c22 {
-  padding: 4px;
 }
 
 .c20.MuiButton-outlined {
@@ -916,11 +921,6 @@ exports[`Applications index test snapshots success 1`] = `
 
 .c13 .filter-options-chip {
   background-color: #E5F7FD;
-}
-
-.c42 {
-  -webkit-text-decoration: none;
-  text-decoration: none;
 }
 
 .c14 td:nth-child(7) {

--- a/ui-cra/src/components/Pipelines/PipelineDetails/__tests__/__snapshots__/PipelineDetails.test.tsx.snap
+++ b/ui-cra/src/components/Pipelines/PipelineDetails/__tests__/__snapshots__/PipelineDetails.test.tsx.snap
@@ -157,6 +157,15 @@ exports[`PipelineDetails snapshots renders 1`] = `
   font-weight: 400;
 }
 
+.c19 {
+  padding: 8px;
+}
+
+.c15 {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
 .c11.MuiButton-root {
   height: 32px;
   font-size: 12px;
@@ -172,15 +181,6 @@ exports[`PipelineDetails snapshots renders 1`] = `
 .c11.MuiButton-outlined {
   padding: 8px 12px;
   border-color: #d8d8d8;
-}
-
-.c19 {
-  padding: 8px;
-}
-
-.c15 {
-  -webkit-text-decoration: none;
-  text-decoration: none;
 }
 
 .c14 .active-tab {

--- a/ui-cra/src/components/ResponsiveDrawer.tsx
+++ b/ui-cra/src/components/ResponsiveDrawer.tsx
@@ -176,7 +176,11 @@ const ResponsiveDrawer = () => {
         <CoreClientContextProvider api={coreClient}>
           <TerraformProvider api={Terraform}>
             <LinkResolverProvider resolver={resolver}>
-              <Pendo defaultTelemetryFlag="true" />
+              <Pendo
+                defaultTelemetryFlag="true"
+                tier="enterprise"
+                version={process.env.REACT_APP_VERSION}
+              />
               <Switch>
                 <Route
                   component={() => (

--- a/ui-cra/yarn.lock
+++ b/ui-cra/yarn.lock
@@ -2335,10 +2335,10 @@
   resolved "https://npm.pkg.github.com/download/@weaveworks/progressive-delivery/0.0.0-rc13/2628159001f4812b90e068e64fae8de6b4e3f2b4#2628159001f4812b90e068e64fae8de6b4e3f2b4"
   integrity sha512-51ET/FrGwKcBUSqRTtaWTTuWQi/y51JQAFYMT6ctOLaiIXSopCyi3alf4aYDZ5TPFAIdOQapJMYiq2HVj5XxOQ==
 
-"@weaveworks/weave-gitops@0.13.0":
-  version "0.13.0"
-  resolved "https://npm.pkg.github.com/download/@weaveworks/weave-gitops/0.13.0/ecb60d35afd5a0c23e2dc68e74142f77729929ad#ecb60d35afd5a0c23e2dc68e74142f77729929ad"
-  integrity sha512-aU83RRQxE+sS800ENFdi95jq6AcSaTX7B41Na18Ux/ucmePcY7w5p7BY+GzLPCQ51xhTkPQ9QFp50Z+AWngR5A==
+"@weaveworks/weave-gitops@npm:@weaveworks/weave-gitops-main@0.13.0-16-g174de884":
+  version "0.13.0-16-g174de884"
+  resolved "https://npm.pkg.github.com/download/@weaveworks/weave-gitops-main/0.13.0-16-g174de884/e4eed8447f029a50ba854a48deb32b55627d9eae#e4eed8447f029a50ba854a48deb32b55627d9eae"
+  integrity sha512-qTEzdnekx78JeRcGunVmEWae20nTSMNkkzXwzZheR6q/Td8F7m/RvO/2KgtzNHjAN74Um0+mk6lVHFyB2POCZA==
   dependencies:
     "@material-ui/core" "^4.12.3"
     "@material-ui/icons" "^4.11.2"


### PR DESCRIPTION
Closes https://github.com/weaveworks/weave-gitops/issues/3154

- Added passing version and tier to the updated `Pendo` component from OSS.

- Updated some snapshots for unrelated but failing UI snapshot tests (it looks like just the order of code in the snapshots changed).

Notes:

- In enterprise, we are supposed to have the app version from start as an env var and don't need to add a separate PendoContainer component, like in OSS, to make an API call. So, in enterprise on both Sign In page and other pages  we track the version.

Testing:
- To test if Pendo has been initialized and with which visitor metadata, run the following command in the browser console
```
console.log(window.pendo.getSerializedMetadata().visitor)
```

If Pendo is not initialized, this will throw an error.

Pendo should be always initialized (with the version) on pages on which the user is logged in and should only be initialized on the Sign In page (but without the version) if there is a user data stored in the window's localStorage.

To clear localStorage for testing, run:

```
window.localStorage.clear()
```
Tested it locally, works as expected.
