### PR TITLE
Make issue templates more readable

### DIFF
--- a/.github/ISSUE_TEMPLATE/acceptance_bug_report.md
+++ b/.github/ISSUE_TEMPLATE/acceptance_bug_report.md
@@ -7,8 +7,9 @@ assignees: ''
 
 ---
 
+<!-- which wge story/feature was being verified and which branch contains the changes. -->
 **WGE Story/Feature:**
- - which wge story/feature was being verified and which branch contains the changes
+
 
 **Priority**
  - low
@@ -19,21 +20,27 @@ assignees: ''
  - low
  - medium
  - high
+ - critical
 
+<!-- A clear and concise description of what the bug is. -->
 **Describe the bug**
-A clear and concise description of what the bug is.
 
+
+<!-- Steps to reproduce the behaviour. -->
 **To Reproduce**
-Steps to reproduce the behaviour:
 
+
+<!-- A clear and concise description of the resulting behaviour. -->
 **Actual behaviour**
-A clear and concise description of the resulting behaviour.
 
+
+<!-- A clear and concise description of what you expected to happen. -->
 **Expected behaviour**
-A clear and concise description of what you expected to happen.
 
+
+<!-- The url of the environment the feature was tested on. -->
 **Test Environment**
-The url of the environment the feature was tested on
 
+
+<!-- Add any other context about the problem here. -->
 **Additional context**
-Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/regression_bug_report.md
+++ b/.github/ISSUE_TEMPLATE/regression_bug_report.md
@@ -8,7 +8,7 @@ assignees: ''
 ---
 
 **Kubernetes release:**
- - which kubernetes release
+
 
 **Priority**
  - low
@@ -19,18 +19,23 @@ assignees: ''
  - low
  - medium
  - high
+ - critical
 
+<!-- A clear and concise description of what the bug is. -->
 **Describe the bug**
-A clear and concise description of what the bug is.
 
+
+<!-- Steps to reproduce the behaviour. -->
 **To Reproduce**
-Steps to reproduce the behaviour:
 
+
+<!-- A clear and concise description of the resulting behaviour. -->
 **Actual behaviour**
-A clear and concise description of the resulting behaviour.
 
+
+<!-- A clear and concise description of what you expected to happen. -->
 **Expected behaviour**
-A clear and concise description of what you expected to happen.
+
 
 **Cloud provider:**
  - AWS
@@ -40,5 +45,5 @@ A clear and concise description of what you expected to happen.
  - VMware
  - LiquidMetal
 
+<!-- Add any other context about the problem here. -->
 **Additional context**
-Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/release_bug_report.md
+++ b/.github/ISSUE_TEMPLATE/release_bug_report.md
@@ -8,10 +8,10 @@ assignees: ''
 ---
 
 **WGE release:**
- - which wge release
+
 
 **Kubernetes release:**
- - which kubernetes release
+
 
 **Priority**
  - low
@@ -22,18 +22,23 @@ assignees: ''
  - low
  - medium
  - high
+ - ctritical
 
+<!-- A clear and concise description of what the bug is. -->
 **Describe the bug**
-A clear and concise description of what the bug is.
 
+
+<!-- Steps to reproduce the behaviour. -->
 **To Reproduce**
-Steps to reproduce the behaviour:
 
+
+<!-- A clear and concise description of the resulting behaviour. -->
 **Actual behaviour**
-A clear and concise description of the resulting behaviour.
 
+
+<!-- A clear and concise description of what you expected to happen. -->
 **Expected behaviour**
-A clear and concise description of what you expected to happen.
+
 
 **Cloud provider:**
  - AWS
@@ -43,5 +48,5 @@ A clear and concise description of what you expected to happen.
  - VMware
  - LiquidMetal
 
+<!-- Add any other context about the problem here. -->
 **Additional context**
-Add any other context about the problem here.


### PR DESCRIPTION
I noticed that sometimes when people use the templates, they dont remove the text that is meant for guidance which affects the readability of the issues. I moved them before the questions and changed them into comments so they dont affect the readability.