### PR TITLE
Fixed random failing acceptan e tests due to resource cleanup

### DIFF
--- a/test/acceptance/test/ui_tenant.go
+++ b/test/acceptance/test/ui_tenant.go
@@ -41,6 +41,12 @@ func deleteTenants(tenantYamls []string) {
 var _ = ginkgo.Describe("Multi-Cluster Control Plane Tenancy", ginkgo.Ordered, ginkgo.Label("ui", "tenant"), func() {
 
 	ginkgo.BeforeEach(ginkgo.OncePerOrdered, func() {
+		gomega.Expect(webDriver.Navigate(testUiUrl)).To(gomega.Succeed())
+
+		if !pages.ElementExist(pages.Navbar(webDriver).Title, 3) {
+			loginUser()
+		}
+
 		// Delete the oidc user default roles/rolebindings because the same user is used as a tenant
 		_ = runCommandPassThrough("kubectl", "delete", "-f", path.Join(testDataPath, "rbac/user-role-bindings.yaml"))
 	})

--- a/test/acceptance/test/utils_gitops.go
+++ b/test/acceptance/test/utils_gitops.go
@@ -687,7 +687,7 @@ func waitForNamespaceDeletion(namespaces []string) {
 		checkOutput := func() error {
 			return runCommandPassThrough("sh", "-c", fmt.Sprintf(`kubectl get namespace %s`, namespace))
 		}
-		gomega.Eventually(checkOutput, ASSERTION_30SECONDS_TIME_OUT).Should(gomega.HaveOccurred(), fmt.Sprintf("'%s' namespace is expected not to be available", namespace))
+		gomega.Eventually(checkOutput, ASSERTION_1MINUTE_TIME_OUT, POLL_INTERVAL_3SECONDS).Should(gomega.HaveOccurred(), fmt.Sprintf("'%s' namespace is expected not to be available", namespace))
 	}
 }
 


### PR DESCRIPTION
- Fixed random failing tests due to automatic ui logout and not checking for login before tenant spec starts
- Increased the timeout for namespace deletion. Sometimes it takes longer than 30sec.