### PR TITLE
use the correct OIDC_TOKEN_DURATION

### DIFF
--- a/charts/mccp/templates/clusters-service/configmap.yaml
+++ b/charts/mccp/templates/clusters-service/configmap.yaml
@@ -39,7 +39,7 @@ data:
   {{- if .Values.config.oidc.enabled }}
   OIDC_ISSUER_URL: {{ .Values.config.oidc.issuerURL | quote }}
   OIDC_REDIRECT_URL: {{ .Values.config.oidc.redirectURL | quote }}
-  OIDC_COOKIE_DURATION: {{ .Values.config.oidc.cookieDuration | quote }}
+  OIDC_TOKEN_DURATION: {{ .Values.config.oidc.cookieDuration | quote }}
   OIDC_CLAIM_USERNAME: {{ .Values.config.oidc.claimUsername | quote }}
   CUSTOM_OIDC_SCOPES: {{ .Values.config.oidc.customScopes | quote }}
   OIDC_CLAIM_GROUPS: {{ .Values.config.oidc.claimGroups | quote }}


### PR DESCRIPTION
According to this commit here:
https://github.com/weaveworks/weave-gitops-enterprise/blob/0bedf106e66180f4987edcc216998293046e04a9/cmd/clusters-service/app/server.go#L224
the correct variable name is not `OIDC_COOKIE_DURATION` but `TOKEN` duration

I have tested this change in a local context (my deployed WGE instance) and it has the intended effect,
(the variable does connect to the setting so no manipulation of the `args` are needed to get this setting in place.)

<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Fixes #2383 

<!--
Describe what has changed in this PR.
For UI changes also include a screenshot.
-->
**What changed?**
The variable looks like it was simply misaligned

<!-- Tell your future self why have you made these changes -->
**Why was this change made?**
There is no other straightforward way for `cookieDuration` in the mccp chart values to have any effect

<!--
Explain to your reviewers the key implementation points, including why you made
certain choices in favour of others. Highlight key areas of the code which need
extra attention, and also indicate which parts are less relevant (eg renaming,
refactoring, etc
-->
**How was this change implemented?**


<!--
How have you verified this change/product value? Tested locally?
Added integration/acceptance test(s)?
Unit tests are required.
-->
**How did you validate the change?**


<!--
Is it notable for release? e.g. schema updates, configuration or data migration
required? If so, please mention it.
-->
**Release notes**


<!--
Are there any documentation updates that should be made for these changes? We want to keep these sources up to date:
- user-guide: https://docs.gitops.weave.works
- internal docs: https://github.com/weaveworks/weave-gitops-enterprise/tree/main/docs
-->
**Documentation Changes**
