### PR TITLE
Improve formatting of log message timestamp in the log UI

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/sirupsen/logrus v1.9.0
 	github.com/spf13/cobra v1.6.1
 	github.com/stretchr/testify v1.8.1
-	github.com/weaveworks/weave-gitops v0.16.0
+	github.com/weaveworks/weave-gitops v0.16.1-0.20230203171357-291c9fea0124
 	github.com/weaveworks/weave-gitops-enterprise-credentials v0.0.2
 	github.com/weaveworks/weave-gitops-enterprise/common v0.0.0
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1389,8 +1389,8 @@ github.com/weaveworks/templates-controller v0.1.2 h1:PVPePP8NUnB2OqCsNvHvp8zm2vk
 github.com/weaveworks/templates-controller v0.1.2/go.mod h1:iLs/20GkUY94KzDhRvmctwun7yX3SGJWs8q0gbTu53I=
 github.com/weaveworks/tf-controller/api v0.0.0-20221220150320-3d0f3743ccb4 h1:RRpzQlhbEC5WjL0jaMEvGUSZ8EsxzdqSSzginwSBTyc=
 github.com/weaveworks/tf-controller/api v0.0.0-20221220150320-3d0f3743ccb4/go.mod h1:VK60b9WR7XEK1DvQNOpKEOlIQ56Qcy5KlAIFksQmUxI=
-github.com/weaveworks/weave-gitops v0.16.0 h1:FofUJ9VY/UyAOihTJ6VcSefcgNFi3o1xBYuSaMEPki0=
-github.com/weaveworks/weave-gitops v0.16.0/go.mod h1:cUnWoB/os7EQY8yxKn9fr+f3Ny8wCXnnF74PPd0l+PU=
+github.com/weaveworks/weave-gitops v0.16.1-0.20230203171357-291c9fea0124 h1:0vs3zdqLTZG90GMJJLuYWPuOUdWfovtSjlGQZ7EpvNU=
+github.com/weaveworks/weave-gitops v0.16.1-0.20230203171357-291c9fea0124/go.mod h1:cUnWoB/os7EQY8yxKn9fr+f3Ny8wCXnnF74PPd0l+PU=
 github.com/weaveworks/weave-gitops-enterprise-credentials v0.0.2 h1:7jeiQehqmI4ds6YIq8TW1Vqhlb6V7G2BVRJ8VM3r99I=
 github.com/weaveworks/weave-gitops-enterprise-credentials v0.0.2/go.mod h1:6PMYg+VtSNePnP7EXyNG+/hNRNZ3r0mQtolIZU4s/J0=
 github.com/xanzy/go-gitlab v0.77.0 h1:UrbGlxkWVCbkpa6Fk6cM8ARh+rLACWemkJnsawT7t98=

--- a/ui-cra/package.json
+++ b/ui-cra/package.json
@@ -24,7 +24,7 @@
     "@types/react-syntax-highlighter": "^13.5.2",
     "@types/styled-components": "^5.1.9",
     "@weaveworks/progressive-delivery": "0.0.0-rc13",
-    "@weaveworks/weave-gitops": "0.16.0",
+    "@weaveworks/weave-gitops": "npm:@weaveworks/weave-gitops-main@0.16.0-5-g291c9fea",
     "classnames": "^2.3.1",
     "d3-scale": "4.0.0",
     "d3-time": "^3.0.0",

--- a/ui-cra/src/components/GitOpsRun/Detail/GitOpsRunLogs.tsx
+++ b/ui-cra/src/components/GitOpsRun/Detail/GitOpsRunLogs.tsx
@@ -6,7 +6,12 @@ import {
   TableRow,
 } from '@material-ui/core';
 import { Error, Info } from '@material-ui/icons';
-import { Flex, Icon, IconType } from '@weaveworks/weave-gitops';
+import {
+  Flex,
+  formatLogTimestamp,
+  Icon,
+  IconType,
+} from '@weaveworks/weave-gitops';
 import { LogEntry } from '@weaveworks/weave-gitops/ui/lib/api/core/core.pb';
 import React from 'react';
 import styled from 'styled-components';
