### PR TITLE
Dashboard reconciliation stuck when running GitOps Run in the no session mode with OSS dashboard already installed 

### DIFF
--- a/charts/mccp/templates/_helpers.tpl
+++ b/charts/mccp/templates/_helpers.tpl
@@ -51,6 +51,14 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
+App selector labels
+*/}}
+{{- define "mccp.appSelectorLabels" -}}
+app.kubernetes.io/part-of: weave-gitops
+weave.works/app: weave-gitops-enterprise
+{{- end }}
+
+{{/*
 Create the name of the service account to use
 */}}
 {{- define "mccp.serviceAccountName" -}}

--- a/charts/mccp/templates/clusters-service/deployment.yaml
+++ b/charts/mccp/templates/clusters-service/deployment.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "mccp.labels" . | nindent 4 }}
+    {{- include "mccp.appSelectorLabels" . | nindent 4 }}
 spec:
   replicas: 1
   selector:
@@ -18,6 +19,7 @@ spec:
       labels:
         app: clusters-service
         {{- include "mccp.selectorLabels" . | nindent 8 }}
+        {{- include "mccp.appSelectorLabels" . | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:


### PR DESCRIPTION
Closes https://github.com/weaveworks/weave-gitops/issues/3546

- Added app selector labels to be able to identify the dashboard deployment and pods.

The OSS counterpart to this PR with the reworked dashboard detection code has been merged already:
https://github.com/weaveworks/weave-gitops/pull/3562
