### PR TITLE
Support comments in templates (raw file support)

### DIFF
--- a/charts/templates-controller/crds/capitemplate-crd.yaml
+++ b/charts/templates-controller/crds/capitemplate-crd.yaml
@@ -286,6 +286,8 @@ spec:
                       type: array
                     path:
                       type: string
+                    raw:
+                      type: string
                   type: object
                 type: array
             type: object

--- a/charts/templates-controller/crds/gitopstemplate-crd.yaml
+++ b/charts/templates-controller/crds/gitopstemplate-crd.yaml
@@ -288,6 +288,8 @@ spec:
                       type: array
                     path:
                       type: string
+                    raw:
+                      type: string
                   type: object
                 type: array
             type: object

--- a/cmd/clusters-service/pkg/templates/testdata/text-template5.yaml
+++ b/cmd/clusters-service/pkg/templates/testdata/text-template5.yaml
@@ -1,0 +1,38 @@
+apiVersion: capi.weave.works/v1alpha2
+kind: CAPITemplate
+metadata:
+  name: cluster-template-2
+  annotations:
+    templates.weave.works/delimiters: "${{,}}"
+spec:
+  description: this is test template 2
+  renderType: templating
+  params:
+    - name: CLUSTER_NAME
+      description: This is used for the cluster naming.
+      options: []
+      required: true
+    - name: NAMESPACE
+      required: true
+    - name: CONTROL_PLANE_MACHINE_COUNT
+      required: true
+    - name: KUBERNETES_VERSION
+      required: true
+  resourcetemplates:
+    - raw: |
+        apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+        kind: KubeadmControlPlane
+        metadata:
+          name: ${{ .params.CLUSTER_NAME }}-control-plane
+          namespace: ${{ .params.NAMESPACE }}
+          labels:
+            cluster.x-k8s.io/cluster-name: ${{ .params.CLUSTER_NAME }} #{"$test-comment": "bar"}
+        spec:
+          machineTemplate:
+            infrastructureRef:
+              apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+              kind: DockerMachineTemplate
+              name: ${{ .params.CLUSTER_NAME }}-control-plane
+              namespace: ${{ .params.NAMESPACE }}
+          replicas: ${{ .params.CONTROL_PLANE_MACHINE_COUNT }}
+          version: ${{ .params.KUBERNETES_VERSION }} #{"$promotion": "foo"}

--- a/cmd/clusters-service/pkg/templates/testdata/text-template6.yaml
+++ b/cmd/clusters-service/pkg/templates/testdata/text-template6.yaml
@@ -1,0 +1,42 @@
+apiVersion: capi.weave.works/v1alpha2
+kind: CAPITemplate
+metadata:
+  name: cluster-template-1
+  namespace: default
+  annotations:
+    templates.weave.works/delimiters: "${{,}}"
+spec:
+  description: this is test template 1
+  renderType: templating
+  params:
+    - name: CLUSTER_NAME
+      description: This is used for the cluster naming.
+      options: []
+      required: true
+    - name: NAMESPACE
+      required: true
+    - name: CONTROL_PLANE_MACHINE_COUNT
+      required: true
+    - name: KUBERNETES_VERSION
+      required: true
+  resourcetemplates:
+    - content:
+        - apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+          kind: KubeadmControlPlane
+          metadata:
+            name: "${{ .params.CLUSTER_NAME }}-control-plane"
+            namespace: "${{ .params.NAMESPACE }}"
+          spec:
+            machineTemplate:
+              infrastructureRef:
+                apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+                kind: DockerMachineTemplate
+                name: "${{ .params.CLUSTER_NAME }}-control-plane"
+                namespace: "${{ .params.NAMESPACE }}"
+            replicas: ${{ .params.CONTROL_PLANE_MACHINE_COUNT }}
+            version: "${{ .params.KUBERNETES_VERSION }}"
+      raw: |
+        apiVersion: v1
+        kind: Namespace
+        metadata:
+          name: "${{ .params.NAMESPACE }}"

