### PR TITLE
fix: Rewrote tests to avoid having to use gingko setup to execute them

### DIFF
--- a/pkg/gitauth/server/gitproviders/repo_url_test.go
+++ b/pkg/gitauth/server/gitproviders/repo_url_test.go
@@ -2,56 +2,77 @@ package gitproviders
 
 import (
 	"net/url"
+	"testing"
 
-	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/spf13/viper"
 )
 
-var _ = DescribeTable("detectGitProviderFromURL", func(input string, expected GitProviderName) {
-	result, err := detectGitProviderFromURL(input, map[string]string{
-		"bitbucket.weave.works": "bitbucket-server",
-	})
-	Expect(err).NotTo(HaveOccurred())
-	Expect(result).To(Equal(expected))
-},
-	Entry("ssh+github", "ssh://git@github.com/weaveworks/weave-gitops.git", GitProviderGitHub),
-	Entry("ssh+gitlab", "ssh://git@gitlab.com/weaveworks/weave-gitops.git", GitProviderGitLab),
-	Entry("https+bitbucket", "https://bitbucket.weave.works/scm/wg/config.git", GitProviderBitBucketServer),
-)
+func TestDetectGitProviderFromURL(t *testing.T) {
+	g := NewGomegaWithT(t)
 
-var _ = Describe("get owner from url", func() {
-	DescribeTable("getOwnerFromURL", func(normalizedURL string, providerName GitProviderName, expected string) {
-		u, err := url.Parse(normalizedURL)
-		Expect(err).NotTo(HaveOccurred())
-		result, err := getOwnerFromURL(*u, providerName)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(result).To(Equal(expected))
-	},
-		Entry("github", "ssh://git@github.com/weaveworks/weave-gitops.git", GitProviderGitHub, "weaveworks"),
-		Entry("gitlab", "ssh://git@gitlab.com/weaveworks/weave-gitops.git", GitProviderGitLab, "weaveworks"),
-		Entry("gitlab", "ssh://git@gitlab.com/weaveworks/infra/weave-gitops.git", GitProviderGitLab, "weaveworks/infra"),
-		Entry("gitlab", "ssh://git@gitlab.com/weaveworks/infra/dev/weave-gitops.git", GitProviderGitLab, "weaveworks/infra/dev"),
-	)
+	tests := []struct {
+		name     string
+		url      string
+		provider GitProviderName
+	}{
+		{name: "ssh+github", url: "ssh://git@github.com/weaveworks/weave-gitops.git", provider: GitProviderGitHub},
+		{name: "ssh+gitlab", url: "ssh://git@gitlab.com/weaveworks/weave-gitops.git", provider: GitProviderGitLab},
+		{name: "https+bitbucket", url: "https://bitbucket.weave.works/scm/wg/config.git", provider: GitProviderBitBucketServer},
+	}
 
-	It("missing owner", func() {
-		normalizedURL := "ssh://git@gitlab.com/weave-gitops.git"
-		u, err := url.Parse(normalizedURL)
-		Expect(err).NotTo(HaveOccurred())
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			provider, err := detectGitProviderFromURL(tt.url, map[string]string{
+				"bitbucket.weave.works": "bitbucket-server",
+			})
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(provider).To(Equal(tt.provider))
+		})
+	}
+}
+
+func TestGetOwnerFromURL(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	tests := []struct {
+		name     string
+		url      string
+		provider GitProviderName
+		owner    string
+	}{
+		{name: "github", url: "ssh://git@github.com/weaveworks/weave-gitops.git", provider: GitProviderGitHub, owner: "weaveworks"},
+		{name: "gitlab", url: "ssh://git@gitlab.com/weaveworks/weave-gitops.git", provider: GitProviderGitLab, owner: "weaveworks"},
+		{name: "gitlab with subgroup", url: "ssh://git@gitlab.com/weaveworks/infra/weave-gitops.git", provider: GitProviderGitLab, owner: "weaveworks/infra"},
+		{name: "gitlab with nested subgroup", url: "ssh://git@gitlab.com/weaveworks/infra/dev/weave-gitops.git", provider: GitProviderGitLab, owner: "weaveworks/infra/dev"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			u, err := url.Parse(tt.url)
+			g.Expect(err).NotTo(HaveOccurred())
+			owner, err := getOwnerFromURL(*u, tt.provider)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(owner).To(Equal(tt.owner))
+		})
+	}
+
+	t.Run("missing owner", func(t *testing.T) {
+		u, err := url.Parse("ssh://git@gitlab.com/weave-gitops.git")
+		g.Expect(err).NotTo(HaveOccurred())
 		_, err = getOwnerFromURL(*u, GitProviderGitLab)
-		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(Equal("could not get owner from url ssh://git@gitlab.com/weave-gitops.git"))
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(Equal("could not get owner from url ssh://git@gitlab.com/weave-gitops.git"))
 	})
 
-	It("empty url", func() {
-		normalizedURL := ""
-		u, err := url.Parse(normalizedURL)
-		Expect(err).NotTo(HaveOccurred())
+	t.Run("empty url", func(t *testing.T) {
+		u, err := url.Parse("")
+		g.Expect(err).NotTo(HaveOccurred())
 		_, err = getOwnerFromURL(*u, GitProviderGitLab)
-		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(Equal("could not get owner from url "))
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(Equal("could not get owner from url "))
 	})
-})
+}
 
 type expectedRepoURL struct {
 	s        string
@@ -61,93 +82,155 @@ type expectedRepoURL struct {
 	protocol RepositoryURLProtocol
 }
 
-var _ = DescribeTable("NewRepoURL", func(input, gitProviderEnv string, expected expectedRepoURL) {
-	if gitProviderEnv != "" {
-		viper.Set("git-host-types", gitProviderEnv)
-	}
-	result, err := NewRepoURL(input)
-	Expect(err).NotTo(HaveOccurred())
+func TestNewRepoURL(t *testing.T) {
+	g := NewGomegaWithT(t)
 
-	Expect(result.String()).To(Equal(expected.s))
-	u, err := url.Parse(expected.s)
-	Expect(err).NotTo(HaveOccurred())
-	Expect(result.URL()).To(Equal(u))
-	Expect(result.Owner()).To(Equal(expected.owner))
-	Expect(result.Provider()).To(Equal(expected.provider))
-	Expect(result.Protocol()).To(Equal(expected.protocol))
-},
-	Entry("github git clone style", "git@github.com:someuser/podinfo.git", "", expectedRepoURL{
-		s:        "ssh://git@github.com/someuser/podinfo.git",
-		owner:    "someuser",
-		name:     "podinfo",
-		provider: GitProviderGitHub,
-		protocol: RepositoryURLProtocolSSH,
-	}),
-	Entry("github url style", "ssh://git@github.com/someuser/podinfo.git", "", expectedRepoURL{
-		s:        "ssh://git@github.com/someuser/podinfo.git",
-		owner:    "someuser",
-		name:     "podinfo",
-		provider: GitProviderGitHub,
-		protocol: RepositoryURLProtocolSSH,
-	}),
-	Entry("github https", "https://github.com/someuser/podinfo.git", "", expectedRepoURL{
-		s:        "ssh://git@github.com/someuser/podinfo.git",
-		owner:    "someuser",
-		name:     "podinfo",
-		provider: GitProviderGitHub,
-		protocol: RepositoryURLProtocolSSH,
-	}),
-	Entry("gitlab git clone style", "git@gitlab.com:someuser/podinfo.git", "", expectedRepoURL{
-		s:        "ssh://git@gitlab.com/someuser/podinfo.git",
-		owner:    "someuser",
-		name:     "podinfo",
-		provider: GitProviderGitLab,
-		protocol: RepositoryURLProtocolSSH,
-	}),
-	Entry("gitlab https", "https://gitlab.com/someuser/podinfo.git", "", expectedRepoURL{
-		s:        "ssh://git@gitlab.com/someuser/podinfo.git",
-		owner:    "someuser",
-		name:     "podinfo",
-		provider: GitProviderGitLab,
-		protocol: RepositoryURLProtocolSSH,
-	}),
-	Entry("trailing slash in url", "https://github.com/sympatheticmoose/podinfo-deploy/", "", expectedRepoURL{
-		s:        "ssh://git@github.com/sympatheticmoose/podinfo-deploy.git",
-		owner:    "sympatheticmoose",
-		name:     "podinfo-deploy",
-		provider: GitProviderGitHub,
-		protocol: RepositoryURLProtocolSSH,
-	}),
-	Entry("subsubgroup", "https://github.com/sympatheticmoose/infra/dev/podinfo-deploy/", "", expectedRepoURL{
-		s:        "ssh://git@github.com/sympatheticmoose/infra/dev/podinfo-deploy.git",
-		owner:    "sympatheticmoose/infra/dev",
-		name:     "podinfo-deploy",
-		provider: GitProviderGitHub,
-		protocol: RepositoryURLProtocolSSH,
-	}),
-	Entry(
-		"custom domain",
-		"git@gitlab.acme.org/sympatheticmoose/podinfo-deploy/",
-		"gitlab.acme.org=gitlab",
-		expectedRepoURL{
-			s:        "ssh://git@gitlab.acme.org/sympatheticmoose/podinfo-deploy.git",
-			owner:    "sympatheticmoose",
-			name:     "podinfo-deploy",
-			provider: "gitlab",
-			protocol: RepositoryURLProtocolSSH,
-		}),
-	Entry("azure ssh clone", "git@ssh.dev.azure.com:v3/weaveworks/weave-gitops-integration/config", "", expectedRepoURL{
-		s:        "ssh://git@ssh.dev.azure.com/v3/weaveworks/weave-gitops-integration/config.git",
-		owner:    "weaveworks/weave-gitops-integration",
-		name:     "config",
-		provider: GitProviderAzureDevOps,
-		protocol: RepositoryURLProtocolSSH,
-	}),
-	Entry("azure https clone", "https://weaveworks@dev.azure.com/weaveworks/weave-gitops-integration/_git/config", "", expectedRepoURL{
-		s:        "ssh://git@dev.azure.com/weaveworks/weave-gitops-integration/_git/config.git",
-		owner:    "weaveworks/weave-gitops-integration",
-		name:     "config",
-		provider: GitProviderAzureDevOps,
-		protocol: RepositoryURLProtocolSSH,
-	}),
-)
+	tests := []struct {
+		name           string
+		url            string
+		gitProviderEnv string
+		result         expectedRepoURL
+	}{
+
+		{
+			name: "github git clone style",
+			url:  "git@github.com:someuser/podinfo.git",
+			result: expectedRepoURL{
+				s:        "ssh://git@github.com/someuser/podinfo.git",
+				owner:    "someuser",
+				name:     "podinfo",
+				provider: GitProviderGitHub,
+				protocol: RepositoryURLProtocolSSH,
+			},
+		},
+		{
+			name: "github url style",
+			url:  "ssh://git@github.com/someuser/podinfo.git",
+			result: expectedRepoURL{
+				s:        "ssh://git@github.com/someuser/podinfo.git",
+				owner:    "someuser",
+				name:     "podinfo",
+				provider: GitProviderGitHub,
+				protocol: RepositoryURLProtocolSSH,
+			},
+		},
+		{
+			name: "github https",
+			url:  "https://github.com/someuser/podinfo.git",
+			result: expectedRepoURL{
+				s:        "ssh://git@github.com/someuser/podinfo.git",
+				owner:    "someuser",
+				name:     "podinfo",
+				provider: GitProviderGitHub,
+				protocol: RepositoryURLProtocolSSH,
+			},
+		},
+		{
+			name: "gitlab git clone style",
+			url:  "git@gitlab.com:someuser/podinfo.git",
+			result: expectedRepoURL{
+				s:        "ssh://git@gitlab.com/someuser/podinfo.git",
+				owner:    "someuser",
+				name:     "podinfo",
+				provider: GitProviderGitLab,
+				protocol: RepositoryURLProtocolSSH,
+			},
+		},
+		{
+			name: "gitlab https",
+			url:  "https://gitlab.com/someuser/podinfo.git",
+			result: expectedRepoURL{
+				s:        "ssh://git@gitlab.com/someuser/podinfo.git",
+				owner:    "someuser",
+				name:     "podinfo",
+				provider: GitProviderGitLab,
+				protocol: RepositoryURLProtocolSSH,
+			},
+		},
+		{
+			name: "trailing slash in url",
+			url:  "https://github.com/sympatheticmoose/podinfo-deploy/",
+			result: expectedRepoURL{
+				s:        "ssh://git@github.com/sympatheticmoose/podinfo-deploy.git",
+				owner:    "sympatheticmoose",
+				name:     "podinfo-deploy",
+				provider: GitProviderGitHub,
+				protocol: RepositoryURLProtocolSSH,
+			},
+		},
+		{
+			name: "subsubgroup",
+			url:  "https://github.com/sympatheticmoose/infra/dev/podinfo-deploy/",
+			result: expectedRepoURL{
+				s:        "ssh://git@github.com/sympatheticmoose/infra/dev/podinfo-deploy.git",
+				owner:    "sympatheticmoose/infra/dev",
+				name:     "podinfo-deploy",
+				provider: GitProviderGitHub,
+				protocol: RepositoryURLProtocolSSH,
+			},
+		},
+		{
+			name:           "custom domain",
+			url:            "git@gitlab.acme.org/sympatheticmoose/podinfo-deploy/",
+			gitProviderEnv: "gitlab.acme.org=gitlab",
+			result: expectedRepoURL{
+				s:        "ssh://git@gitlab.acme.org/sympatheticmoose/podinfo-deploy.git",
+				owner:    "sympatheticmoose",
+				name:     "podinfo-deploy",
+				provider: "gitlab",
+				protocol: RepositoryURLProtocolSSH,
+			},
+		},
+		{
+			name: "azure ssh clone",
+			url:  "git@ssh.dev.azure.com:v3/weaveworks/weave-gitops-integration/config",
+			result: expectedRepoURL{
+				s:        "ssh://git@ssh.dev.azure.com/v3/weaveworks/weave-gitops-integration/config.git",
+				owner:    "weaveworks/weave-gitops-integration",
+				name:     "config",
+				provider: GitProviderAzureDevOps,
+				protocol: RepositoryURLProtocolSSH,
+			},
+		},
+		{
+			name: "azure https clone",
+			url:  "https://weaveworks@dev.azure.com/weaveworks/weave-gitops-integration/_git/config",
+			result: expectedRepoURL{
+				s:        "ssh://git@dev.azure.com/weaveworks/weave-gitops-integration/_git/config.git",
+				owner:    "weaveworks/weave-gitops-integration",
+				name:     "config",
+				provider: GitProviderAzureDevOps,
+				protocol: RepositoryURLProtocolSSH,
+			},
+		},
+		{
+			name: "azure https",
+			url:  "https://dev.azure.com/weaveworks/weave-gitops-integration/_git/config",
+			result: expectedRepoURL{
+				s:        "ssh://git@dev.azure.com/weaveworks/weave-gitops-integration/_git/config.git",
+				owner:    "weaveworks/weave-gitops-integration",
+				name:     "config",
+				provider: GitProviderAzureDevOps,
+				protocol: RepositoryURLProtocolSSH,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.gitProviderEnv != "" {
+				viper.Set("git-host-types", tt.gitProviderEnv)
+			}
+			result, err := NewRepoURL(tt.url)
+			g.Expect(err).NotTo(HaveOccurred())
+
+			g.Expect(result.String()).To(Equal(tt.result.s))
+			u, err := url.Parse(tt.result.s)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(result.URL()).To(Equal(u))
+			g.Expect(result.Owner()).To(Equal(tt.result.owner))
+			g.Expect(result.Provider()).To(Equal(tt.result.provider))
+			g.Expect(result.Protocol()).To(Equal(tt.result.protocol))
+		})
+	}
+}


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->

<!--
Describe what has changed in this PR.
For UI changes also include a screenshot.
-->
**What changed?**
The tests that have been updated, were written in a way that required Gingko setup to execute. Now they can be executed using `go test`.

<!-- Tell your future self why have you made these changes -->
**Why was this change made?**
These tests were not running before because Gingko is not setup in CI.

<!--
Explain to your reviewers the key implementation points, including why you made
certain choices in favour of others. Highlight key areas of the code which need
extra attention, and also indicate which parts are less relevant (eg renaming,
refactoring, etc
-->
**How was this change implemented?**
N/A

<!--
How have you verified this change/product value? Tested locally?
Added integration/acceptance test(s)?
Unit tests are required.
-->
**How did you validate the change?**
N/A

<!--
Is it notable for release? e.g. schema updates, configuration or data migration
required? If so, please mention it.
-->
**Release notes**
N/A

<!--
Are there any documentation updates that should be made for these changes? We want to keep these sources up to date:
- user-guide: https://docs.gitops.weave.works
- internal docs: https://github.com/weaveworks/weave-gitops-enterprise/tree/main/docs
-->
**Documentation Changes**
N/A