### PR TITLE
Switch gitlab.com smoke tests to run against on-prem gitlab instance

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,9 +1,7 @@
 on:
   push:
-    branches-ignore:
-      - "main"
-    tags-ignore:
-      - "*"
+    branches:
+      - main
   workflow_dispatch:
 
 name: deploy
@@ -23,8 +21,82 @@ jobs:
       WEAVE_GITOPS_CLUSTERS_GITHUB_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.WEAVE_GITOPS_CLUSTERS_GITHUB_WORKLOAD_IDENTITY_PROVIDER }}
       WEAVE_GITOPS_CLUSTERS_GITHUB_SERVICE_ACCOUNT: ${{ secrets.WEAVE_GITOPS_CLUSTERS_GITHUB_SERVICE_ACCOUNT }}
 
-  smoke-tests-gitlab:
-    needs: [build]
+  coverage:
+    runs-on: ubuntu-latest
+    env:
+      ARTEFACTS_BASE_DIR: /tmp/workspace/test
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v4.0.0
+        with:
+          go-version: 1.20.x
+      - name: Checkout code
+        uses: actions/checkout@v3.5.0
+      - name: Configure git for private modules
+        env:
+          GITHUB_BUILD_USERNAME: wge-build-bot
+          GITHUB_BUILD_TOKEN: ${{ secrets.BUILD_BOT_PERSONAL_ACCESS_TOKEN }}
+        run: git config --global url."https://${GITHUB_BUILD_USERNAME}:${GITHUB_BUILD_TOKEN}@github.com".insteadOf "https://github.com"
+      - name: Install dependencies
+        run: |
+          go mod download
+          go install github.com/wadey/gocovmerge@latest
+          go install github.com/jstemmer/go-junit-report@latest
+          npm install -g junit-report-merger
+      - name: Run unit tests
+        run: |
+          go version
+          mkdir -p ${{ env.ARTEFACTS_BASE_DIR }}
+
+          WKP_DEBUG=true go test -cover -coverprofile=.coverprofile ./cmd/... ./pkg/... | go-junit-report > ${{ env.ARTEFACTS_BASE_DIR }}/test-results.xml
+          cd ${{ github.workspace }}/common && go test -cover -coverprofile=.coverprofile ./... | go-junit-report > ${{ env.ARTEFACTS_BASE_DIR }}/common-results.xml
+          cd ${{ github.workspace }}/cmd/clusters-service && go test -cover -coverprofile=.coverprofile ./... | go-junit-report > ${{ env.ARTEFACTS_BASE_DIR }}/clusters-service-results.xml
+
+          cd ${{ github.workspace }}
+          # Merge all coverage results
+          gocovmerge .coverprofile common/.coverprofile  cmd/clusters-service/.coverprofile > ${{ env.ARTEFACTS_BASE_DIR }}/merged-profiles
+          # Merge all junit test results
+          jrm ${{ env.ARTEFACTS_BASE_DIR }}/combined-test-results.xml '${{ env.ARTEFACTS_BASE_DIR }}/*.xml'
+      - name: Store unit test coverage results
+        uses: actions/upload-artifact@v3
+        with:
+          name: unit-tests-artifacts
+          path: |
+            ${{ env.ARTEFACTS_BASE_DIR }}
+          retention-days: 1
+
+  smoke-tests-github:
+    needs: [build, coverage]
+    uses: ./.github/workflows/acceptance-test.yaml
+    with:
+      runs-on: ubuntu-latest
+      os-name: linux
+      timeout-minutes: 60
+      label-filter: "--label-filter='smoke&&capd'"
+      kubectl-version: "v1.21.1"
+      login_user_type: "oidc"
+      git-provider: github
+      git-provider_hostname: github.com
+      cluster_resource_set: true
+      management-cluster-kind: kind
+      capi_provider: capd
+      gitops-bin-path: /usr/local/bin/gitops
+      test-artifact-name: smoke-tests-github
+    secrets:
+      WGE_CLUSTER_ADMIN_PASSWORD: "${{ secrets.WGE_CLUSTER_ADMIN_PASSWORD }}"
+      WGE_CLUSTER_ADMIN_PASSWORD_HASH: "${{ secrets.WGE_CLUSTER_ADMIN_PASSWORD_HASH }}"
+      WGE_DEX_CLIENT_SECRET: ${{ secrets.WGE_DEX_CLIENT_SECRET }}
+      WGE_GIT_PROVIDER_PRIVATE_KEY: ${{ secrets.WGE_GITHUB_PRIVATE_KEY }}
+      WGE_GITHUB_TOKEN: ${{ secrets.WGE_GITHUB_TOKEN }}
+      WGE_GITHUB_ORG: ${{ secrets.WGE_GITHUB_ORG }}
+      WGE_GITHUB_USER: ${{ secrets.WGE_GITHUB_USER }}
+      WGE_GITHUB_PASSWORD: ${{ secrets.WGE_GITHUB_PASSWORD }}
+      WGE_GITHUB_MFA_KEY: ${{ secrets.WGE_GITHUB_MFA_KEY }}
+      WGE_EKS_AWS_ACCESS_KEY_ID: ${{ secrets.WGE_EKS_AWS_ACCESS_KEY_ID }}
+      WGE_EKS_AWS_SECRET_ACCESS_KEY: ${{ secrets.WGE_EKS_AWS_SECRET_ACCESS_KEY }}
+
+  smoke-tests-gitlab-deploy:
+    needs: [build, coverage]
     uses: ./.github/workflows/acceptance-test.yaml
     with:
       runs-on: ubuntu-latest
