### PR TITLE
make reboot.sh more resilient to failures

### DIFF
--- a/tools/reboot.sh
+++ b/tools/reboot.sh
@@ -7,6 +7,8 @@
 # the given kind cluster (if it exists) and its GitOps repository and recreate them 
 # both, installing everything from scratch.
 
+set -euo pipefail
+
 export KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-wge-dev}"
 export GITHUB_REPO="${GITHUB_REPO:-wge-dev}"
 export DELETE_GITOPS_DEV_REPO="${DELETE_GITOPS_DEV_REPO:-0}"


### PR DESCRIPTION
I ran into an issue where the version of `clusterctl` in `./tools/bin/` was too old which led to the `clusterctl init` step to fail. However the script just glossed over that instead of bailing out so I didn't notice and just went on trying to install WGE which obviously failed.

Now, `reboot.sh` properly bails out on any error.
