### PR TITLE
Errors on GitOps Run object details pages before GitOps Run objects are ready

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/sirupsen/logrus v1.9.0
 	github.com/spf13/cobra v1.6.1
 	github.com/stretchr/testify v1.8.1
-	github.com/weaveworks/weave-gitops v0.17.1-0.20230217091209-bbc43ef746d2
+	github.com/weaveworks/weave-gitops v0.17.1-0.20230220194849-b061bf0a80f6
 	github.com/weaveworks/weave-gitops-enterprise-credentials v0.0.2
 	github.com/weaveworks/weave-gitops-enterprise/common v0.0.0
 	gopkg.in/yaml.v3 v3.0.1 // indirect
@@ -50,7 +50,7 @@ require (
 	github.com/fluxcd/pkg/apis/meta v0.18.0
 	github.com/fluxcd/pkg/runtime v0.24.0
 	github.com/fluxcd/pkg/untar v0.2.0
-	github.com/fluxcd/source-controller/api v0.32.1
+	github.com/fluxcd/source-controller/api v0.33.0
 	github.com/go-resty/resty/v2 v2.7.0
 	github.com/golang/protobuf v1.5.2
 	github.com/google/go-github/v32 v32.1.0

--- a/go.sum
+++ b/go.sum
@@ -426,8 +426,8 @@ github.com/fluxcd/pkg/ssa v0.22.0 h1:HvJTuiYLZMxCjin7bAqBgnc2RjSqEfYrMbV5yINoM64
 github.com/fluxcd/pkg/ssa v0.22.0/go.mod h1:QND0ZNOQ5EzFxoNKfjUxE9J46AbRK3WKF8YkURwbVg0=
 github.com/fluxcd/pkg/untar v0.2.0 h1:sJXU+FbJcNUb2ffLJNjeR3hwt3X2loVpOMlCUjyFw6E=
 github.com/fluxcd/pkg/untar v0.2.0/go.mod h1:33AyoWaPpjX/xXpczcfhQh2AkB63TFwiR2YwROtv23E=
-github.com/fluxcd/source-controller/api v0.32.1 h1:PD8XEG4k5otsnusZZNEQ9XYY5udHoNgp5bX2yZHcb6k=
-github.com/fluxcd/source-controller/api v0.32.1/go.mod h1:+DiGND4WSNdGkS7loPUroSarif6dHU4VlVgtLMRKCR8=
+github.com/fluxcd/source-controller/api v0.33.0 h1:NZYU3+MNf9puyrTbBa7AJbBDlN7tmt0uw8lyye++5fE=
+github.com/fluxcd/source-controller/api v0.33.0/go.mod h1:+DiGND4WSNdGkS7loPUroSarif6dHU4VlVgtLMRKCR8=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/form3tech-oss/jwt-go v3.2.3+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/frankban/quicktest v1.14.3 h1:FJKSZTDHjyhriyC81FLQ0LY93eSai0ZyR/ZIkd3ZUKE=
@@ -1362,8 +1362,8 @@ github.com/weaveworks/templates-controller v0.1.2 h1:PVPePP8NUnB2OqCsNvHvp8zm2vk
 github.com/weaveworks/templates-controller v0.1.2/go.mod h1:iLs/20GkUY94KzDhRvmctwun7yX3SGJWs8q0gbTu53I=
 github.com/weaveworks/tf-controller/api v0.0.0-20221220150320-3d0f3743ccb4 h1:RRpzQlhbEC5WjL0jaMEvGUSZ8EsxzdqSSzginwSBTyc=
 github.com/weaveworks/tf-controller/api v0.0.0-20221220150320-3d0f3743ccb4/go.mod h1:VK60b9WR7XEK1DvQNOpKEOlIQ56Qcy5KlAIFksQmUxI=
-github.com/weaveworks/weave-gitops v0.17.1-0.20230217091209-bbc43ef746d2 h1:42b0UYpNXN41275psZWn3zYMgXEIa9L4FGzlImarRmc=
-github.com/weaveworks/weave-gitops v0.17.1-0.20230217091209-bbc43ef746d2/go.mod h1:cUnWoB/os7EQY8yxKn9fr+f3Ny8wCXnnF74PPd0l+PU=
+github.com/weaveworks/weave-gitops v0.17.1-0.20230220194849-b061bf0a80f6 h1:t19xKIzu1DnCIAk4Jr1PUvDtArklqYbcL1y6qzPx8cQ=
+github.com/weaveworks/weave-gitops v0.17.1-0.20230220194849-b061bf0a80f6/go.mod h1:KiyIeYvpnrDRhYrMdhbxWgQyGqYy7Nyd7E4KODHkoq8=
 github.com/weaveworks/weave-gitops-enterprise-credentials v0.0.2 h1:7jeiQehqmI4ds6YIq8TW1Vqhlb6V7G2BVRJ8VM3r99I=
 github.com/weaveworks/weave-gitops-enterprise-credentials v0.0.2/go.mod h1:6PMYg+VtSNePnP7EXyNG+/hNRNZ3r0mQtolIZU4s/J0=
 github.com/xanzy/go-gitlab v0.78.0 h1:8jUHfQVAprG04Av5g0PxVd3CNsZ5hCbojIax7Hba1mE=

--- a/ui-cra/package.json
+++ b/ui-cra/package.json
@@ -24,7 +24,7 @@
     "@types/react-syntax-highlighter": "^13.5.2",
     "@types/styled-components": "^5.1.9",
     "@weaveworks/progressive-delivery": "0.0.0-rc13",
-    "@weaveworks/weave-gitops": "npm:@weaveworks/weave-gitops-main@v0.17.0-9-gbbc43ef7",
+    "@weaveworks/weave-gitops": "npm:@weaveworks/weave-gitops-main@0.17.0-18-gb061bf0a",
     "classnames": "^2.3.1",
     "d3-scale": "4.0.0",
     "d3-time": "^3.0.0",

--- a/ui-cra/src/components/GitOpsRun/List/GitOpsRunTable.tsx
+++ b/ui-cra/src/components/GitOpsRun/List/GitOpsRunTable.tsx
@@ -13,6 +13,8 @@ import { FC } from 'react';
 import { Routes } from '../../../utils/nav';
 import CommandCell from './CommandCell';
 
+const sessionObjectsInfo = 'session objects created';
+
 const PortLinks: React.FC<{ ports: string }> = ({ ports = '' }) => {
   const list = ports.split(',');
   return (
@@ -37,7 +39,9 @@ const AutomationLink: React.FC<{ s: FluxObject }> = ({ s }) => {
   const route =
     kind === Kind.Kustomization ? V2Routes.Kustomization : V2Routes.HelmRelease;
 
-  return (
+  const text = `${kind}/${name}`;
+
+  return s.info === sessionObjectsInfo ? (
     <Link
       to={formatURL(route, {
         name,
@@ -45,8 +49,10 @@ const AutomationLink: React.FC<{ s: FluxObject }> = ({ s }) => {
         clusterName,
       })}
     >
-      {kind}/{name}
+      {text}
     </Link>
+  ) : (
+    <>{text}</>
   );
 };
 interface Props {
@@ -104,7 +110,9 @@ const GitOpsRunTable: FC<Props> = ({ sessions }) => {
           value: s => {
             const metadata = s.obj.metadata;
             const clusterName = `${metadata.annotations['run.weave.works/namespace']}/${metadata.name}`;
-            return (
+            const text = 'Bucket/run-dev-bucket';
+
+            return s.info === sessionObjectsInfo ? (
               <Link
                 to={formatURL(V2Routes.Bucket, {
                   name: 'run-dev-bucket',
@@ -112,8 +120,10 @@ const GitOpsRunTable: FC<Props> = ({ sessions }) => {
                   clusterName,
                 })}
               >
-                Bucket/run-dev-bucket
+                {text}
               </Link>
+            ) : (
+              text
             );
           },
         },

--- a/ui-cra/yarn.lock
+++ b/ui-cra/yarn.lock
@@ -2335,10 +2335,10 @@
   resolved "https://npm.pkg.github.com/download/@weaveworks/progressive-delivery/0.0.0-rc13/2628159001f4812b90e068e64fae8de6b4e3f2b4#2628159001f4812b90e068e64fae8de6b4e3f2b4"
   integrity sha512-51ET/FrGwKcBUSqRTtaWTTuWQi/y51JQAFYMT6ctOLaiIXSopCyi3alf4aYDZ5TPFAIdOQapJMYiq2HVj5XxOQ==
 
-"@weaveworks/weave-gitops@npm:@weaveworks/weave-gitops-main@v0.17.0-9-gbbc43ef7":
-  version "0.17.0-9-gbbc43ef7"
-  resolved "https://npm.pkg.github.com/download/@weaveworks/weave-gitops-main/0.17.0-9-gbbc43ef7/bf3632e9bd24dc033e07bfbe5ab0c28a54ed2867#bf3632e9bd24dc033e07bfbe5ab0c28a54ed2867"
-  integrity sha512-P8Xv3NtpGRajdSBDPQ/4McAEU2wtWSgFGadA56WUJ2Zh6pybRmGLAtx2i2ZXBn5ktRMfxN8TlJMH389PeRYNUg==
+"@weaveworks/weave-gitops@npm:@weaveworks/weave-gitops-main@0.17.0-18-gb061bf0a":
+  version "0.17.0-18-gb061bf0a"
+  resolved "https://npm.pkg.github.com/download/@weaveworks/weave-gitops-main/0.17.0-18-gb061bf0a/f7411dff3c8716b84be7837908a3dc3ebbf541ee#f7411dff3c8716b84be7837908a3dc3ebbf541ee"
+  integrity sha512-8YsOKOG2IM+CODtHokfm60aEu+UXtSpx09qbiUGH1oF78x4XWiydS86SHiRYNWlBiiWeROPiGihom9PxO1fSng==
   dependencies:
     "@material-ui/core" "^4.12.3"
     "@material-ui/icons" "^4.11.2"


### PR DESCRIPTION
Closes https://github.com/weaveworks/weave-gitops/issues/3297

- Added displaying session object links only if the session objects have been created.

Description of what was added in OSS:

https://github.com/weaveworks/weave-gitops/pull/3406

Screen recording of links appearing (links start appearing after 0:40):

https://user-images.githubusercontent.com/8824708/219669977-c76137aa-c11f-4b82-9c4a-938512e9a100.mov
