### PR TITLE
Upgrade libssl1.1 and libcrypto1.1 during build to avoid CVEs

### DIFF
--- a/ui-cra/Dockerfile
+++ b/ui-cra/Dockerfile
@@ -22,7 +22,7 @@ RUN --mount=type=cache,target=/home/node/node_modules,uid=1000,gid=1000 make bui
 
 FROM alpine:3.16
 
-RUN apk upgrade libssl3 libcrypto3
+RUN apk upgrade libssl1.1 libcrypto1.1
 
 WORKDIR /
 COPY --from=build /home/node/build /html


### PR DESCRIPTION
- openssl gets CVEs every other day
- alpine only releases every couple of months
- make sure openssl is up to date when we build

