### PR TITLE
Bump Core UI version to unbreak the EE UI

### DIFF
--- a/ui-cra/package.json
+++ b/ui-cra/package.json
@@ -26,7 +26,7 @@
     "@types/styled-components": "^5.1.9",
     "@types/urijs": "^1.19.19",
     "@weaveworks/progressive-delivery": "0.0.0-rc13",
-    "@weaveworks/weave-gitops": "npm:@weaveworks/weave-gitops-main@0.24.0-rc.1-83-g9c0b71da",
+    "@weaveworks/weave-gitops": "npm:@weaveworks/weave-gitops-main@0.24.0-rc.1-102-g800dd906",
     "classnames": "^2.3.1",
     "d3-scale": "4.0.0",
     "d3-time": "^3.0.0",

--- a/ui-cra/yarn.lock
+++ b/ui-cra/yarn.lock
@@ -2337,10 +2337,10 @@
   resolved "https://npm.pkg.github.com/download/@weaveworks/progressive-delivery/0.0.0-rc13/2628159001f4812b90e068e64fae8de6b4e3f2b4"
   integrity sha512-51ET/FrGwKcBUSqRTtaWTTuWQi/y51JQAFYMT6ctOLaiIXSopCyi3alf4aYDZ5TPFAIdOQapJMYiq2HVj5XxOQ==
 
-"@weaveworks/weave-gitops@npm:@weaveworks/weave-gitops-main@0.24.0-rc.1-83-g9c0b71da":
-  version "0.24.0-rc.1-83-g9c0b71da"
-  resolved "https://npm.pkg.github.com/download/@weaveworks/weave-gitops-main/0.24.0-rc.1-83-g9c0b71da/10c607c493e094776724148626acbd9ce7cc477e#10c607c493e094776724148626acbd9ce7cc477e"
-  integrity sha512-LlW966fB6Ue85sLEQFnBRUF/bSodurp/Ez9V4SFrpBwQeuGeDULRQQwOSlbZkD4LhUc4LdD69KN1Kn4McdzIDg==
+"@weaveworks/weave-gitops@npm:@weaveworks/weave-gitops-main@0.24.0-rc.1-102-g800dd906":
+  version "0.24.0-rc.1-102-g800dd906"
+  resolved "https://npm.pkg.github.com/download/@weaveworks/weave-gitops-main/0.24.0-rc.1-102-g800dd906/b3f4b3f6d663efcda7690f2b9c86a139e17fe31a#b3f4b3f6d663efcda7690f2b9c86a139e17fe31a"
+  integrity sha512-+RqZuKo0jgnFfzMG/uw0QMyitOsKntft7I1WbZ5vLXGo9ZNhWJfimI2geSVmGsf/ZF62sZZXXz+xGi2JAj7NpA==
   dependencies:
     "@material-ui/core" "^4.12.3"
     "@material-ui/icons" "^4.11.2"


### PR DESCRIPTION
EE UI would not build, this upgrades core to fix it.

Related to https://github.com/weaveworks/weave-gitops/issues/3759

From @joshri, root cause was: 

> someone imported a module in a weird way - like this "react-markdown/react-markdown.min" instead of just react-markdown and then tried to use that import as a styled component