--- a/go.mod
+++ b/go.mod
@@ -70,7 +70,7 @@ require (
 	github.com/weaveworks/go-checkpoint v0.0.0-20220223124739-fd9899e2b4f2
 	github.com/weaveworks/policy-agent/api v1.0.5
 	github.com/weaveworks/progressive-delivery v0.0.0-20220915081124-d9f0c4063521
-	github.com/weaveworks/templates-controller v0.1.2
+	github.com/weaveworks/templates-controller v0.1.3
 	github.com/xanzy/go-gitlab v0.78.0
 	golang.org/x/crypto v0.3.0
 	golang.org/x/oauth2 v0.3.0
@@ -334,7 +334,7 @@ require (
 	k8s.io/klog/v2 v2.80.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20221110221610-a28e98eb7c70 // indirect
 	k8s.io/kubectl v0.25.4 // indirect
-	k8s.io/utils v0.0.0-20221128185143-99ec85e7a448 // indirect
+	k8s.io/utils v0.0.0-20221128185143-99ec85e7a448
 	oras.land/oras-go v1.2.0 // indirect
 	sigs.k8s.io/cli-utils v0.34.0 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect

--- a/go.sum
+++ b/go.sum
@@ -1358,8 +1358,8 @@ github.com/weaveworks/policy-agent/api v1.0.5 h1:4pqzzta8xPUsE9h9YhGJVg5XQ2NuAU/
 github.com/weaveworks/policy-agent/api v1.0.5/go.mod h1:LlhTiipsV5GSHkL/q7Wa7qrJPZGR9Xtoq2npXTWp9bI=
 github.com/weaveworks/progressive-delivery v0.0.0-20220915081124-d9f0c4063521 h1:EG/SrRMfrUAUCclChn8JwPBlZ5mFtstsnQ1hc241GLg=
 github.com/weaveworks/progressive-delivery v0.0.0-20220915081124-d9f0c4063521/go.mod h1:ib0H6jkIMkHnz/2BpE2Lvj/D6xwhiieiWjUwAcoZ+Oo=
-github.com/weaveworks/templates-controller v0.1.2 h1:PVPePP8NUnB2OqCsNvHvp8zm2vkxttWwS8pMZo+1U/I=
-github.com/weaveworks/templates-controller v0.1.2/go.mod h1:iLs/20GkUY94KzDhRvmctwun7yX3SGJWs8q0gbTu53I=
+github.com/weaveworks/templates-controller v0.1.3 h1:JNkGOV5hRkpU96S75ZOtqhgjMPiwUoUw6CpXiVT6u9A=
+github.com/weaveworks/templates-controller v0.1.3/go.mod h1:iLs/20GkUY94KzDhRvmctwun7yX3SGJWs8q0gbTu53I=
 github.com/weaveworks/tf-controller/api v0.0.0-20221220150320-3d0f3743ccb4 h1:RRpzQlhbEC5WjL0jaMEvGUSZ8EsxzdqSSzginwSBTyc=
 github.com/weaveworks/tf-controller/api v0.0.0-20221220150320-3d0f3743ccb4/go.mod h1:VK60b9WR7XEK1DvQNOpKEOlIQ56Qcy5KlAIFksQmUxI=
 github.com/weaveworks/weave-gitops v0.18.0-rc.0.0.20230223135031-f0a1e3a38bce h1:ABU5DC9259TPDI38y9GeHKepwUnodvs1BnzZ7V0R0NQ=


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234

-->
Closes #1858

<!--
Describe what has changed in this PR.
For UI changes also include a screenshot.
-->
**What changed?**
This PR updates the RenderTemplates function to handle the `raw` field in `resourceTemplates`. The function can now process either the `content` or `raw` field, but will return an error if both fields are supplied.

<!-- Tell your future self why have you made these changes -->
**Why was this change made?**
To enable users to use comments in their templates.

<!--
Explain to your reviewers the key implementation points, including why you made
certain choices in favour of others. Highlight key areas of the code which need
extra attention, and also indicate which parts are less relevant (eg renaming,
refactoring, etc
-->
**How was this change implemented?**

<!--
How have you verified this change/product value? Tested locally?
Added integration/acceptance test(s)?
Unit tests are required.
-->
**How did you validate the change?**
Unit tests.

<!--
Is it notable for release? e.g. schema updates, configuration or data migration
required? If so, please mention it.
-->
**Release notes**


<!--
Are there any documentation updates that should be made for these changes? We want to keep these sources up to date:
- user-guide: https://docs.gitops.weave.works
- internal docs: https://github.com/weaveworks/weave-gitops-enterprise/tree/main/docs
-->
**Documentation Changes**
