### PR TITLE
fix: Implement ValidateToken endpoint for Azure DevOps and BitBucket Server

### DIFF
--- a/pkg/gitauth/azure/azure.go
+++ b/pkg/gitauth/azure/azure.go
@@ -2,6 +2,7 @@ package azure
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -13,6 +14,9 @@ import (
 	"time"
 )
 
+// vso.code_write is used to read/write to Git repositories via the API.
+// Using this scope also allows us to read account information which we
+// use as a proxy for token validation.
 var scopes = []string{"vso.code_write"}
 
 type AuthClient interface {
@@ -72,22 +76,53 @@ func (c *defaultAuthClient) ExchangeCode(ctx context.Context, redirectURI, code 
 	return doCodeExchangeRequest(ctx, u, c.http, strings.NewReader(params.Encode()))
 }
 
+// ValidateToken makes an HTTP call to https://app.vssps.visualstudio.com/_apis/accounts
+// and returns a nil error if the response is 200 OK. Otherwise it returns an error.
+// Making a call to get the accounts of the user is used as a proxy to validate whether
+// the token is still valid.
+// https://learn.microsoft.com/en-us/rest/api/azure/devops/account/accounts/list?view=azure-devops-rest-7.0&tabs=HTTP
 func (c *defaultAuthClient) ValidateToken(ctx context.Context, token string) error {
+	u := buildAzureURL()
+	u.Path = "_apis/accounts"
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return fmt.Errorf("failed to create request for Azure DevOps API: %w", err)
+	}
+
+	// https://learn.microsoft.com/en-us/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate?toc=%2Fazure%2Fdevops%2Forganizations%2Ftoc.json&view=azure-devops&tabs=Linux#use-a-pat
+	b64Token := base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf(":%s", token)))
+	req.Header.Set("Authorization", fmt.Sprintf("Basic %s", b64Token))
+
+	res, err := c.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to send request to Azure DevOps API: %w", err)
+	}
+
+	if res.StatusCode != http.StatusOK {
+		return errors.New("token is invalid")
+	}
+
 	return nil
 }
 
 func buildAzureURL() url.URL {
-	u := url.URL{
-		Scheme: "https",
-		Host:   "app.vssps.visualstudio.com",
+	u := url.URL{}
+
+	// Using a custom hostname here is purely for unit tests
+	host, exists := os.LookupEnv("AZURE_DEVOPS_HOSTNAME")
+	if !exists {
+		host = "app.vssps.visualstudio.com"
 	}
+	u.Scheme = "https"
+	u.Host = host
 
 	return u
 }
 
 func getClientID() (string, error) {
-	id := os.Getenv("AZURE_DEVOPS_CLIENT_ID")
-	if id == "" {
+	id, exists := os.LookupEnv("AZURE_DEVOPS_CLIENT_ID")
+	if !exists {
 		return "", errors.New("environment variable AZURE_DEVOPS_CLIENT_ID is not set")
 	}
 
@@ -95,9 +130,9 @@ func getClientID() (string, error) {
 }
 
 func getClientSecret() (string, error) {
-	secret := os.Getenv("AZURE_DEVOPS_CLIENT_SECRET")
-	if secret == "" {
-		return "", errors.New("environment variable AZURE_DEVOPS_CLIENT_SECRET not set")
+	secret, exists := os.LookupEnv("AZURE_DEVOPS_CLIENT_SECRET")
+	if !exists {
+		return "", errors.New("environment variable AZURE_DEVOPS_CLIENT_SECRET is not set")
 	}
 
 	return secret, nil

--- a/pkg/gitauth/server/server.go
+++ b/pkg/gitauth/server/server.go
@@ -278,7 +278,7 @@ func (s *applicationServer) ValidateProviderToken(ctx context.Context, msg *pb.V
 		return nil, grpcStatus.Error(codes.Unauthenticated, err.Error())
 	}
 
-	v, err := findValidator(msg.Provider, s)
+	v, err := s.findValidator(msg.Provider)
 	if err != nil {
 		return nil, grpcStatus.Error(codes.InvalidArgument, err.Error())
 	}
@@ -307,7 +307,7 @@ func toProtoProvider(p gp.GitProviderName) pb.GitProvider {
 	return pb.GitProvider_Unknown
 }
 
-func findValidator(provider pb.GitProvider, s *applicationServer) (auth.ProviderTokenValidator, error) {
+func (s *applicationServer) findValidator(provider pb.GitProvider) (auth.ProviderTokenValidator, error) {
 	switch provider {
 	case pb.GitProvider_GitHub:
 		return s.ghAuthClient, nil

--- a/pkg/gitauth/server/server_test.go
+++ b/pkg/gitauth/server/server_test.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	"github.com/google/uuid"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -447,44 +448,13 @@ func formatLogVals(vals []interface{}) []string {
 	return list
 }
 
-func contextWithAuth(ctx context.Context) context.Context {
-	md := metadata.New(map[string]string{middleware.GRPCAuthMetadataKey: "mytoken"})
-	ctx = metadata.NewOutgoingContext(ctx, md)
-
-	return ctx
-}
-
 func TestGetBitbucketServerAuthURL(t *testing.T) {
-	lis = bufconn.Listen(bufSize)
-	s = grpc.NewServer()
-
-	rand.Seed(time.Now().UnixNano())
-	secretKey = rand.String(20)
-	jwtClient = auth.NewJwtClient(secretKey)
-
-	cfg := server.ApplicationsConfig{
-		JwtClient:             jwtClient,
-		BitBucketServerClient: bitbucket.NewAuthClient(http.DefaultClient),
-		RandomTokenGenerator:  func() string { return "abc" },
-	}
-	apps = server.NewApplicationsServer(&cfg)
-	pb.RegisterGitAuthServer(s, apps)
-
-	go func() {
-		if err := s.Serve(lis); err != nil {
-			log.Fatalf(err.Error())
-		}
-	}()
-
 	ctx := context.Background()
-	conn, err := grpc.DialContext(ctx, "bufnet", grpc.WithContextDialer(bufDialer), grpc.WithTransportCredentials(insecure.NewCredentials()))
-	if err != nil {
-		t.Fail()
-	}
-	appsClient = pb.NewGitAuthClient(conn)
+	state := uuid.NewString()
+	authClient := newGitAuthClient(t, nil, state)
 
 	t.Run("missing hostname env var", func(t *testing.T) {
-		res, err := appsClient.GetBitbucketServerAuthURL(ctx, &pb.GetBitbucketServerAuthURLRequest{
+		res, err := authClient.GetBitbucketServerAuthURL(ctx, &pb.GetBitbucketServerAuthURLRequest{
 			RedirectUri: "http://localhost/oauth/bitbucket",
 		})
 
@@ -502,7 +472,7 @@ func TestGetBitbucketServerAuthURL(t *testing.T) {
 	t.Run("missing client id env var", func(t *testing.T) {
 		t.Setenv("BITBUCKET_SERVER_HOSTNAME", "stash.stashtestserver.link:7990")
 
-		res, err := appsClient.GetBitbucketServerAuthURL(ctx, &pb.GetBitbucketServerAuthURLRequest{
+		res, err := authClient.GetBitbucketServerAuthURL(ctx, &pb.GetBitbucketServerAuthURLRequest{
 			RedirectUri: "http://localhost/oauth/bitbucket",
 		})
 
@@ -515,7 +485,6 @@ func TestGetBitbucketServerAuthURL(t *testing.T) {
 		if res != nil {
 			t.Errorf("expected a nil response but got a non-nil response instead: %v", res)
 		}
-
 	})
 
 	t.Run("success", func(t *testing.T) {
@@ -523,7 +492,7 @@ func TestGetBitbucketServerAuthURL(t *testing.T) {
 		t.Setenv("BITBUCKET_SERVER_CLIENT_ID", "74c9e0fb-b1d2-45c9-b5b8-624f3d96025c")
 
 		redirectURI := "http://localhost/oauth/bitbucket"
-		res, err := appsClient.GetBitbucketServerAuthURL(ctx, &pb.GetBitbucketServerAuthURLRequest{
+		res, err := authClient.GetBitbucketServerAuthURL(ctx, &pb.GetBitbucketServerAuthURLRequest{
 			RedirectUri: redirectURI,
 		})
 
@@ -534,45 +503,208 @@ func TestGetBitbucketServerAuthURL(t *testing.T) {
 			t.Errorf("expected a non-nil response but got a nil response instead")
 		}
 		expected := fmt.Sprintf("https://%s/rest/oauth2/latest/authorize?client_id=%s&redirect_uri=%s&response_type=code&scope=%s&state=%s",
-			os.Getenv("BITBUCKET_SERVER_HOSTNAME"), os.Getenv("BITBUCKET_SERVER_CLIENT_ID"), url.QueryEscape(redirectURI), "REPO_WRITE+REPO_READ+PUBLIC_REPOS", "abc")
+			os.Getenv("BITBUCKET_SERVER_HOSTNAME"), os.Getenv("BITBUCKET_SERVER_CLIENT_ID"), url.QueryEscape(redirectURI), "REPO_WRITE+REPO_READ+PUBLIC_REPOS", state)
 		if res != nil && res.Url != expected {
 			t.Errorf("expected %q to be equal to %q", res.Url, expected)
 		}
 	})
 }
 
-func TestGetAzureDevopsAuthURL(t *testing.T) {
-	lis = bufconn.Listen(bufSize)
-	s = grpc.NewServer()
-
-	rand.Seed(time.Now().UnixNano())
-	secretKey = rand.String(20)
-	jwtClient = auth.NewJwtClient(secretKey)
-
-	cfg := server.ApplicationsConfig{
-		JwtClient:            jwtClient,
-		AzureDevOpsClient:    azure.NewAuthClient(http.DefaultClient),
-		RandomTokenGenerator: func() string { return "abc" },
-	}
-	apps = server.NewApplicationsServer(&cfg)
-	pb.RegisterGitAuthServer(s, apps)
-
-	go func() {
-		if err := s.Serve(lis); err != nil {
-			log.Fatalf(err.Error())
-		}
-	}()
-
+func TestAuthorizeBitbucketServer(t *testing.T) {
 	ctx := context.Background()
-	conn, err := grpc.DialContext(ctx, "bufnet", grpc.WithContextDialer(bufDialer), grpc.WithTransportCredentials(insecure.NewCredentials()))
-	if err != nil {
-		t.Fail()
-	}
-	appsClient = pb.NewGitAuthClient(conn)
+	clientId := uuid.NewString()
+	clientSecret := uuid.NewString()
+	code := uuid.NewString()
+	state := uuid.NewString()
+	redirectURI := "http://localhost/oauth/bitbucket"
+	authClient := newGitAuthClient(t, nil, state)
+
+	t.Run("missing hostname env var", func(t *testing.T) {
+		res, err := authClient.AuthorizeBitbucketServer(ctx, &pb.AuthorizeBitbucketServerRequest{
+			Code:        code,
+			State:       state,
+			RedirectUri: redirectURI,
+		})
+
+		if err == nil {
+			t.Errorf("expected non-nil error")
+		}
+		if !strings.Contains(err.Error(), "environment variable BITBUCKET_SERVER_HOSTNAME is not set") {
+			t.Errorf("expected error for hostname env var but got instead: %v", err)
+		}
+		if res != nil {
+			t.Errorf("expected a nil response but got a non-nil response instead: %v", res)
+		}
+	})
 
 	t.Run("missing client id env var", func(t *testing.T) {
+		t.Setenv("BITBUCKET_SERVER_HOSTNAME", "stash.stashtestserver.link:7990")
 
-		res, err := appsClient.GetAzureDevOpsAuthURL(ctx, &pb.GetAzureDevOpsAuthURLRequest{
+		res, err := authClient.AuthorizeBitbucketServer(ctx, &pb.AuthorizeBitbucketServerRequest{
+			Code:        code,
+			State:       state,
+			RedirectUri: redirectURI,
+		})
+
+		if err == nil {
+			t.Error("expected non-nil error")
+		}
+		if !strings.Contains(err.Error(), "environment variable BITBUCKET_SERVER_CLIENT_ID is not set") {
+			t.Errorf("expected error for client id env var but got instead: %v", err)
+		}
+		if res != nil {
+			t.Errorf("expected a nil response but got a non-nil response instead: %v", res)
+		}
+	})
+
+	t.Run("missing client secret env var", func(t *testing.T) {
+		t.Setenv("BITBUCKET_SERVER_HOSTNAME", "stash.stashtestserver.link:7990")
+		t.Setenv("BITBUCKET_SERVER_CLIENT_ID", "74c9e0fb-b1d2-45c9-b5b8-624f3d96025c")
+
+		res, err := authClient.AuthorizeBitbucketServer(ctx, &pb.AuthorizeBitbucketServerRequest{
+			Code:        code,
+			State:       state,
+			RedirectUri: redirectURI,
+		})
+
+		if err == nil {
+			t.Error("expected non-nil error")
+		}
+		if !strings.Contains(err.Error(), "environment variable BITBUCKET_SERVER_CLIENT_SECRET is not set") {
+			t.Errorf("expected error for client secret env var but got instead: %v", err)
+		}
+		if res != nil {
+			t.Errorf("expected a nil response but got a non-nil response instead: %v", res)
+		}
+	})
+
+	t.Run("no cookie", func(t *testing.T) {
+		// Set up the response from the git provider
+		ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			values := r.URL.Query()
+			if values.Get("client_id") != clientId {
+				t.Errorf("expected client_id to be %q but got %q", clientId, values.Get("client_id"))
+			}
+			if values.Get("client_secret") != clientSecret {
+				t.Errorf("expected client_secret to be %q but got %q", clientSecret, values.Get("client_secret"))
+			}
+			if values.Get("code") != code {
+				t.Errorf("expected code to be %q but got %q", code, values.Get("code"))
+			}
+			if values.Get("grant_type") != "authorization_code" {
+				t.Errorf("expected grant_type to be %q but got %q", "authorization_code", values.Get("grant_type"))
+			}
+			if values.Get("redirect_uri") != redirectURI {
+				t.Errorf("expected redirect_uri to be %q but got %q", redirectURI, values.Get("redirect_uri"))
+			}
+
+			res := `
+			{
+				"access_token": "eyJhbGciOiJIUzI1NiJ9.eyJpZCI6IjNmMTQ3NTUzYjg3OTQ2Y2FhMWJhYWJkZWQ0MzgwYTM4In0.EDnpBl0hd1BQzIRP--xEvyW1F6gDuiFranQCvi98b2c",
+				"token_type": "bearer",
+				"expires_in": 7200,
+				"refresh_token": "eyJhbGciOiJIUzI1NiJ9.eyJpZCI6ImMwZTMxYmZjYTI2NWI0YTkwMzBiOGM2OTJjNWIyMTYwIn0.grHOsso3B3kaSxNd0QJfj1H3ayjRUuA75SiEt0usmiM",
+				"created_at": 1607635748
+			}`
+			_, _ = w.Write([]byte(res))
+		}))
+		authClient := newGitAuthClient(t, ts.Client(), state)
+		u, _ := url.Parse(ts.URL)
+
+		t.Setenv("BITBUCKET_SERVER_HOSTNAME", u.Host)
+		t.Setenv("BITBUCKET_SERVER_CLIENT_ID", clientId)
+		t.Setenv("BITBUCKET_SERVER_CLIENT_SECRET", clientSecret)
+
+		res, err := authClient.AuthorizeBitbucketServer(ctx, &pb.AuthorizeBitbucketServerRequest{
+			Code:        code,
+			State:       state,
+			RedirectUri: redirectURI,
+		})
+		if err != nil {
+			t.Errorf("expected no error but got an error instead: %v", err)
+		}
+		if res == nil {
+			t.Errorf("expected a non-nil response but got a nil response instead")
+		}
+	})
+
+	t.Run("cookie with valid csrf token", func(t *testing.T) {
+		// Set up the response from the git provider
+		ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			values := r.URL.Query()
+			if values.Get("client_id") != clientId {
+				t.Errorf("expected client_id to be %q but got %q", clientId, values.Get("client_id"))
+			}
+			if values.Get("client_secret") != clientSecret {
+				t.Errorf("expected client_secret to be %q but got %q", clientSecret, values.Get("client_secret"))
+			}
+			if values.Get("code") != code {
+				t.Errorf("expected code to be %q but got %q", code, values.Get("code"))
+			}
+			if values.Get("grant_type") != "authorization_code" {
+				t.Errorf("expected grant_type to be %q but got %q", "authorization_code", values.Get("grant_type"))
+			}
+			if values.Get("redirect_uri") != redirectURI {
+				t.Errorf("expected redirect_uri to be %q but got %q", redirectURI, values.Get("redirect_uri"))
+			}
+
+			res := `
+			{
+				"access_token": "eyJhbGciOiJIUzI1NiJ9.eyJpZCI6IjNmMTQ3NTUzYjg3OTQ2Y2FhMWJhYWJkZWQ0MzgwYTM4In0.EDnpBl0hd1BQzIRP--xEvyW1F6gDuiFranQCvi98b2c",
+				"token_type": "bearer",
+				"expires_in": 7200,
+				"refresh_token": "eyJhbGciOiJIUzI1NiJ9.eyJpZCI6ImMwZTMxYmZjYTI2NWI0YTkwMzBiOGM2OTJjNWIyMTYwIn0.grHOsso3B3kaSxNd0QJfj1H3ayjRUuA75SiEt0usmiM",
+				"created_at": 1607635748
+			}`
+			_, _ = w.Write([]byte(res))
+		}))
+		authClient := newGitAuthClient(t, ts.Client(), state)
+		u, _ := url.Parse(ts.URL)
+
+		t.Setenv("BITBUCKET_SERVER_HOSTNAME", u.Host)
+		t.Setenv("BITBUCKET_SERVER_CLIENT_ID", clientId)
+		t.Setenv("BITBUCKET_SERVER_CLIENT_SECRET", clientSecret)
+
+		res, err := authClient.AuthorizeBitbucketServer(contextWithCookie(ctx, fmt.Sprintf("%s=%s", server.GitProviderCSRFCookieName, state)), &pb.AuthorizeBitbucketServerRequest{
+			Code:        code,
+			State:       state,
+			RedirectUri: redirectURI,
+		})
+		if err != nil {
+			t.Errorf("expected no error but got an error instead: %v", err)
+		}
+		if res == nil {
+			t.Errorf("expected a non-nil response but got a nil response instead")
+		}
+	})
+
+	t.Run("cookie with invalid csrf token", func(t *testing.T) {
+		cookieState := uuid.NewString()
+
+		res, err := authClient.AuthorizeBitbucketServer(contextWithCookie(ctx, fmt.Sprintf("%s=%s", server.GitProviderCSRFCookieName, cookieState)), &pb.AuthorizeBitbucketServerRequest{
+			Code:        code,
+			State:       state,
+			RedirectUri: redirectURI,
+		})
+		if err == nil {
+			t.Errorf("expected non-nil error")
+		}
+		if !strings.Contains(err.Error(), "failed CSRF token check") {
+			t.Errorf("expected CRSF token check error but got instead: %v", err)
+		}
+		if res != nil {
+			t.Errorf("expected a nil response but got a non-nil response instead: %v", res)
+		}
+	})
+}
+
+func TestGetAzureDevopsAuthURL(t *testing.T) {
+	ctx := context.Background()
+	state := uuid.NewString()
+	authClient := newGitAuthClient(t, nil, state)
+
+	t.Run("missing client id env var", func(t *testing.T) {
+		res, err := authClient.GetAzureDevOpsAuthURL(ctx, &pb.GetAzureDevOpsAuthURLRequest{
 			RedirectUri: "http://localhost/oauth/azure",
 		})
 
@@ -588,10 +720,11 @@ func TestGetAzureDevopsAuthURL(t *testing.T) {
 
 	})
 
-	t.Setenv("AZURE_DEVOPS_CLIENT_ID", "74c9e0fb-b1d2-45c9-b5b8-624f3d96025c")
 	t.Run("success", func(t *testing.T) {
+		t.Setenv("AZURE_DEVOPS_CLIENT_ID", "74c9e0fb-b1d2-45c9-b5b8-624f3d96025c")
+
 		redirectURI := "http://localhost/oauth/azure"
-		res, err := appsClient.GetAzureDevOpsAuthURL(ctx, &pb.GetAzureDevOpsAuthURLRequest{
+		res, err := authClient.GetAzureDevOpsAuthURL(ctx, &pb.GetAzureDevOpsAuthURLRequest{
 			RedirectUri: redirectURI,
 		})
 
@@ -602,9 +735,205 @@ func TestGetAzureDevopsAuthURL(t *testing.T) {
 			t.Errorf("expected a non-nil response but got a nil response instead")
 		}
 		expected := fmt.Sprintf("https://app.vssps.visualstudio.com/oauth2/authorize?client_id=%s&redirect_uri=%s&response_type=Assertion&scope=%s&state=%s",
-			os.Getenv("AZURE_DEVOPS_CLIENT_ID"), url.QueryEscape(redirectURI), "vso.code_write", "abc")
+			os.Getenv("AZURE_DEVOPS_CLIENT_ID"), url.QueryEscape(redirectURI), "vso.code_write", state)
 		if res != nil && res.Url != expected {
 			t.Errorf("expected %q to be equal to %q", res.Url, expected)
 		}
 	})
+}
+
+func TestAuthorizeAzureDevOps(t *testing.T) {
+	ctx := context.Background()
+	clientSecret := uuid.NewString()
+	code := uuid.NewString()
+	state := uuid.NewString()
+	redirectURI := "http://localhost/oauth/azure"
+	authClient := newGitAuthClient(t, nil, state)
+
+	t.Run("missing client secret env var", func(t *testing.T) {
+		res, err := authClient.AuthorizeAzureDevOps(ctx, &pb.AuthorizeAzureDevOpsRequest{
+			Code:        code,
+			State:       state,
+			RedirectUri: redirectURI,
+		})
+
+		if err == nil {
+			t.Error("expected non-nil error")
+		}
+		if !strings.Contains(err.Error(), "environment variable AZURE_DEVOPS_CLIENT_SECRET is not set") {
+			t.Errorf("expected error for client secret env var but got instead: %v", err)
+		}
+		if res != nil {
+			t.Errorf("expected a nil response but got a non-nil response instead: %v", res)
+		}
+	})
+
+	t.Run("no cookie", func(t *testing.T) {
+		// Set up the response from the git provider
+		ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_ = r.ParseForm()
+			if r.Form.Get("client_assertion_type") != "urn:ietf:params:oauth:client-assertion-type:jwt-bearer" {
+				t.Errorf("expected client_assertion_type to be %q but got %q", "urn:ietf:params:oauth:client-assertion-type:jwt-bearer", r.Form.Get("client_assertion_type"))
+			}
+			if r.Form.Get("client_assertion") != clientSecret {
+				t.Errorf("expected client_assertion to be %q but got %q", clientSecret, r.Form.Get("client_assertion"))
+			}
+			if r.Form.Get("grant_type") != "urn:ietf:params:oauth:grant-type:jwt-bearer" {
+				t.Errorf("expected grant_type to be %q but got %q", "urn:ietf:params:oauth:grant-type:jwt-bearer", r.Form.Get("grant_type"))
+			}
+			if r.Form.Get("assertion") != code {
+				t.Errorf("expected assertion to be %q but got %q", code, r.Form.Get("assertion"))
+			}
+			if r.Form.Get("redirect_uri") != redirectURI {
+				t.Errorf("expected redirect_uri to be %q but got %q", redirectURI, r.Form.Get("redirect_uri"))
+			}
+
+			res := `
+			{
+				"access_token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Im9PdmN6NU1fN3AtSGpJS2xGWHo5M3VfVjBabyJ9.eyJuYW1laWQiOiI5MGVkNzhmNi1hZWE3LTRhZDItYmZiYi01MzgzZDY1MjFkNjkiLCJzY3AiOiJ2c28uY29kZV93cml0ZSIsImF1aSI6IjQyZjg0ZTQ2LTU0NzktNDMwNS1iNmY0LWY0NGFmMTk4M2EyNCIsImFwcGlkIjoiNzEyMmY1ZDQtYzA1Ni00MDcyLTlhZjQtMThmMzYwNjRjM2E5IiwiaXNzIjoiYXBwLnZzdG9rZW4udmlzdWFsc3R1ZGlvLmNvbSIsImF1ZCI6ImFwcC52c3Rva2VuLnZpc3VhbHN0dWRpby5jb20iLCJuYmYiOjE2Nzk3NDEwMDEsImV4cCI6MTY3OTc0NDYwMX0.uk4fFXygl2-E2np2aeGuRBR2265Lrr_Upx9dylQ_qmlwBJDc3Pd2n7y8YbrkIsA54f3qm-z8cTna0DhwSW5Kl333_jkQb0o2oa3h_7BiI8AJ6RG3OV3VqwckohAXHd8pndQJcCCOSbIzdN4si6LSbVdBig9ZrksGyl51yKwOvFKAyo8mjcgS9oGjvLGDCPfY7NczOKmLTt3OOgbElBMRJJJLPUGoIm6yeVaBhhC8S821YYe5ZlIggtnI5s1wsyOgB_Fb4fw6ikz6YADZh2iaie8l3tQmIL5l_C-MqNg_02yEr516ooFY6qB20tljBHL6KL9rXIWrNV_0xWDfM9ihyA",
+				"token_type": "jwt-bearer",
+				"expires_in": "3599",
+				"refresh_token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Im9PdmN6NU1fN3AtSGpJS2xGWHo5M3VfVjBabyJ9.eyJuYW1laWQiOiI5MGVkNzhmNi1hZWE3LTRhZDItYmZiYi01MzgzZDY1MjFkNjkiLCJhY2kiOiIzZDIwYmNjNC01OTg0LTQyMDQtYTMzNi1lYWVhMWY2OWUxODUiLCJzY3AiOiJ2c28uY29kZV93cml0ZSIsImlzcyI6ImFwcC52c3Rva2VuLnZpc3VhbHN0dWRpby5jb20iLCJhdWQiOiJhcHAudnN0b2tlbi52aXN1YWxzdHVkaW8uY29tIiwibmJmIjoxNjc5NzQxMDAxLCJleHAiOjE3MTEzNjM0MDF9.SOIDb6hU7FhaDDbms3M0iyctr93AxLa3Z3cXEigTE3cGaKVBXN1ScHQPd1WzU9Wosiq8EjijamEB4faPROfHTCpLXSyZEuzG42P15nxVrv8ztwovqSJue5JgZTT4mCNIYME4aFaB8q-wrbxS7TTnbV1iqmHMeinx2WMq_hS7o11Mb6odkEr-HFtENztGoLC1ljdYU1byZo_PaB78RRLjKNzOwxgOjZssooQxayjAyqfqKbjoHvzuTJWxu9_DN57QpLWQeXbbPXY10v-lKylu43-B3yAC9psK0ueaqJHENyQnS-djnDqC12Q5cXdIG9RIC1SWqGuvJQGlN0Vx5eOz7g",
+				"scope": "vso.code_write vso.authorization_grant"
+			}`
+			_, _ = w.Write([]byte(res))
+		}))
+		authClient := newGitAuthClient(t, ts.Client(), state)
+		u, _ := url.Parse(ts.URL)
+
+		t.Setenv("AZURE_DEVOPS_HOSTNAME", u.Host)
+		t.Setenv("AZURE_DEVOPS_CLIENT_SECRET", clientSecret)
+
+		res, err := authClient.AuthorizeAzureDevOps(ctx, &pb.AuthorizeAzureDevOpsRequest{
+			Code:        code,
+			State:       state,
+			RedirectUri: redirectURI,
+		})
+		if err != nil {
+			t.Errorf("expected no error but got an error instead: %v", err)
+		}
+		if res == nil {
+			t.Errorf("expected a non-nil response but got a nil response instead")
+		}
+	})
+
+	t.Run("cookie with valid csrf token", func(t *testing.T) {
+		// Set up the response from the git provider
+		ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_ = r.ParseForm()
+			if r.Form.Get("client_assertion_type") != "urn:ietf:params:oauth:client-assertion-type:jwt-bearer" {
+				t.Errorf("expected client_assertion_type to be %q but got %q", "urn:ietf:params:oauth:client-assertion-type:jwt-bearer", r.Form.Get("client_assertion_type"))
+			}
+			if r.Form.Get("client_assertion") != clientSecret {
+				t.Errorf("expected client_assertion to be %q but got %q", clientSecret, r.Form.Get("client_assertion"))
+			}
+			if r.Form.Get("grant_type") != "urn:ietf:params:oauth:grant-type:jwt-bearer" {
+				t.Errorf("expected grant_type to be %q but got %q", "urn:ietf:params:oauth:grant-type:jwt-bearer", r.Form.Get("grant_type"))
+			}
+			if r.Form.Get("assertion") != code {
+				t.Errorf("expected assertion to be %q but got %q", code, r.Form.Get("assertion"))
+			}
+			if r.Form.Get("redirect_uri") != redirectURI {
+				t.Errorf("expected redirect_uri to be %q but got %q", redirectURI, r.Form.Get("redirect_uri"))
+			}
+
+			res := `
+			{
+				"access_token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Im9PdmN6NU1fN3AtSGpJS2xGWHo5M3VfVjBabyJ9.eyJuYW1laWQiOiI5MGVkNzhmNi1hZWE3LTRhZDItYmZiYi01MzgzZDY1MjFkNjkiLCJzY3AiOiJ2c28uY29kZV93cml0ZSIsImF1aSI6IjQyZjg0ZTQ2LTU0NzktNDMwNS1iNmY0LWY0NGFmMTk4M2EyNCIsImFwcGlkIjoiNzEyMmY1ZDQtYzA1Ni00MDcyLTlhZjQtMThmMzYwNjRjM2E5IiwiaXNzIjoiYXBwLnZzdG9rZW4udmlzdWFsc3R1ZGlvLmNvbSIsImF1ZCI6ImFwcC52c3Rva2VuLnZpc3VhbHN0dWRpby5jb20iLCJuYmYiOjE2Nzk3NDEwMDEsImV4cCI6MTY3OTc0NDYwMX0.uk4fFXygl2-E2np2aeGuRBR2265Lrr_Upx9dylQ_qmlwBJDc3Pd2n7y8YbrkIsA54f3qm-z8cTna0DhwSW5Kl333_jkQb0o2oa3h_7BiI8AJ6RG3OV3VqwckohAXHd8pndQJcCCOSbIzdN4si6LSbVdBig9ZrksGyl51yKwOvFKAyo8mjcgS9oGjvLGDCPfY7NczOKmLTt3OOgbElBMRJJJLPUGoIm6yeVaBhhC8S821YYe5ZlIggtnI5s1wsyOgB_Fb4fw6ikz6YADZh2iaie8l3tQmIL5l_C-MqNg_02yEr516ooFY6qB20tljBHL6KL9rXIWrNV_0xWDfM9ihyA",
+				"token_type": "jwt-bearer",
+				"expires_in": "3599",
+				"refresh_token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Im9PdmN6NU1fN3AtSGpJS2xGWHo5M3VfVjBabyJ9.eyJuYW1laWQiOiI5MGVkNzhmNi1hZWE3LTRhZDItYmZiYi01MzgzZDY1MjFkNjkiLCJhY2kiOiIzZDIwYmNjNC01OTg0LTQyMDQtYTMzNi1lYWVhMWY2OWUxODUiLCJzY3AiOiJ2c28uY29kZV93cml0ZSIsImlzcyI6ImFwcC52c3Rva2VuLnZpc3VhbHN0dWRpby5jb20iLCJhdWQiOiJhcHAudnN0b2tlbi52aXN1YWxzdHVkaW8uY29tIiwibmJmIjoxNjc5NzQxMDAxLCJleHAiOjE3MTEzNjM0MDF9.SOIDb6hU7FhaDDbms3M0iyctr93AxLa3Z3cXEigTE3cGaKVBXN1ScHQPd1WzU9Wosiq8EjijamEB4faPROfHTCpLXSyZEuzG42P15nxVrv8ztwovqSJue5JgZTT4mCNIYME4aFaB8q-wrbxS7TTnbV1iqmHMeinx2WMq_hS7o11Mb6odkEr-HFtENztGoLC1ljdYU1byZo_PaB78RRLjKNzOwxgOjZssooQxayjAyqfqKbjoHvzuTJWxu9_DN57QpLWQeXbbPXY10v-lKylu43-B3yAC9psK0ueaqJHENyQnS-djnDqC12Q5cXdIG9RIC1SWqGuvJQGlN0Vx5eOz7g",
+				"scope": "vso.code_write vso.authorization_grant"
+			}`
+			_, _ = w.Write([]byte(res))
+		}))
+		authClient := newGitAuthClient(t, ts.Client(), state)
+		u, _ := url.Parse(ts.URL)
+
+		t.Setenv("AZURE_DEVOPS_HOSTNAME", u.Host)
+		t.Setenv("AZURE_DEVOPS_CLIENT_SECRET", clientSecret)
+
+		res, err := authClient.AuthorizeAzureDevOps(contextWithCookie(ctx, fmt.Sprintf("%s=%s", server.GitProviderCSRFCookieName, state)), &pb.AuthorizeAzureDevOpsRequest{
+			Code:        code,
+			State:       state,
+			RedirectUri: redirectURI,
+		})
+		if err != nil {
+			t.Errorf("expected no error but got an error instead: %v", err)
+		}
+		if res == nil {
+			t.Errorf("expected a non-nil response but got a nil response instead")
+		}
+	})
+
+	t.Run("cookie with invalid csrf token", func(t *testing.T) {
+		cookieState := uuid.NewString()
+
+		res, err := authClient.AuthorizeAzureDevOps(contextWithCookie(ctx, fmt.Sprintf("%s=%s", server.GitProviderCSRFCookieName, cookieState)), &pb.AuthorizeAzureDevOpsRequest{
+			Code:        code,
+			State:       state,
+			RedirectUri: redirectURI,
+		})
+		if err == nil {
+			t.Errorf("expected non-nil error")
+		}
+		if !strings.Contains(err.Error(), "failed CSRF token check") {
+			t.Errorf("expected CRSF token check error but got instead: %v", err)
+		}
+		if res != nil {
+			t.Errorf("expected a nil response but got a non-nil response instead: %v", res)
+		}
+	})
+}
+
+func newGitAuthClient(t *testing.T, c *http.Client, state string) pb.GitAuthClient {
+	t.Helper()
+
+	if c == nil {
+		c = http.DefaultClient
+	}
+
+	lis = bufconn.Listen(bufSize)
+	s = grpc.NewServer()
+
+	rand.Seed(time.Now().UnixNano())
+	secretKey = rand.String(20)
+	jwtClient = auth.NewJwtClient(secretKey)
+
+	cfg := server.ApplicationsConfig{
+		Logger:                logr.Discard(),
+		JwtClient:             jwtClient,
+		AzureDevOpsClient:     azure.NewAuthClient(c),
+		BitBucketServerClient: bitbucket.NewAuthClient(c),
+		RandomTokenGenerator:  func() string { return state },
+	}
+	apps = server.NewApplicationsServer(&cfg)
+	pb.RegisterGitAuthServer(s, apps)
+
+	go func() {
+		if err := s.Serve(lis); err != nil {
+			log.Fatalf(err.Error())
+		}
+	}()
+
+	ctx := context.Background()
+	conn, err := grpc.DialContext(ctx, "bufnet", grpc.WithContextDialer(bufDialer), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fail()
+	}
+	return pb.NewGitAuthClient(conn)
+}
+
+func contextWithAuth(ctx context.Context) context.Context {
+	md := metadata.New(map[string]string{middleware.GRPCAuthMetadataKey: "mytoken"})
+	ctx = metadata.NewOutgoingContext(ctx, md)
+
+	return ctx
+}
+
+func contextWithCookie(ctx context.Context, value string) context.Context {
+	md := metadata.New(map[string]string{runtime.MetadataPrefix + "cookie": value})
+	ctx = metadata.NewOutgoingContext(ctx, md)
+
+	return ctx
 }


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Closes #2541 

<!--
Describe what has changed in this PR.
For UI changes also include a screenshot.
-->
**What changed?**
The `/v1/gitauth/validate_token` endpoint is called by the UI to check whether a token is valid or not. If it returns an error then the token is invalid whereas if it returns no error then the token is valid. This PR implements this endpoint for BitBucket Server and Azure DevOps.

<!-- Tell your future self why have you made these changes -->
**Why was this change made?**
This functionality was not implemented before so the token was considered valid as far as the UI was concerned.

<!--
Explain to your reviewers the key implementation points, including why you made
certain choices in favour of others. Highlight key areas of the code which need
extra attention, and also indicate which parts are less relevant (eg renaming,
refactoring, etc
-->
**How was this change implemented?**
For BitBucket Server, the call is made to `/rest/api/latest/users` [docs](https://developer.atlassian.com/server/bitbucket/rest/v808/api-group-system-maintenance/#api-api-latest-users-get).
For Azure DevOps, the call is made to `_apis/accounts` [docs](https://learn.microsoft.com/en-us/rest/api/azure/devops/account/accounts/list?view=azure-devops-rest-7.0&tabs=HTTP).
Both of these calls are authenticated and don't require additional scopes beyond those already requested.

<!--
How have you verified this change/product value? Tested locally?
Added integration/acceptance test(s)?
Unit tests are required.
-->
**How did you validate the change?**
Unit tests
Manual tests

<!--
Is it notable for release? e.g. schema updates, configuration or data migration
required? If so, please mention it.
-->
**Release notes**
N/A

<!--
Are there any documentation updates that should be made for these changes? We want to keep these sources up to date:
- user-guide: https://docs.gitops.weave.works
- internal docs: https://github.com/weaveworks/weave-gitops-enterprise/tree/main/docs
-->
**Documentation Changes**
N/A