### PR TITLE
Fixes the helm-chart installing if customScopes omitted

### DIFF
--- a/charts/mccp/values.yaml
+++ b/charts/mccp/values.yaml
@@ -74,6 +74,7 @@ config:
     # Customise the requested scopes for then OIDC authentication flow - openid will always be requested
     # NOTE: these cannot contains spaces between the elements.
     # customScopes: "groups,email,profile"
+    customScopes: ""
   auth:
     userAccount:
       enabled: true


### PR DESCRIPTION
Need an empty string there in the base values.yaml

Alternative: could look into providing better defaults in the template like:
- `CUSTOM_OIDC_SCOPES: {{ default (.Values.config.oidc.customScopes | quote) "" }}`

kind of thing?

Fixes [installing the helm chart in smoke tests](https://github.com/weaveworks/weave-gitops-enterprise/actions/runs/4819439696/jobs/8582805281):

`Error: INSTALLATION FAILED: unable to build kubernetes objects from release manifest: error validating "": error validating data: unknown object type "nil" in ConfigMap.data.CUSTOM_OIDC_SCOPES`

Before:

```
helm template charts/mccp --set config.oidc.enabled=true | grep CUSTOM
  CUSTOM_OIDC_SCOPES:
```

After:

```
helm template charts/mccp --set config.oidc.enabled=true | grep CUSTOM
  CUSTOM_OIDC_SCOPES: ""
```

Should look into some helm chart unit tests..