@@ -28,10 +33,13 @@ const Header = styled(Flex)`
 
 const makeHeader = (logs: LogEntry[], reverseSort: boolean) => {
   if (!logs.length) return 'No logs found';
+
+  const timestamp = formatLogTimestamp(
+    reverseSort ? logs[logs.length - 1].timestamp : logs[0].timestamp,
+  );
+
   return `showing logs from ${
-    reverseSort
-      ? `now to ${logs[logs.length - 1].timestamp}`
-      : `${logs[0].timestamp} to now`
+    reverseSort ? `now to ${timestamp}` : `${timestamp} to now`
   }`;
 };
 
@@ -47,7 +55,9 @@ const LogRow: React.FC<{ log: LogEntry }> = ({ log }) => {
           )}
         </Flex>
       </TableCell>
-      <TableCell className="gray">{log.timestamp || '-'}</TableCell>
+      <TableCell className="gray">
+        {formatLogTimestamp(log.timestamp)}
+      </TableCell>
       <TableCell>{log.source || '-'}</TableCell>
       <TableCell className="break-word">{log.message || '-'}</TableCell>
     </TableRow>
@@ -68,7 +78,7 @@ function GitOpsRunLogs({ className, name, namespace }: Props) {
 
   const [reverseSort, setReverseSort] = React.useState(false);
   const [token, setToken] = React.useState('');
-  const { isLoading, data, error } = useGetLogs({
+  const { isLoading, data } = useGetLogs({
     sessionNamespace: namespace,
     sessionId: name,
     token,
@@ -77,7 +87,7 @@ function GitOpsRunLogs({ className, name, namespace }: Props) {
   React.useEffect(() => {
     if (isLoading) return;
     setToken(data?.nextToken || '');
-  }, [data]);
+  }, [isLoading, data]);
 
   const logs = data?.logs || [];
 

--- a/ui-cra/yarn.lock
+++ b/ui-cra/yarn.lock
@@ -2335,10 +2335,10 @@
   resolved "https://npm.pkg.github.com/download/@weaveworks/progressive-delivery/0.0.0-rc13/2628159001f4812b90e068e64fae8de6b4e3f2b4#2628159001f4812b90e068e64fae8de6b4e3f2b4"
   integrity sha512-51ET/FrGwKcBUSqRTtaWTTuWQi/y51JQAFYMT6ctOLaiIXSopCyi3alf4aYDZ5TPFAIdOQapJMYiq2HVj5XxOQ==
 
-"@weaveworks/weave-gitops@0.16.0":
-  version "0.16.0"
-  resolved "https://npm.pkg.github.com/download/@weaveworks/weave-gitops/0.16.0/6d3b17c8e7a4e2ae19b8d9502a276cf9699a4264#6d3b17c8e7a4e2ae19b8d9502a276cf9699a4264"
-  integrity sha512-gHZXh5dff3V+rpNYkTYsrccVIfHGNPzwHrejYK+Yq5FehqURxQFC7M5FXM5D8kmbzUWSOjs+RQ9yhojt9oAGjA==
+"@weaveworks/weave-gitops@npm:@weaveworks/weave-gitops-main@0.16.0-5-g291c9fea":
+  version "0.16.0-5-g291c9fea"
+  resolved "https://npm.pkg.github.com/download/@weaveworks/weave-gitops-main/0.16.0-5-g291c9fea/4b730ac254bce5f518c7819676523778029a68f4#4b730ac254bce5f518c7819676523778029a68f4"
+  integrity sha512-+ayLENlg46Xdj/l4/dKvwQdQgq/YOupFl9oP9KgLL7Vk4JHWOLFC9dmq+0CNH4QVhDlAKAHeqn/6hiwbaYB3+Q==
   dependencies:
     "@material-ui/core" "^4.12.3"
     "@material-ui/icons" "^4.11.2"


### PR DESCRIPTION
Closes https://github.com/weaveworks/weave-gitops-enterprise/issues/2319

- Added formatting of log timestamps with the `formatLogTimestamp ` function imported from OSS.
- Also added formatting the header timestamp with the same function, because we don't have a better spec for the header timestamp format yet.
- Fixed a couple of linter warnings in the GitOpsRunLogs view.

Figma design:

<img width="285" alt="Screenshot 2023-02-02 at 23 54 04" src="https://user-images.githubusercontent.com/8824708/216473903-af40e188-19d6-45aa-a917-752af853896a.png">

Formatted timestamps:
<img width="1477" alt="Screenshot 2023-02-03 at 19 24 50" src="https://user-images.githubusercontent.com/8824708/216679123-9424267e-cee3-43db-8873-5e179daf6030.png">

<img width="1476" alt="Screenshot 2023-02-03 at 19 24 38" src="https://user-images.githubusercontent.com/8824708/216679110-bfe276ba-8137-46c9-a6ac-b6936a311857.png">
