### PR TITLE
[PEPSI] Update to OSS with longer refresh token expiration

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/sirupsen/logrus v1.9.0
 	github.com/spf13/cobra v1.6.1
 	github.com/stretchr/testify v1.8.1
-	github.com/weaveworks/weave-gitops v0.18.0
+	github.com/weaveworks/weave-gitops v0.18.1-0.20230302161705-49cd7b6f85fa
 	github.com/weaveworks/weave-gitops-enterprise-credentials v0.0.2
 	github.com/weaveworks/weave-gitops-enterprise/common v0.0.0
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1362,10 +1362,8 @@ github.com/weaveworks/templates-controller v0.1.3 h1:JNkGOV5hRkpU96S75ZOtqhgjMPi
 github.com/weaveworks/templates-controller v0.1.3/go.mod h1:iLs/20GkUY94KzDhRvmctwun7yX3SGJWs8q0gbTu53I=
 github.com/weaveworks/tf-controller/api v0.0.0-20221220150320-3d0f3743ccb4 h1:RRpzQlhbEC5WjL0jaMEvGUSZ8EsxzdqSSzginwSBTyc=
 github.com/weaveworks/tf-controller/api v0.0.0-20221220150320-3d0f3743ccb4/go.mod h1:VK60b9WR7XEK1DvQNOpKEOlIQ56Qcy5KlAIFksQmUxI=
-github.com/weaveworks/weave-gitops v0.18.0-rc.0.0.20230301095859-d48bd12d6810 h1:uBXJrn3rVORyKtOYgf/qQeufWq/I57XNJ6kAGLzkSSY=
-github.com/weaveworks/weave-gitops v0.18.0-rc.0.0.20230301095859-d48bd12d6810/go.mod h1:MYxa0F0O/Qlc7OW7TN6y79ck+NG+1h7urJ0mvRX0LiE=
-github.com/weaveworks/weave-gitops v0.18.0 h1:RgSUS/hrC4mXRRHixB5DAX/wguiKbSqSRqsmEBSj3o0=
-github.com/weaveworks/weave-gitops v0.18.0/go.mod h1:MYxa0F0O/Qlc7OW7TN6y79ck+NG+1h7urJ0mvRX0LiE=
+github.com/weaveworks/weave-gitops v0.18.1-0.20230302161705-49cd7b6f85fa h1:O8e2IPF7g22GoKUqTStrTR6KRbSJkaQjZOFBB/wOByM=
+github.com/weaveworks/weave-gitops v0.18.1-0.20230302161705-49cd7b6f85fa/go.mod h1:MYxa0F0O/Qlc7OW7TN6y79ck+NG+1h7urJ0mvRX0LiE=
 github.com/weaveworks/weave-gitops-enterprise-credentials v0.0.2 h1:7jeiQehqmI4ds6YIq8TW1Vqhlb6V7G2BVRJ8VM3r99I=
 github.com/weaveworks/weave-gitops-enterprise-credentials v0.0.2/go.mod h1:6PMYg+VtSNePnP7EXyNG+/hNRNZ3r0mQtolIZU4s/J0=
 github.com/xanzy/go-gitlab v0.78.0 h1:8jUHfQVAprG04Av5g0PxVd3CNsZ5hCbojIax7Hba1mE=

--- a/ui-cra/package.json
+++ b/ui-cra/package.json
@@ -24,7 +24,7 @@
     "@types/react-syntax-highlighter": "^13.5.2",
     "@types/styled-components": "^5.1.9",
     "@weaveworks/progressive-delivery": "0.0.0-rc13",
-    "@weaveworks/weave-gitops": "0.18.0",
+    "@weaveworks/weave-gitops": "npm:@weaveworks/weave-gitops-main@0.18.0-2-g49cd7b6f",
     "classnames": "^2.3.1",
     "d3-scale": "4.0.0",
     "d3-time": "^3.0.0",

--- a/ui-cra/yarn.lock
+++ b/ui-cra/yarn.lock
@@ -2335,10 +2335,10 @@
   resolved "https://npm.pkg.github.com/download/@weaveworks/progressive-delivery/0.0.0-rc13/2628159001f4812b90e068e64fae8de6b4e3f2b4#2628159001f4812b90e068e64fae8de6b4e3f2b4"
   integrity sha512-51ET/FrGwKcBUSqRTtaWTTuWQi/y51JQAFYMT6ctOLaiIXSopCyi3alf4aYDZ5TPFAIdOQapJMYiq2HVj5XxOQ==
 
-"@weaveworks/weave-gitops@0.18.0":
-  version "0.18.0"
-  resolved "https://npm.pkg.github.com/download/@weaveworks/weave-gitops/0.18.0/af8de1b5d15a5d52fabae240e3735f287aeeceb8#af8de1b5d15a5d52fabae240e3735f287aeeceb8"
-  integrity sha512-Xs9AbHt7fbAekeBvRcR8A8C3sH+gqH1HWOYDqpX99ih3QH9Bp6ll4XzU697DXK7X1cOdSgrCoQoQYNRSdhOY+w==
+"@weaveworks/weave-gitops@npm:@weaveworks/weave-gitops-main@0.18.0-2-g49cd7b6f":
+  version "0.18.0-2-g49cd7b6f"
+  resolved "https://npm.pkg.github.com/download/@weaveworks/weave-gitops-main/0.18.0-2-g49cd7b6f/e0403c44658ceb9f68237ebf59dad598e7d734ab#e0403c44658ceb9f68237ebf59dad598e7d734ab"
+  integrity sha512-+ebqGgTcCKKX0trR5z+JP5suXIZPQdQd1fQUEbvMnjpmruqPSaWtgSQLvEeK3etpTq6kYHDsNsL4UwD5WrXHuw==
   dependencies:
     "@material-ui/core" "^4.12.3"
     "@material-ui/icons" "^4.11.2"


### PR DESCRIPTION
- This version of OSS expires the refreshToken 1h after the id_token to avoid them both being deleted at the same time and breaking refreshing.
- Setting the tokenDuration configuration so that it is greater than the IdP's id_token expiration will probably also work. This is to handle cases where id_token expiration < tokenDuration

<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Closes

<!--
Describe what has changed in this PR.
For UI changes also include a screenshot.
-->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why was this change made?**


<!--
Explain to your reviewers the key implementation points, including why you made
certain choices in favour of others. Highlight key areas of the code which need
extra attention, and also indicate which parts are less relevant (eg renaming,
refactoring, etc
-->
**How was this change implemented?**


<!--
How have you verified this change/product value? Tested locally?
Added integration/acceptance test(s)?
Unit tests are required.
-->
**How did you validate the change?**


<!--
Is it notable for release? e.g. schema updates, configuration or data migration
required? If so, please mention it.
-->
**Release notes**


<!--
Are there any documentation updates that should be made for these changes? We want to keep these sources up to date:
- user-guide: https://docs.gitops.weave.works
- internal docs: https://github.com/weaveworks/weave-gitops-enterprise/tree/main/docs
-->
**Documentation Changes**
