### PR TITLE
Support yaml commands for objects without namespaces

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/sirupsen/logrus v1.9.0
 	github.com/spf13/cobra v1.6.1
 	github.com/stretchr/testify v1.8.2
-	github.com/weaveworks/weave-gitops v0.19.1-0.20230316090717-efdd1e1fe2a6
+	github.com/weaveworks/weave-gitops v0.19.1-0.20230320180007-c3bdb387f664
 	github.com/weaveworks/weave-gitops-enterprise-credentials v0.0.2
 	github.com/weaveworks/weave-gitops-enterprise/common v0.0.0
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1341,8 +1341,8 @@ github.com/weaveworks/templates-controller v0.1.4 h1:kCKfXhX5PVqsHV9R7/AbVn2nqHR
 github.com/weaveworks/templates-controller v0.1.4/go.mod h1:Z/SQzXvD43LXUD//9D9PcDczK0GKMYZlJtrMP57uk+Y=
 github.com/weaveworks/tf-controller/api v0.0.0-20221220150320-3d0f3743ccb4 h1:RRpzQlhbEC5WjL0jaMEvGUSZ8EsxzdqSSzginwSBTyc=
 github.com/weaveworks/tf-controller/api v0.0.0-20221220150320-3d0f3743ccb4/go.mod h1:VK60b9WR7XEK1DvQNOpKEOlIQ56Qcy5KlAIFksQmUxI=
-github.com/weaveworks/weave-gitops v0.19.1-0.20230316090717-efdd1e1fe2a6 h1:G9sOZtEQJ1bX3Vy8p4BwkU4hul6Riyn1utiKD2z1e6c=
-github.com/weaveworks/weave-gitops v0.19.1-0.20230316090717-efdd1e1fe2a6/go.mod h1:sa0PNyyEgoVgKLTyhF1tJ+tHHk5kXevcqcjkooWxVF4=
+github.com/weaveworks/weave-gitops v0.19.1-0.20230320180007-c3bdb387f664 h1:6MyaDXPF3pSQGiJNePXW6wfB1EBCxwAzIlKMWL8SO+k=
+github.com/weaveworks/weave-gitops v0.19.1-0.20230320180007-c3bdb387f664/go.mod h1:sa0PNyyEgoVgKLTyhF1tJ+tHHk5kXevcqcjkooWxVF4=
 github.com/weaveworks/weave-gitops-enterprise-credentials v0.0.2 h1:7jeiQehqmI4ds6YIq8TW1Vqhlb6V7G2BVRJ8VM3r99I=
 github.com/weaveworks/weave-gitops-enterprise-credentials v0.0.2/go.mod h1:6PMYg+VtSNePnP7EXyNG+/hNRNZ3r0mQtolIZU4s/J0=
 github.com/xanzy/go-gitlab v0.78.0 h1:8jUHfQVAprG04Av5g0PxVd3CNsZ5hCbojIax7Hba1mE=

--- a/ui-cra/package.json
+++ b/ui-cra/package.json
@@ -24,7 +24,7 @@
     "@types/react-syntax-highlighter": "^13.5.2",
     "@types/styled-components": "^5.1.9",
     "@weaveworks/progressive-delivery": "0.0.0-rc13",
-    "@weaveworks/weave-gitops": "0.19.0",
+    "@weaveworks/weave-gitops": "npm:@weaveworks/weave-gitops-main@0.19.0-11-gc3bdb387",
     "classnames": "^2.3.1",
     "d3-scale": "4.0.0",
     "d3-time": "^3.0.0",

--- a/ui-cra/src/components/CodeView.tsx
+++ b/ui-cra/src/components/CodeView.tsx
@@ -2,7 +2,7 @@ import {
   Canary,
   CanaryMetricTemplate,
 } from '@weaveworks/progressive-delivery/api/prog/types.pb';
-import { CopyToClipboard } from '@weaveworks/weave-gitops';
+import { CopyToClipboard, createYamlCommand } from '@weaveworks/weave-gitops';
 import styled from 'styled-components';
 
 type Props = {
@@ -28,13 +28,11 @@ const deletionColor = '#814a1c';
 const updateColor = '#787118';
 
 function CodeView({ code, object, className, kind, colorizeChanges }: Props) {
-  let headerText = '';
-
-  if (kind && object) {
-    headerText = `kubectl get ${kind.toLowerCase()} ${object.name} -n ${
-      object.namespace
-    } -o yaml `;
-  }
+  let headerText = createYamlCommand(
+    kind || '',
+    object?.name || '',
+    object?.namespace || '',
+  );
 
   return (
     <div className={className}>

--- a/ui-cra/yarn.lock
+++ b/ui-cra/yarn.lock
@@ -2335,10 +2335,10 @@
   resolved "https://npm.pkg.github.com/download/@weaveworks/progressive-delivery/0.0.0-rc13/2628159001f4812b90e068e64fae8de6b4e3f2b4#2628159001f4812b90e068e64fae8de6b4e3f2b4"
   integrity sha512-51ET/FrGwKcBUSqRTtaWTTuWQi/y51JQAFYMT6ctOLaiIXSopCyi3alf4aYDZ5TPFAIdOQapJMYiq2HVj5XxOQ==
 
-"@weaveworks/weave-gitops@0.19.0":
-  version "0.19.0"
-  resolved "https://npm.pkg.github.com/download/@weaveworks/weave-gitops/0.19.0/6f105e4cf6d692891eb3950e9a9a47e7f50aef37#6f105e4cf6d692891eb3950e9a9a47e7f50aef37"
-  integrity sha512-160064lYxlAt78rJhp5NQvTMbCJST6e3FdSjzHtRMpUsDssEC4VqoORLcmBgMrqaGlrQ4fWs+ZJ8hC16ebPIlA==
+"@weaveworks/weave-gitops@npm:@weaveworks/weave-gitops-main@0.19.0-11-gc3bdb387":
+  version "0.19.0-11-gc3bdb387"
+  resolved "https://npm.pkg.github.com/download/@weaveworks/weave-gitops-main/0.19.0-11-gc3bdb387/78c163f711f3b7bba9164571f7744fbda7d29612#78c163f711f3b7bba9164571f7744fbda7d29612"
+  integrity sha512-qRpEcVcSn5TxC+31O8MVBuXpF95ojIsLkVl87EAgKJmpHib3iOPl/SNFn3BoFsT6wZc3qKiR22GBqBiPNgiRYA==
   dependencies:
     "@material-ui/core" "^4.12.3"
     "@material-ui/icons" "^4.11.2"


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Closes #[3530](https://github.com/weaveworks/weave-gitops/issues/3530)

Imports `createYamlCommand` from OSS #[3539](https://app.zenhub.com/workspaces/team-denim-620d1a3e7981e80013070165/issues/gh/weaveworks/weave-gitops/3539) and adds to `CodeView`
