### PR TITLE
Revert "Download only the tools necessary for running integration tests"

### DIFF
--- a/.github/workflows/acceptance-test.yaml
+++ b/.github/workflows/acceptance-test.yaml
@@ -178,12 +178,29 @@ jobs:
     runs-on: ${{ inputs.runs-on }}
     timeout-minutes: ${{ inputs.timeout-minutes }}
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v3.5.0
+      - id: go-cache-paths
+        run: |
+          echo "go-build=$(go env GOCACHE)" >> $GITHUB_OUTPUT
+          echo "go-mod=$(go env GOMODCACHE)" >> $GITHUB_OUTPUT
       - name: Install Go
-        uses: actions/setup-go@v4.0.0
+        uses: actions/setup-go@v3.5.0
         with:
           go-version: 1.20.x
+      - name: Checkout code
+        uses: actions/checkout@v3.1.0
+        with:
+          fetch-depth: 0
+      - name: Go Build Cache
+        env:
+          GO_CACHE_NAME: cache-go-modules
+        uses: actions/cache@v3.0.11
+        with:
+          path: |
+            ${{ steps.go-cache-paths.outputs.go-build }}
+            ${{ steps.go-cache-paths.outputs.go-mod }}
+          key: ${{ runner.os }}-go-build-${{ env.GO_CACHE_NAME }}-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-build-${{ env.GO_CACHE_NAME }}-
       - name: setup aws credentials
         uses: aws-actions/configure-aws-credentials@v1-node16
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -114,8 +114,10 @@ jobs:
       - id: cache-paths
         run: |
           echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
+          echo "go-build=$(go env GOCACHE)" >> $GITHUB_OUTPUT
+          echo "go-mod=$(go env GOMODCACHE)" >> $GITHUB_OUTPUT
       - name: Checkout code
-        uses: actions/checkout@v3.5.0
+        uses: actions/checkout@v3.1.0
       - name: Yarn Cache
         uses: actions/cache@v3.0.11
         with:

--- a/Makefile
+++ b/Makefile
@@ -164,8 +164,7 @@ ui-build-for-tests:
 	# Github actions npm is slow sometimes, hence increasing the network-timeout
 	yarn config set network-timeout 300000 && cd ui-cra && yarn install && yarn build
 
-integration-tests:	
-	$(CURRENT_DIR)/tools/download-deps.sh $(CURRENT_DIR)/tools/test-dependencies.toml
+integration-tests: dependencies
 	go test -v ./cmd/clusters-service/... -tags=integration
 	go test -v ./pkg/git/... -tags=integration
 

