### PR TITLE
Hide clusters button when using query service backend

### DIFF
--- a/ui-cra/src/components/Clusters/ClusterDetails.tsx
+++ b/ui-cra/src/components/Clusters/ClusterDetails.tsx
@@ -1,11 +1,12 @@
 import { ThemeProvider } from '@material-ui/core/styles';
 import {
-  Button as WeaveButton,
   Icon,
   IconType,
   RouterTab,
   SubRouterTabs,
+  Button as WeaveButton,
   theme,
+  useFeatureFlags,
   useListSources,
 } from '@weaveworks/weave-gitops';
 import { useHistory, useRouteMatch } from 'react-router-dom';
@@ -19,10 +20,10 @@ import { CircularProgress, createStyles, makeStyles } from '@material-ui/core';
 import { useEffect, useState } from 'react';
 import useClusters from '../../hooks/clusters';
 import { GitopsClusterEnriched } from '../../types/custom';
+import { toFilterQueryString } from '../../utils/FilterQueryString';
 import { useIsClusterWithSources } from '../Applications/utils';
 import { Tooltip } from '../Shared';
 import ClusterDashboard from './ClusterDashboard';
-import { toFilterQueryString } from '../../utils/FilterQueryString';
 type Props = {
   className?: string;
   name: string;
@@ -38,9 +39,6 @@ const ActionsWrapper = styled.div<Size>`
 
 const useStyles = makeStyles(() =>
   createStyles({
-    clusterApplicationBtn: {
-      marginBottom: theme.spacing.medium,
-    },
     addApplicationBtnLoader: {
       marginLeft: theme.spacing.xl,
     },
@@ -57,6 +55,10 @@ const ClusterDetails = ({ clusterName }: Props) => {
     useState<GitopsClusterEnriched | null>(null);
   const isClusterWithSources = useIsClusterWithSources(clusterName);
   const { isLoading: loading } = useListSources('', '', { retry: false });
+  const { isFlagEnabled } = useFeatureFlags();
+  const useQueryServiceBackend = isFlagEnabled(
+    'WEAVE_GITOPS_FEATURE_QUERY_SERVICE_BACKEND',
+  );
 
   useEffect(
     () => setCurrentCluster(getCluster(clusterName)),
@@ -74,23 +76,26 @@ const ClusterDetails = ({ clusterName }: Props) => {
         <ContentWrapper loading={isLoading}>
           {currentCluster && (
             <div style={{ overflowX: 'auto' }}>
-              <ActionsWrapper>
-                <WeaveButton
-                  id="cluster-application"
-                  className={classes.clusterApplicationBtn}
-                  startIcon={<Icon type={IconType.FilterIcon} size="base" />}
-                  onClick={() => {
-                    const filtersValues = toFilterQueryString([
-                      {
-                        key: 'clusterName',
-                        value: `${currentCluster?.namespace}/${currentCluster?.name}`,
-                      },
-                    ]);
-                    history.push(`/applications?filters=${filtersValues}`);
-                  }}
-                >
-                  GO TO APPLICATIONS
-                </WeaveButton>
+              <ActionsWrapper style={{ marginBottom: theme.spacing.medium }}>
+                {!useQueryServiceBackend && (
+                  <WeaveButton
+                    id="cluster-application"
+                    className={classes.addApplicationBtnLoader}
+                    startIcon={<Icon type={IconType.FilterIcon} size="base" />}
+                    onClick={() => {
+                      const filtersValues = toFilterQueryString([
+                        {
+                          key: 'clusterName',
+                          value: `${currentCluster?.namespace}/${currentCluster?.name}`,
+                        },
+                      ]);
+                      history.push(`/applications?filters=${filtersValues}`);
+                    }}
+                  >
+                    GO TO APPLICATIONS
+                  </WeaveButton>
+                )}
+
                 {loading ? (
                   <CircularProgress size={30} />
                 ) : (


### PR DESCRIPTION
Closes #2802 

Hides the application button when using the Query service backend.

The root cause of the bug was the `DataTable` looking at the URL parameters and trying to sort/filter when we don't want it to. This is hard set in the component which lives in Core and was not easily changeable. 

A better fix is coming in: https://github.com/weaveworks/weave-gitops-enterprise/pull/2793