### PR TITLE
fix: the new git provider didn't commit all required files

### DIFF
--- a/pkg/git/github_test.go
+++ b/pkg/git/github_test.go
@@ -73,6 +73,10 @@ func TestCreatePullRequestInGitHubOrganization(t *testing.T) {
 						Path:    "management/cluster-01.yaml",
 						Content: &content,
 					},
+					{
+						Path:    "management/cluster-02.yaml",
+						Content: &content,
+					},
 				},
 			},
 		},
@@ -84,7 +88,7 @@ func TestCreatePullRequestInGitHubOrganization(t *testing.T) {
 	assert.Equal(t, pr.GetHTMLURL(), res.Link)
 	assert.Equal(t, pr.GetTitle(), "New cluster")
 	assert.Equal(t, pr.GetBody(), "Creates a cluster through a CAPI template")
-	assert.Equal(t, pr.GetChangedFiles(), 1)
+	assert.Equal(t, pr.GetChangedFiles(), 2)
 }
 
 func TestCreatePullRequestInGitHubUser(t *testing.T) {

--- a/pkg/git/gitlab_test.go
+++ b/pkg/git/gitlab_test.go
@@ -92,6 +92,10 @@ func TestCreatePullRequestInGitLab(t *testing.T) {
 						Path:    "management/cluster-01.yaml",
 						Content: &content,
 					},
+					{
+						Path:    "management/cluster-02.yaml",
+						Content: &content,
+					},
 				},
 			},
 		},
@@ -103,6 +107,7 @@ func TestCreatePullRequestInGitLab(t *testing.T) {
 	assert.Equal(t, pr.WebURL, res.Link)
 	assert.Equal(t, pr.Title, "New cluster")
 	assert.Equal(t, pr.Description, "Creates a cluster through a CAPI template")
+	assert.Equal(t, pr.ChangesCount, "2")
 }
 
 func TestCreatePullRequestInGitLab_UpdateFiles(t *testing.T) {

--- a/pkg/git/gitprovider.go
+++ b/pkg/git/gitprovider.go
@@ -55,10 +55,10 @@ func (g goGitProvider) WriteFilesToBranch(ctx context.Context, log logr.Logger, 
 	for _, c := range req.Commits {
 		// Adapt for go-git-providers
 		adapted := make([]gitprovider.CommitFile, 0)
-		for _, f := range c.Files {
+		for idx := range c.Files {
 			adapted = append(adapted, gitprovider.CommitFile{
-				Path:    &f.Path,
-				Content: f.Content,
+				Path:    &c.Files[idx].Path,
+				Content: c.Files[idx].Content,
 			})
 		}
 


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
References:
* Previous PR: https://github.com/weaveworks/weave-gitops-enterprise/pull/2450
* Issue: https://github.com/weaveworks/weave-gitops-enterprise/issues/2413

<!--
Describe what has changed in this PR.
For UI changes also include a screenshot.
-->
**What changed?**
- Fixed the new internal git provider

<!-- Tell your future self why have you made these changes -->
**Why was this change made?**
The root cause was a misused pointer reference in
`pkg/git/gitprovider.go`. For some reasons `go-git-providers` (GGP) expects a reference to a string as filename. That wouldn't be an issue in most cases, but we tried to convert WGE internal `CommitFile` to GGP's `CommitFile`. In that loop we assigned a reference, but that reference gets updated while we are in the loop:

```go
for _, f := range c.Files {
  adapted = append(adapted, gitprovider.CommitFile{
    Path:    &f.Path,
    Content: f.Content,
  })
}
```

As a result we end up with the same filename for all files, therefore we commit only one file.

<!--
Explain to your reviewers the key implementation points, including why you made
certain choices in favour of others. Highlight key areas of the code which need
extra attention, and also indicate which parts are less relevant (eg renaming,
refactoring, etc
-->
**How was this change implemented?**
Fixed the pointer issue using the original `c.Files[index]` as source.

<!--
How have you verified this change/product value? Tested locally?
Added integration/acceptance test(s)?
Unit tests are required.
-->
**How did you validate the change?**
Added integration test case about it.

<!--
Is it notable for release? e.g. schema updates, configuration or data migration
required? If so, please mention it.
-->
**Release notes**
I think it doesn't have to be in the release notes as it will be released with the original change-set. For the next version it does not fix anything, it fixes main now.

<!--
Are there any documentation updates that should be made for these changes? We want to keep these sources up to date:
- user-guide: https://docs.gitops.weave.works
- internal docs: https://github.com/weaveworks/weave-gitops-enterprise/tree/main/docs
-->
**Documentation Changes**
nothing