### PR TITLE
Up to gitopssets-controller 0.5.1

### DIFF
--- a/charts/gitopssets-controller/crds/gitopsset-crd.yaml
+++ b/charts/gitopssets-controller/crds/gitopsset-crd.yaml
@@ -197,8 +197,6 @@ spec:
                           description: RepositoryRef is the name of a GitRepository
                             resource to be generated from.
                           type: string
-                      required:
-                      - directories
                       type: object
                     list:
                       description: ListGenerator generates from a hard-coded list.
@@ -376,8 +374,6 @@ spec:
                                     description: RepositoryRef is the name of a GitRepository
                                       resource to be generated from.
                                     type: string
-                                required:
-                                - directories
                                 type: object
                               list:
                                 description: ListGenerator generates from a hard-coded

--- a/charts/mccp/values.yaml
+++ b/charts/mccp/values.yaml
@@ -183,4 +183,4 @@ gitopssets-controller:
   controllerManager:
     manager:
       image:
-        tag: v0.5.0
+        tag: v0.5.1


### PR DESCRIPTION
To fix `directories` being required in the gitopssets-controller gitRepository generator.

https://github.com/weaveworks/gitopssets-controller/releases/tag/v0.5.1