### PR TITLE
Expose template metadata in the template rendering.

### DIFF
--- a/cmd/clusters-service/pkg/templates/processors.go
+++ b/cmd/clusters-service/pkg/templates/processors.go
@@ -242,7 +242,10 @@ func (p *TextTemplateProcessor) Render(tmpl []byte, values map[string]string) ([
 	}
 
 	var out bytes.Buffer
-	if err := parsed.Execute(&out, map[string]interface{}{"params": values}); err != nil {
+	if err := parsed.Execute(&out, map[string]interface{}{
+		"params":   values,
+		"template": templateMetadata(p.template),
+	}); err != nil {
 		return nil, fmt.Errorf("failed to render template: %w", err)
 	}
 
@@ -328,4 +331,14 @@ func makeTemplateFunctions() template.FuncMap {
 		delete(f, v)
 	}
 	return f
+}
+
+// this could add additional fields from the data.
+func templateMetadata(t templatesv1.Template) map[string]any {
+	return map[string]any{
+		"meta": map[string]any{
+			"name":      t.GetName(),
+			"namespace": t.GetNamespace(),
+		},
+	}
 }


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes [#1234](https://github.com/weaveworks/weave-gitops-interlock/issues/244)
Fixes #5678
-->
Closes https://github.com/weaveworks/weave-gitops-interlock/issues/244

<!--
Describe what has changed in this PR.
For UI changes also include a screenshot.
-->
**What changed?**
This exposes some template metadata for the surrounding CAPI/GitOps template via the .template.meta key in the "templating" renderType.

The data can be used when rendering file paths etc.

<!-- Tell your future self why have you made these changes -->
**Why was this change made?**
Allow rendering templates to dynamically generated paths.

<!--
Explain to your reviewers the key implementation points, including why you made
certain choices in favour of others. Highlight key areas of the code which need
extra attention, and also indicate which parts are less relevant (eg renaming,
refactoring, etc
-->
**How was this change implemented?**
I opted not to expose the entire `Template` resource, as a recent(ish) PR upstream got a review that highlighted that this binds the metadata to the struct too tightly.

<!--
How have you verified this change/product value? Tested locally?
Added integration/acceptance test(s)?
Unit tests are required.
-->
**How did you validate the change?**
Tests!

<!--
Is it notable for release? e.g. schema updates, configuration or data migration
required? If so, please mention it.
-->
**Release notes**
Template path generation can now include metadata from the template when generating the output.

<!--
Are there any documentation updates that should be made for these changes? We want to keep these sources up to date:
- user-guide: https://docs.gitops.weave.works
- internal docs: https://github.com/weaveworks/weave-gitops-enterprise/tree/main/docs
-->
**Documentation Changes**
The user guide should include an example...

```yaml
apiVersion: capi.weave.works/v1alpha2
kind: CAPITemplate
metadata:
  name: cluster-template-1
  namespace: test-namespace
spec:
  description: this is test template 1
  renderType: templating
  resourcetemplates:
  - content:
    - apiVersion: cluster.x-k8s.io/v1alpha3
      kind: Cluster
      metadata:
        name: "{{ .template.meta.namespace }}-cluster"
    path: "./clusters/{{ .template.meta.name }}/capi-cluster.yaml"
```
Currently, the template meta only includes the `namespace` and `name` fields from the CAPITemplate.