### PR TITLE
Adds bitbucket.org as a default provider domain

### DIFF
--- a/pkg/gitauth/server/gitproviders/repo_url.go
+++ b/pkg/gitauth/server/gitproviders/repo_url.go
@@ -8,6 +8,7 @@ import (
 	"github.com/fluxcd/go-git-providers/github"
 	"github.com/fluxcd/go-git-providers/gitlab"
 	"github.com/spf13/viper"
+	"github.com/weaveworks/weave-gitops-enterprise/pkg/git"
 	"github.com/weaveworks/weave-gitops/pkg/utils"
 )
 
@@ -20,6 +21,7 @@ const (
 	AzureDevOpsHTTPDefaultDomain = "dev.azure.com"
 	// AzureDevOpsSSHDefaultDomain is used for SSH clone URLs
 	AzureDevOpsSSHDefaultDomain = "ssh.dev.azure.com"
+	BitBucketDefaultDomain      = "bitbucket.org"
 )
 
 type RepoURL struct {
@@ -118,6 +120,7 @@ func GitHostTypes(gitHostTypesConfig map[string]string) map[string]string {
 		gitlab.DefaultDomain:         string(GitProviderGitLab),
 		AzureDevOpsHTTPDefaultDomain: string(GitProviderAzureDevOps),
 		AzureDevOpsSSHDefaultDomain:  string(GitProviderAzureDevOps),
+		BitBucketDefaultDomain:       string(git.BitBucketServerProviderName),
 	}
 
 	// add in the user defined git host types

--- a/pkg/gitauth/server/gitproviders/repo_url_test.go
+++ b/pkg/gitauth/server/gitproviders/repo_url_test.go
@@ -19,6 +19,7 @@ func TestDetectGitProviderFromURL(t *testing.T) {
 		{name: "ssh+github", url: "ssh://git@github.com/weaveworks/weave-gitops.git", provider: GitProviderGitHub},
 		{name: "ssh+gitlab", url: "ssh://git@gitlab.com/weaveworks/weave-gitops.git", provider: GitProviderGitLab},
 		{name: "https+bitbucket", url: "https://bitbucket.weave.works/scm/wg/config.git", provider: GitProviderBitBucketServer},
+		{name: "ssh+bitbucket.org", url: "ssh://git@bitbucket.org/pesto-01/pesto-repo-01.git", provider: GitProviderBitBucketServer},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Adds `bitbucket.org` as a default domain that we recognise as a bitbucket provider

So user doesn't have to explicitly add it to the GIT_HOST_TYPES