### PR TITLE
Write templates to specified path

### DIFF
--- a/cmd/gitops/app/create/templates/cmd.go
+++ b/cmd/gitops/app/create/templates/cmd.go
@@ -89,8 +89,7 @@ func templatesCmdRunE() func(*cobra.Command, []string) error {
 		if flags.export {
 			renderedTemplate := ""
 			for _, file := range templateResources.RenderedTemplate {
-				fileName := filepath.Base(*file.Path)
-				renderedTemplate += "\n#" + fileName + "\n---\n" + *file.Content
+				renderedTemplate += "\n# path: " + *file.Path + "\n---\n" + *file.Content
 			}
 
 			err := export(renderedTemplate, os.Stdout)


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Closes #2215 

<!--
Describe what has changed in this PR.
For UI changes also include a screenshot.
-->
**What changed?**
`gitops create template template.yaml --values CLUSTER_NAME=ewq --export` (`go run cmd/gitops/main.go create template ...`)

only renders to stdout. We want to respect the file paths returned and write out the yaml to those paths, relative to the `--outDir` flag. e.g: 

`gitops create template --outDir ./out --values CLUSTER_NAME=ewq` should write out: `./out/clusters/ewq.yaml`

<!--
How have you verified this change/product value? Tested locally?
Added integration/acceptance test(s)?
Unit tests are required.
-->
**How did you validate the change?**
Tested with `go run cmd/gitops/main.go create template cmd/gitops/app/create/templates/testdata/template.yaml --values RESOURCE_NAME=ewq NAMESPACE=default TEMPLATE_PATH=./ GIT_REPO_NAME=test GIT_REPO_NAMESPACE=default --outDir=./out`

after updating `template.yaml` to: 
```  
resourcetemplates:
    - path: "/resources1/${RESOURCE_NAME}.yaml"
      content:
        - apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
          kind: Kustomization
          metadata:
            name: ${RESOURCE_NAME}
            namespace: ${NAMESPACE}
          spec:
            interval: 1h
            path: ${TEMPLATE_PATH}
            sourceRef:
              kind: GitRepository
              name: ${GIT_REPO_NAME}
              namespace: ${GIT_REPO_NAMESPACE}
    - path: "/resources2/${RESOURCE_NAME}.yaml"
      content:
        - apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
          kind: Kustomization
          metadata:
            name: ${RESOURCE_NAME}
            namespace: ${NAMESPACE}
          spec:
            interval: 1h
            path: ${TEMPLATE_PATH}
            sourceRef:
              kind: GitRepository
              name: ${GIT_REPO_NAME}
              namespace: ${GIT_REPO_NAMESPACE}
```
The directories and files that got created:
![Screenshot 2023-01-12 at 16 41 09](https://user-images.githubusercontent.com/35202557/212112415-8484a389-afcf-4320-92c3-91a7171db154.png)

<!--
Are there any documentation updates that should be made for these changes? We want to keep these sources up to date:
- user-guide: https://docs.gitops.weave.works
- internal docs: https://github.com/weaveworks/weave-gitops-enterprise/tree/main/docs
-->
**Documentation Changes**
Need to update docs. 