### PR TITLE
passing service logger to bitbucket server client factory to address `logger is required` issue

### DIFF
--- a/pkg/git/bitbucket_server.go
+++ b/pkg/git/bitbucket_server.go
@@ -39,6 +39,7 @@ func (p *BitBucketServerProvider) Setup(opts ProviderOption) error {
 	ggpOpts := []gitprovider.ClientOption{
 		gitprovider.WithDomain(opts.Hostname),
 		gitprovider.WithConditionalRequests(opts.ConditionalRequests),
+		gitprovider.WithLogger(&p.log),
 	}
 
 	var err error

--- a/pkg/git/bitbucket_server_test.go
+++ b/pkg/git/bitbucket_server_test.go
@@ -1,0 +1,24 @@
+package git
+
+import (
+	"github.com/go-logr/logr/testr"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestCreateBitbucketServerClient(t *testing.T) {
+
+	hostname := "https://my-bit-bucket-server/scm/flux/fleet-tenants-irsa.git"
+	token := "myToken"
+	tokenType := "myTokenType"
+
+	providerOpts := []ProviderWithFn{}
+
+	providerOpts = append(providerOpts, WithUsername("git"))
+	providerOpts = append(providerOpts, WithToken(tokenType, token))
+	providerOpts = append(providerOpts, WithDomain(hostname))
+	providerOpts = append(providerOpts, WithConditionalRequests())
+
+	_, err := NewFactory(testr.New(t)).Create(BitBucketServerProviderName, providerOpts...)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
Passing logger server to bitbucket client as quick fix for https://github.com/weaveworks/weave-gitops-interlock/issues/425

<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Part of https://github.com/weaveworks/weave-gitops-interlock/issues/425

<!--
Describe what has changed in this PR.
For UI changes also include a screenshot.
-->
**What changed?**

Cause go-git-providers bitbucket server client does not allow empty loggers. More info in the ticket

<!-- Tell your future self why have you made these changes -->

**Why was this change made?**

To send a non empty logger when creating a bitbucket server client

<!--
How have you verified this change/product value? Tested locally?
Added integration/acceptance test(s)?
Unit tests are required.
-->
**How did you validate the change?**

Added unit test around the creation and the issue but not e2e tested.

