### PR TITLE
Revert "Support enabling verbose client-go logging"

### DIFF
--- a/cmd/clusters-service/app/server.go
+++ b/cmd/clusters-service/app/server.go
@@ -11,7 +11,6 @@ import (
 	"crypto/x509/pkix"
 	"encoding/pem"
 	"errors"
-	"flag"
 	"fmt"
 	"math/big"
 	"net"
@@ -32,7 +31,7 @@ import (
 	"github.com/go-logr/logr"
 	grpc_runtime "github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
+	flag "github.com/spf13/pflag"
 	"github.com/spf13/viper"
 	gitopsv1alpha1 "github.com/weaveworks/cluster-controller/api/v1alpha1"
 	"github.com/weaveworks/go-checkpoint"
@@ -82,7 +81,6 @@ import (
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	k8scache "k8s.io/client-go/tools/cache"
-	"k8s.io/klog/v2"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -145,7 +143,6 @@ type Params struct {
 	CostEstimationFilters             string                    `mapstructure:"cost-estimation-filters"`
 	CostEstimationAPIRegion           string                    `mapstructure:"cost-estimation-api-region"`
 	CostEstimationFilename            string                    `mapstructure:"cost-estimation-csv-file"`
-	KLogVerbosity                     string                    `mapstructure:"klog-verbosity"`
 }
 
 type OIDCAuthenticationOptions struct {
@@ -230,13 +227,12 @@ func NewAPIServerCommand(log logr.Logger, tempDir string) *cobra.Command {
 	cmdFlags.Bool("use-k8s-cached-clients", true, "Enables the use of cached clients")
 	cmdFlags.String("ui-config", "", "UI configuration, JSON encoded")
 	cmdFlags.String("pipeline-controller-address", pipelines.DefaultPipelineControllerAddress, "Pipeline controller address")
-	cmdFlags.String("klog-verbosity", "0", "Set the logging of the klog library")
 
 	cmdFlags.String("cost-estimation-filters", "", "Cost estimation filters")
 	cmdFlags.String("cost-estimation-api-region", "", "API region for cost estimation queries")
 	cmdFlags.String("cost-estimation-csv-file", "", "Filename to parse as Cost Estimation data")
 
-	cmdFlags.VisitAll(func(fl *pflag.Flag) {
+	cmdFlags.VisitAll(func(fl *flag.Flag) {
 		if strings.HasPrefix(fl.Name, "cost-estimation") {
 			cobra.CheckErr(cmdFlags.MarkHidden(fl.Name))
 		}
@@ -310,32 +306,9 @@ func initializeConfig(cmd *cobra.Command) error {
 	return nil
 }
 
-// configureKlogVerbosity sets the klog verbosity level.
-// This log is used by the client-go k8s libraries and can be useful for debugging
-// client-go's network requests.
-//
-// v=5 - log CRD cache things?
-// v=6 - log requests (e.g. GET url)
-// v=7 - log req/res headers
-// v=8 - log res body
-func configureKLogVerbosity(v string) error {
-	klog.InitFlags(nil)
-	err := flag.Set("v", v)
-	if err != nil {
-		return fmt.Errorf("could not set klog verbosity: %w", err)
-	}
-	flag.Parse()
-	return nil
-}
-
 func StartServer(ctx context.Context, log logr.Logger, tempDir string, p Params) error {
-	featureflags.SetFromEnv(os.Environ())
 
-	log.Info("Setting klog verbosity", "verbosity", p.KLogVerbosity)
-	err := configureKLogVerbosity(p.KLogVerbosity)
-	if err != nil {
-		return fmt.Errorf("could not configure klog verbosity: %w", err)
-	}
+	featureflags.SetFromEnv(os.Environ())
 
 	if p.CAPITemplatesNamespace == "" {
 		return errors.New("CAPI templates namespace not set")
@@ -354,7 +327,7 @@ func StartServer(ctx context.Context, log logr.Logger, tempDir string, p Params)
 		schemeBuilder = append(schemeBuilder, capiv1.AddToScheme)
 	}
 
-	err = schemeBuilder.AddToScheme(scheme)
+	err := schemeBuilder.AddToScheme(scheme)
 	if err != nil {
 		return err
 	}

--- a/go.mod
+++ b/go.mod
@@ -326,7 +326,7 @@ require (
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/apiserver v0.25.4 // indirect
 	k8s.io/component-base v0.25.4 // indirect
-	k8s.io/klog/v2 v2.80.1
+	k8s.io/klog/v2 v2.80.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20221110221610-a28e98eb7c70 // indirect
 	k8s.io/kubectl v0.25.4 // indirect
 	k8s.io/utils v0.0.0-20221108210102-8e77b1f39fe2 // indirect

--- a/tools/dev-values.yaml
+++ b/tools/dev-values.yaml
@@ -20,9 +20,6 @@ extraEnvVars:
     value: ""
   - name: WEAVE_GITOPS_FEATURE_TELEMETRY
     value: "false"
-  # Can bump this up to 4+ to get more verbose logging
-  - name: KLOG_VERBOSITY
-    value: "0"
 
 extraEnvVarsSecret: ""
 


### PR DESCRIPTION
Reverts weaveworks/weave-gitops-enterprise#1806

This breaks passing cli flags into the cluster-service e.g.

```
❯ go run cmd/clusters-service/main.go --dev-mode
{"level":"info","ts":1673961951.795032,"logger":"gitops","caller":"app/server.go:334","msg":"Setting klog verbosity","verbosity":"0"}
flag provided but not defined: -dev-mode
Usage of /var/folders/c_/ksp92k1j6m56l4l_p83t8jf00000gn/T/go-build3592919515/b001/exe/main:
  -add_dir_header
    	If true, adds the file directory to the header of the log messages
  -alsologtostderr
    	log to standard error as well as files (no effect when -logtostderr=true)
  -kubeconfig string
    	Paths to a kubeconfig. Only required if out-of-cluster.
  -log_backtrace_at value
    	when logging hits line file:N, emit a stack trace
  -log_dir string
    	If non-empty, write log files in this directory (no effect when -logtostderr=true)
  -log_file string
    	If non-empty, use this log file (no effect when -logtostderr=true)
  -log_file_max_size uint
    	Defines the maximum size a log file can grow to (no effect when -logtostderr=true). Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
  -logtostderr
    	log to standard error instead of files (default true)
  -one_output
    	If true, only write logs to their native severity level (vs also writing to each lower severity level; no effect when -logtostderr=true)
  -skip_headers
    	If true, avoid header prefixes in the log messages
  -skip_log_headers
    	If true, avoid headers when opening log files (no effect when -logtostderr=true)
  -stderrthreshold value
    	logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=false) (default 2)
  -v value
    	number for the log level verbosity
  -vmodule value
    	comma-separated list of pattern=N settings for file-filtered logging
exit status 2
```