### PR TITLE
fix: no manual promotion button in pipelines

### DIFF
--- a/tools/dev-resources/pipelines/github/podinfo-dev/notification.yaml
+++ b/tools/dev-resources/pipelines/github/podinfo-dev/notification.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: flux-system
 spec:
   type: generic
-  address: http://pipeline-promotion.pipeline-system.svc.cluster.local/promotion/flux-system/podinfo-github/dev
+  address: http://chart-pipeline-controller-promotion.flux-system.svc.cluster.local:8082/promotion/flux-system/podinfo-github/dev
 ---
 apiVersion: notification.toolkit.fluxcd.io/v1beta1
 kind: Alert


### PR DESCRIPTION
It seems the issue was a misconfigured Notification object. I assume it was created in a "pipelines dev" environment where it was a practice to deploy the service and related resources in pipeline-system.

Fixes #3020

![image](https://github.com/weaveworks/weave-gitops-enterprise/assets/183191/f3d0e84d-c482-4013-9820-d2894fe38c91)
from the [fluxga cluster](https://fluxga.eng-sandbox.weave.works/pipelines/details/status?kind=Pipeline&name=pipelines&namespace=flux-system)