--- a/go.mod
+++ b/go.mod
@@ -84,6 +84,10 @@ require (
 )
 
 require (
+	github.com/fluxcd/pkg/http/fetch v0.3.0 // indirect
+	github.com/fluxcd/pkg/tar v0.2.0 // indirect
+	github.com/gitops-tools/pkg v0.1.0 // indirect
+	golang.org/x/exp v0.0.0-20230315142452-642cacee5cc0 // indirect
 	google.golang.org/api v0.107.0 // indirect
 	gopkg.in/urfave/cli.v1 v1.20.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -445,11 +445,15 @@ github.com/fluxcd/pkg/apis/kustomize v0.8.0 h1:A6aLolxPV2Sll44SOHiX96lbXXmRZmS5B
 github.com/fluxcd/pkg/apis/kustomize v0.8.0/go.mod h1:9DPEVSfVIkiC2H3Dk6Ght4YJkswhYIaufXla4tB5Y84=
 github.com/fluxcd/pkg/apis/meta v0.19.1 h1:fCI5CnTXpAqr67UlaI9q0H+OztMKB5kDTr6xV6vlAo0=
 github.com/fluxcd/pkg/apis/meta v0.19.1/go.mod h1:ZPPMYrPnWwPQYNEGM/Uc0N4SurUPS3xNI3IIpCQEfuM=
+github.com/fluxcd/pkg/http/fetch v0.3.0 h1:/mLj0IzTx+GhR09etzMJsBoNQ0qeOx9cSdeUgRB+oqM=
+github.com/fluxcd/pkg/http/fetch v0.3.0/go.mod h1:dHTDYIeL0ZAQ9mHM6ZS4VProxho+Atm73MHJ55yj0Sg=
 github.com/fluxcd/pkg/kustomize v0.13.1 h1:xfDghn/kRaa5vYN64dLTAL1b1B1tDwcXlnOAqmz5W28=
 github.com/fluxcd/pkg/runtime v0.32.0 h1:GwPyl27qs0jg95o8lGQD+FiAAxFPJMKs58L63AQRk50=
 github.com/fluxcd/pkg/runtime v0.32.0/go.mod h1:toGOOubMo4ZC1aWhB8C3drdTglr1/A1dETeNwjiIv0g=
 github.com/fluxcd/pkg/ssa v0.23.1 h1:om5u4O2xU9ESZHf1wBzeyrsqe/nKf2+eIs9aXocnVW4=
 github.com/fluxcd/pkg/ssa v0.23.1/go.mod h1:3RvpJRHRzE4z168elHxEJit76Ol7uyoBtNNDV5H85es=
+github.com/fluxcd/pkg/tar v0.2.0 h1:HEUHgONQYsJGeZZ4x6h5nQU9Aox1I4T3bOp1faWTqf8=
+github.com/fluxcd/pkg/tar v0.2.0/go.mod h1:w0/TOC7kwBJhnSJn7TCABkc/I7ib1f2Yz6vOsbLBnhw=
 github.com/fluxcd/pkg/untar v0.2.0 h1:sJXU+FbJcNUb2ffLJNjeR3hwt3X2loVpOMlCUjyFw6E=
 github.com/fluxcd/pkg/untar v0.2.0/go.mod h1:33AyoWaPpjX/xXpczcfhQh2AkB63TFwiR2YwROtv23E=
 github.com/fluxcd/source-controller/api v0.36.0 h1:c5/uWFqKZ9vtDkkXsdMTyiuHNNEX3B6ldjgTsB7Uy14=
@@ -465,6 +469,8 @@ github.com/fzipp/gocyclo v0.3.1/go.mod h1:DJHO6AUmbdqj2ET4Z9iArSuwWgYDRryYt2wASx
 github.com/getkin/kin-openapi v0.76.0/go.mod h1:660oXbgy5JFMKreazJaQTw7o+X00qeSyhcnluiMv+Xg=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
+github.com/gitops-tools/pkg v0.1.0 h1:atKTGUjGEEvkSX+HGCzI76rHRB84+nr77ll8kyJY3Nk=
+github.com/gitops-tools/pkg v0.1.0/go.mod h1:c+ZMQS6qVn3+HfJ3Hl04ARo7zxD30ackJnV60UlLC5s=
 github.com/gliderlabs/ssh v0.3.5 h1:OcaySEmAQJgyYcArR+gGGTHCyE7nvhEMTlYY+Dp8CpY=
 github.com/gliderlabs/ssh v0.3.5/go.mod h1:8XB4KraRrX39qHhT6yxPsHedjA08I/uBVwj4xC+/+z4=
 github.com/globalsign/mgo v0.0.0-20180905125535-1ca0a4f7cbcb/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=
@@ -1464,6 +1470,8 @@ github.com/valyala/tcplisten v1.0.0/go.mod h1:T0xQ8SeCZGxckz9qRXTfG43PvQ/mcWh7Fw
 github.com/viki-org/dnscache v0.0.0-20130720023526-c70c1f23c5d8/go.mod h1:dniwbG03GafCjFohMDmz6Zc6oCuiqgH6tGNyXTkHzXE=
 github.com/weaveworks/cluster-controller v1.4.1 h1:vnbHPI+0GkcSOp986WvO5D6grb2IMgDvveKblmGm3vk=
 github.com/weaveworks/cluster-controller v1.4.1/go.mod h1:NrgkuiyejE2nizsiXNeqaNWfVhpvG2SlAiWHnxKIS4U=
+github.com/weaveworks/gitopssets-controller v0.6.0 h1:o1U/StVVCs5JTFP62AIl0JXQn6gnuBdY71AvjVikrZM=
+github.com/weaveworks/gitopssets-controller v0.6.0/go.mod h1:FF4+ie44tnxSgFv+juV3b4f8ScGRxMckJGqwbYU7mfk=
 github.com/weaveworks/gitopssets-controller v0.7.0 h1:t0BSAzXlyowf3R6VtgkFVaee4/BS0KXBs4/q4MnMbOc=
 github.com/weaveworks/gitopssets-controller v0.7.0/go.mod h1:mF1D5uoRqPU+2MxHAR6tcW84zw4gdsPccHM2VNVFroY=
 github.com/weaveworks/pipeline-controller/api v0.0.0-20230228164807-3af8aa2ecc3d h1:HhH19ygpcDDadUMNIc8PtSCqpQ49gpY7je7P/Ow4ZAc=
@@ -1620,6 +1628,8 @@ golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
 golang.org/x/exp v0.0.0-20200331195152-e8c3332aa8e5/go.mod h1:4M0jN8W1tt0AVLNr8HDosyJCDCDuyL9N9+3m7wDWgKw=
+golang.org/x/exp v0.0.0-20230315142452-642cacee5cc0 h1:pVgRXcIictcr+lBQIFeiwuwtDIs4eL21OuM9nyAADmo=
+golang.org/x/exp v0.0.0-20230315142452-642cacee5cc0/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/tools/download-deps.sh
+++ b/tools/download-deps.sh
@@ -131,3 +131,8 @@ tools=$("${BIN_DIR}"/stoml "${DEP_FILE}" .)
 for tool in $tools; do
     download_dependency "${tool}" "${BIN_DIR}"
 done
+
+echo "Installing golangci-lint"
+curl -sSfL \
+  https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh \
+  | sh -s -- -b "$(go env GOPATH)"/bin v1.46.2

--- a/tools/test-dependencies.toml
+++ b/tools/test-dependencies.toml
@@ -1,3 +1,0 @@
-[envtest]
-version="1.19.2"
-special_tarpath="https://storage.googleapis.com/kubebuilder-tools/kubebuilder-tools-${version}-${goos}-${goarch}.tar.gz;kubebuilder/bin"


### PR DESCRIPTION
Reverts weaveworks/weave-gitops-enterprise#2671

Not sure why this changeset has caused smoke tests to fail in `main` but I prefer to revert it and investigate without blocking others.