### PR TITLE
Add logs to GitOps Run detail page

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/sirupsen/logrus v1.9.0
 	github.com/spf13/cobra v1.6.1
 	github.com/stretchr/testify v1.8.1
-	github.com/weaveworks/weave-gitops v0.15.1-0.20230131153537-a24b01ac000a
+	github.com/weaveworks/weave-gitops v0.15.1-0.20230131181641-e373d6359fc6
 	github.com/weaveworks/weave-gitops-enterprise-credentials v0.0.2
 	github.com/weaveworks/weave-gitops-enterprise/common v0.0.0
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1389,8 +1389,8 @@ github.com/weaveworks/templates-controller v0.1.2 h1:PVPePP8NUnB2OqCsNvHvp8zm2vk
 github.com/weaveworks/templates-controller v0.1.2/go.mod h1:iLs/20GkUY94KzDhRvmctwun7yX3SGJWs8q0gbTu53I=
 github.com/weaveworks/tf-controller/api v0.0.0-20221220150320-3d0f3743ccb4 h1:RRpzQlhbEC5WjL0jaMEvGUSZ8EsxzdqSSzginwSBTyc=
 github.com/weaveworks/tf-controller/api v0.0.0-20221220150320-3d0f3743ccb4/go.mod h1:VK60b9WR7XEK1DvQNOpKEOlIQ56Qcy5KlAIFksQmUxI=
-github.com/weaveworks/weave-gitops v0.15.1-0.20230131153537-a24b01ac000a h1:YhUQdrOU38ulowH1GdG0smdM8p62NWz/zkjZUAzOJYU=
-github.com/weaveworks/weave-gitops v0.15.1-0.20230131153537-a24b01ac000a/go.mod h1:cUnWoB/os7EQY8yxKn9fr+f3Ny8wCXnnF74PPd0l+PU=
+github.com/weaveworks/weave-gitops v0.15.1-0.20230131181641-e373d6359fc6 h1:SKozmC0H4aBvfba5BTPoYiZm2AaPAf3mMAUQgF9CLnQ=
+github.com/weaveworks/weave-gitops v0.15.1-0.20230131181641-e373d6359fc6/go.mod h1:cUnWoB/os7EQY8yxKn9fr+f3Ny8wCXnnF74PPd0l+PU=
 github.com/weaveworks/weave-gitops-enterprise-credentials v0.0.2 h1:7jeiQehqmI4ds6YIq8TW1Vqhlb6V7G2BVRJ8VM3r99I=
 github.com/weaveworks/weave-gitops-enterprise-credentials v0.0.2/go.mod h1:6PMYg+VtSNePnP7EXyNG+/hNRNZ3r0mQtolIZU4s/J0=
 github.com/xanzy/go-gitlab v0.77.0 h1:UrbGlxkWVCbkpa6Fk6cM8ARh+rLACWemkJnsawT7t98=

--- a/ui-cra/package.json
+++ b/ui-cra/package.json
@@ -24,7 +24,7 @@
     "@types/react-syntax-highlighter": "^13.5.2",
     "@types/styled-components": "^5.1.9",
     "@weaveworks/progressive-delivery": "0.0.0-rc13",
-    "@weaveworks/weave-gitops": "npm:@weaveworks/weave-gitops-main@0.15.0-37-ga24b01ac",
+    "@weaveworks/weave-gitops": "npm:@weaveworks/weave-gitops-main@",
     "classnames": "^2.3.1",
     "d3-scale": "4.0.0",
     "d3-time": "^3.0.0",

--- a/ui-cra/src/components/GitOpsRun/Detail/GitOpsRunLogs.tsx
+++ b/ui-cra/src/components/GitOpsRun/Detail/GitOpsRunLogs.tsx
@@ -4,11 +4,12 @@ import { Flex } from '@weaveworks/weave-gitops';
 import { LogEntry } from '@weaveworks/weave-gitops/ui/lib/api/core/core.pb';
 import React from 'react';
 import styled from 'styled-components';