@@ -39,7 +111,7 @@ jobs:
       management-cluster-kind: kind
       capi_provider: capd
       gitops-bin-path: /usr/local/bin/gitops
-      test-artifact-name: smoke-tests-gitlab
+      test-artifact-name: smoke-tests-gitlab-deploy
     secrets:
       WGE_CLUSTER_ADMIN_PASSWORD: "${{ secrets.WGE_CLUSTER_ADMIN_PASSWORD }}"
       WGE_CLUSTER_ADMIN_PASSWORD_HASH: "${{ secrets.WGE_CLUSTER_ADMIN_PASSWORD_HASH }}"
@@ -55,41 +127,42 @@ jobs:
       WGE_EKS_AWS_ACCESS_KEY_ID: ${{ secrets.WGE_EKS_AWS_ACCESS_KEY_ID }}
       WGE_EKS_AWS_SECRET_ACCESS_KEY: ${{ secrets.WGE_EKS_AWS_SECRET_ACCESS_KEY }}
 
-  # smoke-tests-gitlab-on-prem:
-  #   needs: [build]
-  #   uses: ./.github/workflows/acceptance-test.yaml
-  #   with:
-  #     runs-on: ubuntu-latest
-  #     os-name: linux
-  #     timeout-minutes: 60
-  #     label-filter: "--label-filter='smoke&&tenant'"
-  #     kubectl-version: "v1.23.3"
-  #     login_user_type: "oidc"
-  #     git-provider: gitlab
-  #     git-provider_hostname: gitlab.git.dev.weave.works
-  #     cluster_resource_set: true
-  #     management-cluster-kind: kind
-  #     capi_provider: capd
-  #     gitops-bin-path: /usr/local/bin/gitops
-  #     test-artifact-name: smoke-tests-gitlab-on-prem
-  #   secrets:
-  #     WGE_CLUSTER_ADMIN_PASSWORD: "${{ secrets.WGE_CLUSTER_ADMIN_PASSWORD }}"
-  #     WGE_CLUSTER_ADMIN_PASSWORD_HASH: "${{ secrets.WGE_CLUSTER_ADMIN_PASSWORD_HASH }}"
-  #     WGE_DEX_CLIENT_SECRET: ${{ secrets.WGE_DEX_CLIENT_SECRET }}
-  #     WGE_GITHUB_TOKEN: ${{ secrets.WGE_GITHUB_TOKEN }}
-  #     WGE_GIT_PROVIDER_PRIVATE_KEY: ${{ secrets.WGE_ON_PREM_GITLAB_PRIVATE_KEY }}
-  #     WGE_GITLAB_TOKEN: ${{ secrets.WGE_ON_PREM_GITLAB_TOKEN }}
-  #     WGE_GITLAB_ORG: ${{ secrets.WGE_ON_PREM_GITLAB_ORG }}
-  #     WGE_GITLAB_USER: ${{ secrets.WGE_ON_PREM_GITLAB_USER }}
-  #     WGE_GITLAB_PASSWORD: ${{ secrets.WGE_ON_PREM_GITLAB_PASSWORD }}
-  #     WGE_GITLAB_CLIENT_ID: ${{ secrets.WGE_ON_PREM_GITLAB_CLIENT_ID }}
-  #     WGE_GITLAB_CLIENT_SECRET: ${{ secrets.WGE_ON_PREM_GITLAB_CLIENT_SECRET }}
-  #     WGE_EKS_AWS_ACCESS_KEY_ID: ${{ secrets.WGE_EKS_AWS_ACCESS_KEY_ID }}
-  #     WGE_EKS_AWS_SECRET_ACCESS_KEY: ${{ secrets.WGE_EKS_AWS_SECRET_ACCESS_KEY }}
+  smoke-tests-gitlab-tenant:
+    needs: [build, coverage]
+    uses: ./.github/workflows/acceptance-test.yaml
+    with:
+      runs-on: ubuntu-latest
+      os-name: linux
+      timeout-minutes: 60
+      label-filter: "--label-filter='smoke&&tenant'"
+      kubectl-version: "v1.23.3"
+      login_user_type: "oidc"
+      git-provider: gitlab
+      git-provider_hostname: gitlab.git.dev.weave.works
+      cluster_resource_set: true
+      management-cluster-kind: kind
+      capi_provider: capd
+      gitops-bin-path: /usr/local/bin/gitops
+      test-artifact-name: smoke-tests-gitlab-tenant
+    secrets:
+      WGE_CLUSTER_ADMIN_PASSWORD: "${{ secrets.WGE_CLUSTER_ADMIN_PASSWORD }}"
+      WGE_CLUSTER_ADMIN_PASSWORD_HASH: "${{ secrets.WGE_CLUSTER_ADMIN_PASSWORD_HASH }}"
+      WGE_DEX_CLIENT_SECRET: ${{ secrets.WGE_DEX_CLIENT_SECRET }}
+      WGE_GITHUB_TOKEN: ${{ secrets.WGE_GITHUB_TOKEN }}
+      WGE_GIT_PROVIDER_PRIVATE_KEY: ${{ secrets.WGE_ON_PREM_GITLAB_PRIVATE_KEY }}
+      WGE_GITLAB_TOKEN: ${{ secrets.WGE_ON_PREM_GITLAB_TOKEN }}
+      WGE_GITLAB_ORG: ${{ secrets.WGE_ON_PREM_GITLAB_ORG }}
+      WGE_GITLAB_USER: ${{ secrets.WGE_ON_PREM_GITLAB_USER }}
+      WGE_GITLAB_PASSWORD: ${{ secrets.WGE_ON_PREM_GITLAB_PASSWORD }}
+      WGE_GITLAB_CLIENT_ID: ${{ secrets.WGE_ON_PREM_GITLAB_CLIENT_ID }}
+      WGE_GITLAB_CLIENT_SECRET: ${{ secrets.WGE_ON_PREM_GITLAB_CLIENT_SECRET }}
+      WGE_EKS_AWS_ACCESS_KEY_ID: ${{ secrets.WGE_EKS_AWS_ACCESS_KEY_ID }}
+      WGE_EKS_AWS_SECRET_ACCESS_KEY: ${{ secrets.WGE_EKS_AWS_SECRET_ACCESS_KEY }}
 
   smoke-test-results:
     if: ${{ always() }}
