### PR TITLE
ci: Download only the tools necessary for running integration tests

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -27,11 +27,11 @@ jobs:
       ARTEFACTS_BASE_DIR: /tmp/workspace/test
     steps:
       - name: Install Go
-        uses: actions/setup-go@v3.5.0
+        uses: actions/setup-go@v4.0.0
         with:
           go-version: 1.20.x
       - name: Checkout code
-        uses: actions/checkout@v3.1.0
+        uses: actions/checkout@v3.5.0
       - name: Configure git for private modules
         env:
           GITHUB_BUILD_USERNAME: wge-build-bot
@@ -180,9 +180,9 @@ jobs:
           GITHUB_BUILD_TOKEN: ${{ secrets.BUILD_BOT_PERSONAL_ACCESS_TOKEN }}
         run: git config --global url."https://${GITHUB_BUILD_USERNAME}:${GITHUB_BUILD_TOKEN}@github.com".insteadOf "https://github.com"
       - name: Checkout code
-        uses: actions/checkout@v3.1.0
+        uses: actions/checkout@v3.5.0
       - name: Install Go
-        uses: actions/setup-go@v3.5.0
+        uses: actions/setup-go@v4.0.0
         with:
           go-version: 1.20.x
       - name: Setup snyk

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,7 +20,7 @@ jobs:
     needs: build
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3.1.0
+      uses: actions/checkout@v3.5.0
       with:
         fetch-depth: 0
     - name: Build Changelog

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -117,7 +117,7 @@ jobs:
           echo "go-build=$(go env GOCACHE)" >> $GITHUB_OUTPUT
           echo "go-mod=$(go env GOMODCACHE)" >> $GITHUB_OUTPUT
       - name: Checkout code
-        uses: actions/checkout@v3.1.0
+        uses: actions/checkout@v3.5.0
       - name: Yarn Cache
         uses: actions/cache@v3.0.11
         with:

--- a/Makefile
+++ b/Makefile
@@ -164,7 +164,8 @@ ui-build-for-tests:
 	# Github actions npm is slow sometimes, hence increasing the network-timeout
 	yarn config set network-timeout 300000 && cd ui-cra && yarn install && yarn build
 
-integration-tests: dependencies
+integration-tests:
+	$(CURRENT_DIR)/tools/download-deps.sh $(CURRENT_DIR)/tools/test-dependencies.toml
 	go test -v ./cmd/clusters-service/... -tags=integration
 	go test -v ./pkg/git/... -tags=integration
 

--- a/tools/download-deps.sh
+++ b/tools/download-deps.sh
@@ -131,8 +131,3 @@ tools=$("${BIN_DIR}"/stoml "${DEP_FILE}" .)
 for tool in $tools; do
     download_dependency "${tool}" "${BIN_DIR}"
 done
-
-echo "Installing golangci-lint"
-curl -sSfL \
-  https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh \
-  | sh -s -- -b "$(go env GOPATH)"/bin v1.46.2

--- a/tools/test-dependencies.toml
+++ b/tools/test-dependencies.toml
@@ -1,0 +1,3 @@
+[envtest]
+version="1.19.2"
+special_tarpath="https://storage.googleapis.com/kubebuilder-tools/kubebuilder-tools-${version}-${goos}-${goarch}.tar.gz;kubebuilder/bin"


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Closes #2670 

<!--
Describe what has changed in this PR.
For UI changes also include a screenshot.
-->
**What changed?**
To speed up integration test execution by not downloading dependencies that are not needed. This PR does not change the acceptance/smoke test workflows in any way. 

<!-- Tell your future self why have you made these changes -->
**Why was this change made?**
N/A

<!--
Explain to your reviewers the key implementation points, including why you made
certain choices in favour of others. Highlight key areas of the code which need
extra attention, and also indicate which parts are less relevant (eg renaming,
refactoring, etc
-->
**How was this change implemented?**
N/A

<!--
How have you verified this change/product value? Tested locally?
Added integration/acceptance test(s)?
Unit tests are required.
-->
**How did you validate the change?**
N/A

<!--
Is it notable for release? e.g. schema updates, configuration or data migration
required? If so, please mention it.
-->
**Release notes**
N/A

<!--
Are there any documentation updates that should be made for these changes? We want to keep these sources up to date:
- user-guide: https://docs.gitops.weave.works
- internal docs: https://github.com/weaveworks/weave-gitops-enterprise/tree/main/docs
-->
**Documentation Changes**
N/A