### PR TITLE
Fix Pendo initialization

### DIFF
--- a/tools/dev-values.yaml
+++ b/tools/dev-values.yaml
@@ -24,7 +24,7 @@ extraEnvVars:
   - name: WEAVE_GITOPS_FEATURE_COST_ESTIMATION
     value: ""
   - name: WEAVE_GITOPS_FEATURE_TELEMETRY
-    value: "true"
+    value: "false"
   - name: BITBUCKET_SERVER_HOSTNAME
     value: "bitbucket.yiannis.net"
 


### PR DESCRIPTION
Closes https://github.com/weaveworks/weave-gitops/issues/3566

The OSS PR for this issue was merged already:
https://github.com/weaveworks/weave-gitops/pull/3567

The enterprise part is more about verifying that Pendo initialization in enterprise works as expected, based on the `WEAVE_GITOPS_FEATURE_TELEMETRY` flag value, making sure the UI does not display errors if Pendo is not initialized, and restoring the initial telemetry flag dev value.

Tested it locally both in Tilt and with the enterprise dashboard installed via the HelmRelease, everything is working as expected: when the value of the `WEAVE_GITOPS_FEATURE_TELEMETRY` flag is not explicitly set to `false`, Pendo is initialized in enterprise. If Pendo is not inittialized, the UI works as expected.

- To test that Pendo is initialized or not, as expected, please set the desired value of the `WEAVE_GITOPS_FEATURE_TELEMETRY` flag in `tools/dev-values.yaml` (when running the UI with Tilt) or in the HelmRelease manifests (when installing enterprise according to the [installation instructions](https://docs.gitops.weave.works/docs/installation/weave-gitops-enterprise/) ) and run:
```
console.log(window.pendo.getSerializedMetadata())
```
in the browser console.

If Pendo was initialized, there will be some data displayed. If not, an error will be thrown.