### PR TITLE
Leave Port Forwards column empty in case there are none

### DIFF
--- a/ui-cra/src/components/GitOpsRun/List/GitOpsRunTable.tsx
+++ b/ui-cra/src/components/GitOpsRun/List/GitOpsRunTable.tsx
@@ -137,7 +137,10 @@ const GitOpsRunTable: FC<Props> = ({ sessions }) => {
           value: ({ obj }) => {
             const ports: string =
               obj.metadata.annotations['run.weave.works/port-forward'];
-            return <PortLinks ports={ports} />;
+            if (ports?.length) {
+                return <PortLinks ports={ports} />;
+            }
+            return null;
           },
           sortValue: ({ obj }) =>
             obj.metadata.annotations['run.weave.works/port-forward'],


### PR DESCRIPTION
In GitOps Run there's not always any ports forwarded to the cluster so
the UI code needs to handle that case.

closes #2392
