### PR TITLE
uprgade cluster-bootstrap-controller rbac-proxy to v0.14.1 

### DIFF
--- a/charts/mccp/templates/cluster-bootstrap-controller/deployment.yaml
+++ b/charts/mccp/templates/cluster-bootstrap-controller/deployment.yaml
@@ -28,7 +28,7 @@ spec:
         - --upstream=http://127.0.0.1:8080/
         - --logtostderr=true
         - --v=10
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.14.1
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443


### PR DESCRIPTION
Bump the version of kube-rbac-proxy to the latest currently available.

Addresses https://github.com/weaveworks/weave-gitops-interlock/issues/417