### PR TITLE
Update one-time-password selector for github smoke tests

### DIFF
--- a/test/acceptance/test/pages/login_page.go
+++ b/test/acceptance/test/pages/login_page.go
@@ -82,7 +82,7 @@ func ActivateDeviceGithub(webDriver *agouti.Page) *DeviceActivationGitHub {
 		Password:            webDriver.Find(`input[type=password][name*=password]`),
 		Signin:              webDriver.Find(`input[type=submit][value="Sign in"]`),
 		UserCode:            webDriver.All(`input[type=text][name^=user-code-]`),
-		AuthCode:            webDriver.Find(`input#totp`),
+		AuthCode:            webDriver.Find(`input#app_totp`),
 		Verify:              webDriver.FindByButton(`Verify`),
 		Continue:            webDriver.Find(`[type=submit][name=commit]`),
 		AuthroizeWeaveworks: webDriver.FindByButton(`Authorize weaveworks`),


### PR DESCRIPTION
- Seems github changed it at some point.
- Selecting by name / aria stuff may be more stable..

<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Closes

<!--
Describe what has changed in this PR.
For UI changes also include a screenshot.
-->
**What changed?**

Update the github otp input field css selector in the smoke tests.

<!-- Tell your future self why have you made these changes -->
**Why was this change made?**


GitHub's OTP input field selector id changed


<!--
Explain to your reviewers the key implementation points, including why you made
certain choices in favour of others. Highlight key areas of the code which need
extra attention, and also indicate which parts are less relevant (eg renaming,
refactoring, etc
-->
**How was this change implemented?**

<!--
How have you verified this change/product value? Tested locally?
Added integration/acceptance test(s)?
Unit tests are required.
-->
**How did you validate the change?**

- Downloaded the test artifacts
- Open html
- Try old selector, doesn't work
- Try new selector, works!

<!--
Is it notable for release? e.g. schema updates, configuration or data migration
required? If so, please mention it.
-->
**Release notes**


<!--
Are there any documentation updates that should be made for these changes? We want to keep these sources up to date:
- user-guide: https://docs.gitops.weave.works
- internal docs: https://github.com/weaveworks/weave-gitops-enterprise/tree/main/docs
-->
**Documentation Changes**