-import { Select } from '../../../utils/form';
+import { useGetLogs } from '../../../hooks/gitopsrun';
 
 type Props = {
   className?: string;
-  logs: LogEntry[];
+  name: string;
+  namespace: string;
 };
 
 const Header = styled(Flex)`
@@ -38,25 +39,35 @@ const LogRow: React.FC<{ log: LogEntry }> = ({ log }) => {
   );
 };
 
-function GitOpsRunLogs({ className, logs }: Props) {
-  const [logOptions, setLogOptions] = React.useState<string[]>([
-    'log one',
-    'log two',
-  ]);
-  const [levelOptions, setLevelOptions] = React.useState<string[]>([
-    'level one',
-    'level two',
-  ]);
-  const [logValue, setLogValue] = React.useState('-');
-  const [levelValue, setLevelValue] = React.useState('-');
+function GitOpsRunLogs({ className, name, namespace }: Props) {
+  // const [logOptions, setLogOptions] = React.useState<string[]>([
+  //   'log one',
+  //   'log two',
+  // ]);
+  // const [levelOptions, setLevelOptions] = React.useState<string[]>([
+  //   'level one',
+  //   'level two',
+  // ]);
+  // const [logValue, setLogValue] = React.useState('-');
+  // const [levelValue, setLevelValue] = React.useState('-');
+
+  const [token, setToken] = React.useState('');
+  const { isLoading, data, error } = useGetLogs({
+    sessionNamespace: namespace,
+    sessionId: name,
+    token,
+  });
 
   React.useEffect(() => {
-    //find logs and levels for selects, plus earliest timestamp?!
-  }, [logs]);
+    if (isLoading) return;
+    setToken(data?.nextToken || '');
+  }, [data]);
+
+  const logs = data?.logs || [];
 
   return (
     <Flex className={className} wide tall column>
-      <Flex>
+      {/* <Flex>
         <Select
           label="LOG"
           value={logValue}
@@ -70,8 +81,12 @@ function GitOpsRunLogs({ className, logs }: Props) {
           items={levelOptions}
           onChange={e => setLevelValue(e.target.value as string)}
         />
-      </Flex>
-      <Header wide>showing logs from ....</Header>
+      </Flex> */}
+      <Header wide>
+        {logs.length
+          ? 'showing logs from ' + logs[0].timestamp
+          : 'No logs found'}
+      </Header>
       <TableContainer>
         <Table>
           {logs.map(log => (

--- a/ui-cra/src/components/GitOpsRun/Detail/index.tsx
+++ b/ui-cra/src/components/GitOpsRun/Detail/index.tsx
@@ -1,8 +1,6 @@
 import { RouterTab, SubRouterTabs } from '@weaveworks/weave-gitops';
-import { useEffect, useState } from 'react';
 import { useRouteMatch } from 'react-router-dom';
 import styled from 'styled-components';
-import { useGetLogs } from '../../../hooks/gitopsrun';
 import { ContentWrapper } from '../../Layout/ContentWrapper';
 import { PageTemplate } from '../../Layout/PageTemplate';
 import GitOpsRunLogs from './GitOpsRunLogs';
@@ -19,34 +17,17 @@ const PageTitle = styled.h4`
 `;
 
 const GitOpsRunDetail = ({ name, namespace }: Props) => {
-  const [token, setToken] = useState('');
-  const { isLoading, data, error } = useGetLogs({
-    sessionNamespace: namespace,
-    sessionId: name,
-    token,
-  });
-
-  console.log(data);
-
-  useEffect(() => {
-    if (isLoading) return;
-    setToken(data?.nextToken || '');
-  }, [data]);
-
   const { path } = useRouteMatch();
   return (
     <PageTemplate
       documentTitle="GitOps Run Detail"
       path={[{ label: 'GitOps Run Detail' }]}
     >
-      <ContentWrapper
-        loading={isLoading}
-        errors={[{ message: error?.message }]}
-      >
+      <ContentWrapper>
         <PageTitle>{name}</PageTitle>
         <SubRouterTabs rootPath={`${path}/logs`}>
           <RouterTab name="Logs" path={`${path}/logs`}>
-            <GitOpsRunLogs logs={data?.logs || []} />
+            <GitOpsRunLogs name={name || ''} namespace={namespace || ''} />
           </RouterTab>
         </SubRouterTabs>
       </ContentWrapper>

--- a/ui-cra/src/components/GitOpsRun/List/GitOpsRunTable.tsx
+++ b/ui-cra/src/components/GitOpsRun/List/GitOpsRunTable.tsx
@@ -69,10 +69,6 @@ const GitOpsRunTable: FC<Props> = ({ sessions }) => {
     ),
   };
 
-  // Name field for when Detail page is ready to be hooked up
-
-  console.log(sessions);
-
   return (
     <DataTable
       key={sessions?.length}

--- a/ui-cra/src/hooks/gitopsrun.tsx
+++ b/ui-cra/src/hooks/gitopsrun.tsx
@@ -8,6 +8,7 @@ export const useGetLogs = (req: GetSessionLogsRequest) => {
   const { isLoading, data, error } = useQuery<GetSessionLogsResponse, Error>(
     'logs',
     () => coreClient.GetSessionLogs(req),
+    { refetchInterval: 5000 },
   );
   return { isLoading, data, error };
 };

--- a/ui-cra/yarn.lock
+++ b/ui-cra/yarn.lock
@@ -2335,10 +2335,10 @@
   resolved "https://npm.pkg.github.com/download/@weaveworks/progressive-delivery/0.0.0-rc13/2628159001f4812b90e068e64fae8de6b4e3f2b4#2628159001f4812b90e068e64fae8de6b4e3f2b4"
   integrity sha512-51ET/FrGwKcBUSqRTtaWTTuWQi/y51JQAFYMT6ctOLaiIXSopCyi3alf4aYDZ5TPFAIdOQapJMYiq2HVj5XxOQ==
 
-"@weaveworks/weave-gitops@npm:@weaveworks/weave-gitops-main@0.15.0-37-ga24b01ac":
-  version "0.15.0-37-ga24b01ac"
-  resolved "https://npm.pkg.github.com/download/@weaveworks/weave-gitops-main/0.15.0-37-ga24b01ac/0231ff540f1dc58c0d798d74d228aeb98a9b5d1f#0231ff540f1dc58c0d798d74d228aeb98a9b5d1f"
-  integrity sha512-jYPcUhxuJk7EvCWUsT83T1vK2a04LomKiRBnpyutZQnLw9FOqgSEzO771HXjkQXWX5eo5sj/1L3WGLR1TTP0CA==
+"@weaveworks/weave-gitops@npm:@weaveworks/weave-gitops-main@":
+  version "0.15.0-38-geb24ee5b"
+  resolved "https://npm.pkg.github.com/download/@weaveworks/weave-gitops-main/0.15.0-38-geb24ee5b/430e59167ad847d5d2f4838999c93328e9726324#430e59167ad847d5d2f4838999c93328e9726324"
+  integrity sha512-jCrTCRREk7vJ9cNi4bCJuMDJaxUe6tFqEfV6H2SGe2cUs61l5LtXyxojbICtyWJaTY98Ew0FwC0XoI2f22A0OA==
   dependencies:
     "@material-ui/core" "^4.12.3"
     "@material-ui/icons" "^4.11.2"


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes weaveworks/weave-gitops#1234
Fixes #5678
-->
Closes [#3290](https://github.com/weaveworks/weave-gitops/issues/3290)

What's still missing in the UI for this page?
- the two Selects to filter by level and source - it was my understanding that we're adding this functionality to the backend request, so I commented out what was in the skeleton for now
- sorting - are we doing this like the usual data table where all columns are sortable? As of right now the figma only shows an arrow by the header timestamp, suggesting that we're only sorting by timestamp? Just want to make sure.
- error notifications - the errors can't be handled by content wrapper, so I need to use the notification system. Have to look into how that all works.
- timestamp formatting
<img width="1463" alt="image" src="https://user-images.githubusercontent.com/65822698/215855795-f239b1e7-bc2a-4e04-90d0-395e2f675c7c.png">