-    needs: [smoke-tests-gitlab]
+    needs:
+      [smoke-tests-github, smoke-tests-gitlab-deploy, smoke-tests-gitlab-tenant]
     uses: ./.github/workflows/publish-test-results.yaml
     with:
       runs-on: ubuntu-latest
@@ -98,3 +171,32 @@ jobs:
       slack-notification: false
     secrets:
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+
+  snyk-monitor:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Configure git for private modules
+        env:
+          GITHUB_BUILD_USERNAME: wge-build-bot
+          GITHUB_BUILD_TOKEN: ${{ secrets.BUILD_BOT_PERSONAL_ACCESS_TOKEN }}
+        run: git config --global url."https://${GITHUB_BUILD_USERNAME}:${GITHUB_BUILD_TOKEN}@github.com".insteadOf "https://github.com"
+      - name: Checkout code
+        uses: actions/checkout@v3.5.0
+      - name: Install Go
+        uses: actions/setup-go@v4.0.0
+        with:
+          go-version: 1.20.x
+      - name: Setup snyk
+        uses: snyk/actions/setup@master
+      - name: Monitor dependencies & license problems with Snyk
+        # Throw an error if the error is "snyk couldn't run".
+        # Don't throw an error on "there are vulnerabilities", those
+        # are notified separately
+        run: |
+          exit_code=0
+          snyk monitor --all-projects --org=product-engineering-ly9 || exit_code=$?
+          if [ $exit_code -gt 1 ]; then
+            exit $exit_code
+          fi
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_API_TOKEN }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,7 +1,9 @@
 on:
   push:
-    branches:
+    branches-ignore:
       - "main"
+    tags-ignore:
+      - "*"
   workflow_dispatch:
 
 concurrency:
@@ -126,7 +128,7 @@ jobs:
       - name: Install modules
         run: cd ui-cra && yarn --pure-lockfile
       - name: Run Front-end Unit Tests
-        run: cd ui-cra && ./node_modules/.bin/react-scripts test
+        run: cd ui-cra && ./node_modules/.bin/react-scripts test  
 
   snyk-checks:
     runs-on: ubuntu-latest
@@ -154,3 +156,4 @@ jobs:
           snyk test --org=product-engineering-ly9 --json --file=ui-cra/yarn.lock | snyk-delta
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_API_TOKEN }}
+


### PR DESCRIPTION
- We've been seeing many smoke failures due to gitlab.com's bot detection system rejecting our selenium webdriver
  - https://github.com/weaveworks/weave-gitops-enterprise/actions/runs/4828357241/jobs/8602863634
- This PR switches the tests that use gitlab.com to use our on-prem instance instead
- To better reflect the test labels that are invoked (deploy vs tenant, though "deploy" is a bit vague..), rename:
  - `smoke-tests-gitlab` -> `smoke-tests-gitlab-deploy`
  - `smoke-tests-gitlab-on-prem` -> `smoke-tests-gitlab-tenant`

Using on-prem the tests passed first go:
- https://github.com/weaveworks/weave-gitops-enterprise/actions/runs/4829355638
