### PR TITLE
Add timestamp tooltip to GitOps Run table

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/sirupsen/logrus v1.9.0
 	github.com/spf13/cobra v1.6.1
 	github.com/stretchr/testify v1.8.1
-	github.com/weaveworks/weave-gitops v0.16.1-0.20230209101124-40066d7e31dd
+	github.com/weaveworks/weave-gitops v0.16.1-0.20230209164609-4d04b4d69a42
 	github.com/weaveworks/weave-gitops-enterprise-credentials v0.0.2
 	github.com/weaveworks/weave-gitops-enterprise/common v0.0.0
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1389,8 +1389,8 @@ github.com/weaveworks/templates-controller v0.1.2 h1:PVPePP8NUnB2OqCsNvHvp8zm2vk
 github.com/weaveworks/templates-controller v0.1.2/go.mod h1:iLs/20GkUY94KzDhRvmctwun7yX3SGJWs8q0gbTu53I=
 github.com/weaveworks/tf-controller/api v0.0.0-20221220150320-3d0f3743ccb4 h1:RRpzQlhbEC5WjL0jaMEvGUSZ8EsxzdqSSzginwSBTyc=
 github.com/weaveworks/tf-controller/api v0.0.0-20221220150320-3d0f3743ccb4/go.mod h1:VK60b9WR7XEK1DvQNOpKEOlIQ56Qcy5KlAIFksQmUxI=
-github.com/weaveworks/weave-gitops v0.16.1-0.20230209101124-40066d7e31dd h1:I1qFO7TpUvAGP50ZX2nefHkJq1bsMJjg5TJT1a5CLqs=
-github.com/weaveworks/weave-gitops v0.16.1-0.20230209101124-40066d7e31dd/go.mod h1:cUnWoB/os7EQY8yxKn9fr+f3Ny8wCXnnF74PPd0l+PU=
+github.com/weaveworks/weave-gitops v0.16.1-0.20230209164609-4d04b4d69a42 h1:H5F/UdLf2pCNjcbjHggDvth1OvXvXAZGrrwR/GNaTyk=
+github.com/weaveworks/weave-gitops v0.16.1-0.20230209164609-4d04b4d69a42/go.mod h1:cUnWoB/os7EQY8yxKn9fr+f3Ny8wCXnnF74PPd0l+PU=
 github.com/weaveworks/weave-gitops-enterprise-credentials v0.0.2 h1:7jeiQehqmI4ds6YIq8TW1Vqhlb6V7G2BVRJ8VM3r99I=
 github.com/weaveworks/weave-gitops-enterprise-credentials v0.0.2/go.mod h1:6PMYg+VtSNePnP7EXyNG+/hNRNZ3r0mQtolIZU4s/J0=
 github.com/xanzy/go-gitlab v0.78.0 h1:8jUHfQVAprG04Av5g0PxVd3CNsZ5hCbojIax7Hba1mE=

--- a/ui-cra/package.json
+++ b/ui-cra/package.json
@@ -24,7 +24,7 @@
     "@types/react-syntax-highlighter": "^13.5.2",
     "@types/styled-components": "^5.1.9",
     "@weaveworks/progressive-delivery": "0.0.0-rc13",
-    "@weaveworks/weave-gitops": "npm:@weaveworks/weave-gitops-main@0.16.0-27-g40066d7e",
+    "@weaveworks/weave-gitops": "npm:@weaveworks/weave-gitops-main@",
     "classnames": "^2.3.1",
     "d3-scale": "4.0.0",
     "d3-time": "^3.0.0",

--- a/ui-cra/src/components/GitOpsRun/List/GitOpsRunTable.tsx
+++ b/ui-cra/src/components/GitOpsRun/List/GitOpsRunTable.tsx
@@ -145,7 +145,11 @@ const GitOpsRunTable: FC<Props> = ({ sessions }) => {
         {
           label: 'Created',
           value: ({ obj }) => (
-            <Timestamp time={obj.metadata.creationTimestamp} hideSeconds />
+            <Timestamp
+              tooltip
+              time={obj.metadata.creationTimestamp}
+              hideSeconds
+            />
           ),
           sortValue: ({ obj }) => obj.metadata.creationTimestamp,
           minWidth: 175,

--- a/ui-cra/yarn.lock
+++ b/ui-cra/yarn.lock
@@ -2335,10 +2335,10 @@
   resolved "https://npm.pkg.github.com/download/@weaveworks/progressive-delivery/0.0.0-rc13/2628159001f4812b90e068e64fae8de6b4e3f2b4#2628159001f4812b90e068e64fae8de6b4e3f2b4"
   integrity sha512-51ET/FrGwKcBUSqRTtaWTTuWQi/y51JQAFYMT6ctOLaiIXSopCyi3alf4aYDZ5TPFAIdOQapJMYiq2HVj5XxOQ==
 
-"@weaveworks/weave-gitops@npm:@weaveworks/weave-gitops-main@0.16.0-27-g40066d7e":
-  version "0.16.0-27-g40066d7e"
-  resolved "https://npm.pkg.github.com/download/@weaveworks/weave-gitops-main/0.16.0-27-g40066d7e/f919c1cf12a35e7e94ab0e40db0101f3ce66e587#f919c1cf12a35e7e94ab0e40db0101f3ce66e587"
-  integrity sha512-0vc0njm9ZN9A1rLmfsQAnB4EZ/JbQq9IhOHLdq2Vs/dAVpHcTfIOuxczN1zI8lBsym87GoYY9rMg4MgWIZPD4A==
+"@weaveworks/weave-gitops@npm:@weaveworks/weave-gitops-main@":
+  version "0.16.0-32-g3f675703"
+  resolved "https://npm.pkg.github.com/download/@weaveworks/weave-gitops-main/0.16.0-32-g3f675703/1602eacd93fe6917d0eb9ece36bc36715f22d9c8#1602eacd93fe6917d0eb9ece36bc36715f22d9c8"
+  integrity sha512-+ZRD/K9sN7xrR/MEB2Uu4Totrh5QRWOcnwHRzO8f8I4X5WX27U8oD6J4U3wlbyaN7stw3MlkAw4ip20wnqNqWQ==
   dependencies:
     "@material-ui/core" "^4.12.3"
     "@material-ui/icons" "^4.11.2"


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Closes [3152](https://github.com/weaveworks/weave-gitops/issues/3152)

Uses the new timestamp tooltip to add a full timestamp to the GitOps Run table

