### PR TITLE
Handle forbidden access to secrets.

### DIFF
--- a/cmd/clusters-service/pkg/server/clusters.go
+++ b/cmd/clusters-service/pkg/server/clusters.go
@@ -435,7 +435,7 @@ func (s *server) kubeConfigForCluster(ctx context.Context, cluster types.Namespa
 		Name:      "cluster-kubeconfig-override",
 	}
 	sec, err := secretByName(ctx, cl, overrideSecretName)
-	if err != nil && !apierrors.IsNotFound(err) {
+	if err != nil && !(apierrors.IsNotFound(err) || apierrors.IsForbidden(err)) {
 		return nil, fmt.Errorf("failed to get secret for cluster %s: %w", cluster, err)
 	}
 	if sec != nil {
@@ -451,7 +451,7 @@ func (s *server) kubeConfigForCluster(ctx context.Context, cluster types.Namespa
 		Name:      fmt.Sprintf("%s-user-kubeconfig", cluster.Name),
 	}
 	sec, err = secretByName(ctx, cl, userSecretName)
-	if err != nil && !apierrors.IsNotFound(err) {
+	if err != nil && !(apierrors.IsNotFound(err) || apierrors.IsForbidden(err)) {
 		return nil, fmt.Errorf("failed to get secret for cluster %s: %w", cluster, err)
 	}
 	if sec != nil {

--- a/cmd/clusters-service/pkg/server/common_test.go
+++ b/cmd/clusters-service/pkg/server/common_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -11,7 +12,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/discovery"
 	fakeclientset "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/rest"
@@ -45,7 +48,7 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 )
 
-func createClient(t *testing.T, clusterState ...runtime.Object) client.Client {
+func newTestScheme(t *testing.T) *runtime.Scheme {
 	scheme := runtime.NewScheme()
 	schemeBuilder := runtime.SchemeBuilder{
 		corev1.AddToScheme,
@@ -65,20 +68,24 @@ func createClient(t *testing.T, clusterState ...runtime.Object) client.Client {
 		t.Fatal(err)
 	}
 
-	c := fake.NewClientBuilder().
+	return scheme
+}
+
+func createClient(t *testing.T, clusterState ...runtime.Object) client.Client {
+	scheme := newTestScheme(t)
+
+	return fake.NewClientBuilder().
 		WithScheme(scheme).
 		WithRuntimeObjects(clusterState...).
 		WithIndex(&corev1.Event{}, "type", client.IndexerFunc(func(o client.Object) []string {
 			event := o.(*corev1.Event)
 			return []string{event.Type}
-		})).
-		Build()
-
-	return c
+		})).Build()
 }
 
 type serverOptions struct {
 	clusterState          []runtime.Object
+	client                client.Client
 	namespace             string
 	provider              git.Provider
 	ns                    string
@@ -112,7 +119,10 @@ func getServer(t *testing.T, clients map[string]client.Client, namespaces map[st
 }
 
 func createServer(t *testing.T, o serverOptions) capiv1_protos.ClustersServiceServer {
-	c := createClient(t, o.clusterState...)
+	c := o.client
+	if c == nil {
+		c = createClient(t, o.clusterState...)
+	}
 	dc := discovery.NewDiscoveryClient(fakeclientset.NewSimpleClientset().Discovery().RESTClient())
 
 	mgmtFetcher := mgmtfetcher.NewManagementCrossNamespacesFetcher(&mgmtfetcherfake.FakeNamespaceCache{
@@ -404,4 +414,38 @@ func nsn(name, namespace string) types.NamespacedName {
 		Name:      name,
 		Namespace: namespace,
 	}
+}
+
+var notImplementedError = errors.New("not implemented")
+
+type mockTracker struct {
+	getImpl func(gvr schema.GroupVersionResource, ns, name string) (runtime.Object, error)
+}
+
+func (t *mockTracker) Add(obj runtime.Object) error {
+	return notImplementedError
+}
+
+func (t *mockTracker) Get(gvr schema.GroupVersionResource, ns, name string) (runtime.Object, error) {
+	return t.getImpl(gvr, ns, name)
+}
+
+func (t *mockTracker) Create(gvr schema.GroupVersionResource, obj runtime.Object, ns string) error {
+	return notImplementedError
+}
+
+func (t *mockTracker) Update(gvr schema.GroupVersionResource, obj runtime.Object, ns string) error {
+	return notImplementedError
+}
+
+func (t *mockTracker) List(gvr schema.GroupVersionResource, gvk schema.GroupVersionKind, ns string) (runtime.Object, error) {
+	return nil, notImplementedError
+}
+
+func (t *mockTracker) Delete(gvr schema.GroupVersionResource, ns, name string) error {
+	return notImplementedError
+}
+
+func (t *mockTracker) Watch(gvr schema.GroupVersionResource, ns string) (watch.Interface, error) {
+	return nil, notImplementedError
 }


### PR DESCRIPTION
Closes 2437

**What changed?**
This ignores forbidden access to the additional components of a secret.

<!-- Tell your future self why have you made these changes -->
**Why was this change made?**
All but the original secret may be forbidden (technically, the original could be forbidden too, but then we'd have nothing, so better to return the error for the cluster secret).

<!--
Explain to your reviewers the key implementation points, including why you made
certain choices in favour of others. Highlight key areas of the code which need
extra attention, and also indicate which parts are less relevant (eg renaming,
refactoring, etc
-->
**How was this change implemented?**
Ignore forbidden errors looking for the additional secrets.

```
Error from server (Forbidden): secrets "cluster-kubeconfig-override" is forbidden: User "https://dex.howard.moomboo.space#CgcxMDI1NTE4EgZnaXRodWI" cannot get resource "secrets" in API group "" in the namespace "test"
```
This will ignore this error message (and looking for the user secret too).

<!--
How have you verified this change/product value? Tested locally?
Added integration/acceptance test(s)?
Unit tests are required.
-->
**How did you validate the change?**


<!--
Is it notable for release? e.g. schema updates, configuration or data migration
required? If so, please mention it.
-->
**Release notes**


<!--
Are there any documentation updates that should be made for these changes? We want to keep these sources up to date:
- user-guide: https://docs.gitops.weave.works
- internal docs: https://github.com/weaveworks/weave-gitops-enterprise/tree/main/docs
-->
**Documentation Changes**
