### PR TITLE
Provide a default value for the logLevel

### DIFF
--- a/charts/mccp/values.yaml
+++ b/charts/mccp/values.yaml
@@ -34,6 +34,7 @@ enableTerraformUI: false
 enableRunUI: false
 
 config:
+  logLevel: info
   cluster:
     name: management
   git:


### PR DESCRIPTION
- For discovery
- To avoid the error:

> Error: INSTALLATION FAILED: unable to build kubernetes objects
> from release manifest: error validating "": error validating
> data: unknown object type "nil" in ConfigMap.data.LOG_LEVEL

Follow up to #2272 