### PR TITLE
Implement proper polling on GitOps Run logs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/sirupsen/logrus v1.9.0
 	github.com/spf13/cobra v1.6.1
 	github.com/stretchr/testify v1.8.1
-	github.com/weaveworks/weave-gitops v0.16.1-0.20230203171357-291c9fea0124
+	github.com/weaveworks/weave-gitops v0.16.1-0.20230206153653-15f6ed263c8c
 	github.com/weaveworks/weave-gitops-enterprise-credentials v0.0.2
 	github.com/weaveworks/weave-gitops-enterprise/common v0.0.0
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1389,8 +1389,8 @@ github.com/weaveworks/templates-controller v0.1.2 h1:PVPePP8NUnB2OqCsNvHvp8zm2vk
 github.com/weaveworks/templates-controller v0.1.2/go.mod h1:iLs/20GkUY94KzDhRvmctwun7yX3SGJWs8q0gbTu53I=
 github.com/weaveworks/tf-controller/api v0.0.0-20221220150320-3d0f3743ccb4 h1:RRpzQlhbEC5WjL0jaMEvGUSZ8EsxzdqSSzginwSBTyc=
 github.com/weaveworks/tf-controller/api v0.0.0-20221220150320-3d0f3743ccb4/go.mod h1:VK60b9WR7XEK1DvQNOpKEOlIQ56Qcy5KlAIFksQmUxI=
-github.com/weaveworks/weave-gitops v0.16.1-0.20230203171357-291c9fea0124 h1:0vs3zdqLTZG90GMJJLuYWPuOUdWfovtSjlGQZ7EpvNU=
-github.com/weaveworks/weave-gitops v0.16.1-0.20230203171357-291c9fea0124/go.mod h1:cUnWoB/os7EQY8yxKn9fr+f3Ny8wCXnnF74PPd0l+PU=
+github.com/weaveworks/weave-gitops v0.16.1-0.20230206153653-15f6ed263c8c h1:R+xYlPECKmLZoPePL0RnR6Tt9vks9+wPxv/Cq2WEFNA=
+github.com/weaveworks/weave-gitops v0.16.1-0.20230206153653-15f6ed263c8c/go.mod h1:cUnWoB/os7EQY8yxKn9fr+f3Ny8wCXnnF74PPd0l+PU=
 github.com/weaveworks/weave-gitops-enterprise-credentials v0.0.2 h1:7jeiQehqmI4ds6YIq8TW1Vqhlb6V7G2BVRJ8VM3r99I=
 github.com/weaveworks/weave-gitops-enterprise-credentials v0.0.2/go.mod h1:6PMYg+VtSNePnP7EXyNG+/hNRNZ3r0mQtolIZU4s/J0=
 github.com/xanzy/go-gitlab v0.78.0 h1:8jUHfQVAprG04Av5g0PxVd3CNsZ5hCbojIax7Hba1mE=

--- a/ui-cra/package.json
+++ b/ui-cra/package.json
@@ -24,7 +24,7 @@
     "@types/react-syntax-highlighter": "^13.5.2",
     "@types/styled-components": "^5.1.9",
     "@weaveworks/progressive-delivery": "0.0.0-rc13",
-    "@weaveworks/weave-gitops": "npm:@weaveworks/weave-gitops-main@0.16.0-5-g291c9fea",
+    "@weaveworks/weave-gitops": "npm:@weaveworks/weave-gitops-main@0.16.0-16-g15f6ed26",
     "classnames": "^2.3.1",
     "d3-scale": "4.0.0",
     "d3-time": "^3.0.0",

