### PR TITLE
Add in Explorer navigation element

### DIFF
--- a/ui-cra/src/components/Layout/Navigation.tsx
+++ b/ui-cra/src/components/Layout/Navigation.tsx
@@ -140,6 +140,12 @@ function getNavItems(isFlagEnabled: (flag: string) => boolean): NavItem[] {
       icon: IconType.FluxIcon,
     },
     {
+      label: 'Explore',
+      link: { value: Routes.Explorer },
+      icon: IconType.SearchIcon,
+      disabled: !isFlagEnabled('WEAVE_GITOPS_FEATURE_EXPLORER'),
+    },
+    {
       label: 'Guardrails',
     },
     {


### PR DESCRIPTION
In all the excitement of re-doing the side nav, it seems the `Explorer` navigation element got removed. It was added here:

https://github.com/weaveworks/weave-gitops-enterprise/pull/2546/files#diff-471cb0798ffd7e79c2ba049f292f79d2dd87ef463acc51b6e8581ac1beb3db58R187

Because the `Navigation` file was moved, the root cause will be lost to the sands of time :shrug: 

This PR adds the navigation element back in.

cc @enekofb 