### PR TITLE
removed log in fake to avoid panic in ci

### DIFF
--- a/pkg/query/collector/watching_test.go
+++ b/pkg/query/collector/watching_test.go
@@ -254,16 +254,13 @@ type fakeWatcher struct {
 }
 
 func (f fakeWatcher) Start(ctx context.Context, log logr.Logger) error {
-	f.log.Info("fake watcher started")
 	return nil
 }
 
 func (f fakeWatcher) Stop() error {
-	f.log.Info("fake watcher stopped")
 	return nil
 }
 
 func (f fakeWatcher) Status() (string, error) {
-	f.log.Info("fake watcher status")
 	return string(ClusterWatchingStopped), nil
 }


### PR DESCRIPTION
we see panicking in [CI](https://github.com/weaveworks/weave-gitops-enterprise/actions/runs/4561505600/jobs/8048912585?pr=2645)

`panic: Log in goroutine after TestWatch has completed: "level"=0 "msg"="fake watcher started"`

This PR removes the logging in the fakes to avoid the panic