--- a/ui-cra/src/components/GitOpsRun/Detail/GitOpsRunLogs.tsx
+++ b/ui-cra/src/components/GitOpsRun/Detail/GitOpsRunLogs.tsx
@@ -76,8 +76,9 @@ function GitOpsRunLogs({ className, name, namespace }: Props) {
   // const [logValue, setLogValue] = React.useState('-');
   // const [levelValue, setLevelValue] = React.useState('-');
 
-  const [reverseSort, setReverseSort] = React.useState(false);
-  const [token, setToken] = React.useState('');
+  const [reverseSort, setReverseSort] = React.useState<boolean>(false);
+  const [token, setToken] = React.useState<string>('');
+  const [logs, setLogs] = React.useState<LogEntry[]>([]);
   const { isLoading, data } = useGetLogs({
     sessionNamespace: namespace,
     sessionId: name,
@@ -86,10 +87,12 @@ function GitOpsRunLogs({ className, name, namespace }: Props) {
 
   React.useEffect(() => {
     if (isLoading) return;
-    setToken(data?.nextToken || '');
+    if (data?.logs?.length && data?.nextToken) {
+      setLogs(reverseSort ? [...data.logs, ...logs] : [...logs, ...data.logs]);
+      setToken(data.nextToken);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isLoading, data]);
-
-  const logs = data?.logs || [];
 
   return (
     <Flex className={className} wide tall column>

--- a/ui-cra/src/hooks/gitopsrun.tsx
+++ b/ui-cra/src/hooks/gitopsrun.tsx
@@ -4,11 +4,15 @@ import {
   GetSessionLogsResponse,
 } from '@weaveworks/weave-gitops/ui/lib/api/core/core.pb';
 import { useQuery } from 'react-query';
+import useNotifications from '../contexts/Notifications';
+import { formatError } from '../utils/formatters';
 export const useGetLogs = (req: GetSessionLogsRequest) => {
+  const { setNotifications } = useNotifications();
+  const onError = (error: Error) => setNotifications(formatError(error));
   const { isLoading, data, error } = useQuery<GetSessionLogsResponse, Error>(
     'logs',
     () => coreClient.GetSessionLogs(req),
-    { refetchInterval: 5000 },
+    { retry: false, refetchInterval: 5000, onError },
   );
   return { isLoading, data, error };
 };

--- a/ui-cra/yarn.lock
+++ b/ui-cra/yarn.lock
@@ -2335,10 +2335,10 @@
   resolved "https://npm.pkg.github.com/download/@weaveworks/progressive-delivery/0.0.0-rc13/2628159001f4812b90e068e64fae8de6b4e3f2b4#2628159001f4812b90e068e64fae8de6b4e3f2b4"
   integrity sha512-51ET/FrGwKcBUSqRTtaWTTuWQi/y51JQAFYMT6ctOLaiIXSopCyi3alf4aYDZ5TPFAIdOQapJMYiq2HVj5XxOQ==
 
-"@weaveworks/weave-gitops@npm:@weaveworks/weave-gitops-main@0.16.0-5-g291c9fea":
-  version "0.16.0-5-g291c9fea"
-  resolved "https://npm.pkg.github.com/download/@weaveworks/weave-gitops-main/0.16.0-5-g291c9fea/4b730ac254bce5f518c7819676523778029a68f4#4b730ac254bce5f518c7819676523778029a68f4"
-  integrity sha512-+ayLENlg46Xdj/l4/dKvwQdQgq/YOupFl9oP9KgLL7Vk4JHWOLFC9dmq+0CNH4QVhDlAKAHeqn/6hiwbaYB3+Q==
+"@weaveworks/weave-gitops@npm:@weaveworks/weave-gitops-main@0.16.0-16-g15f6ed26":
+  version "0.16.0-16-g15f6ed26"
+  resolved "https://npm.pkg.github.com/download/@weaveworks/weave-gitops-main/0.16.0-16-g15f6ed26/e47242d4475ea20ea67edf8f12889eb3114d0884#e47242d4475ea20ea67edf8f12889eb3114d0884"
+  integrity sha512-Bfq74TRtP3B+DVVsaX2WQ22VhvMHu8Sz36DPOElrE0aww9IY4/PtTm4SBwaPdXj/2g5SokuasmBBqvXJbETfmA==
   dependencies:
     "@material-ui/core" "^4.12.3"
     "@material-ui/icons" "^4.11.2"


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Closes #2340 

This uses the `nextToken` portion of the log response properly - and adds the notifications context on error.

When we get new logs, we append them to existing logs, and change the token. When there aren't new logs, nothing changes. 

Forgive the slightly erratic video - here it is in action:

https://user-images.githubusercontent.com/65822698/216737494-42c08b2e-30e2-4a3b-b6ad-282cc1eb39e3.mov


When I end my session:
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/65822698/216737830-f3b2cd33-d24e-4309-b025-02e53d914c28.png">