### PR TITLE
ci: Add notification job dependencies

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -208,7 +208,7 @@ jobs:
     if: ${{ failure() }}
     steps:
     - name: Send alert
-      uses: archive/github-actions-slack@v2
+      uses: archive/github-actions-slack@d9dae40827adf93bddf939db6552d1e392259d7d # v2.7.0
       with:
         slack-bot-user-oauth-access-token: ${{ secrets.WEAVEWORKS_SLACK_GENERICBOT_TOKEN }}
         slack-channel: C01M1BJQ7AT # weave-gitops-dev


### PR DESCRIPTION
We need to add dependent jobs otherwise the notification job is being skipped.

<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Closes #3037 

<!--
Describe what has changed in this PR.
For UI changes also include a screenshot.
-->
**What changed?**
Added notification job dependencies

<!-- Tell your future self why have you made these changes -->
**Why was this change made?**
If we don't have dependent jobs, the notification job is being skipped. See example in https://docs.github.com/en/actions/learn-github-actions/contexts#example-usage-of-the-needs-context

<!--
Explain to your reviewers the key implementation points, including why you made
certain choices in favour of others. Highlight key areas of the code which need
extra attention, and also indicate which parts are less relevant (eg renaming,
refactoring, etc
-->
**How was this change implemented?**
N/A

<!--
How have you verified this change/product value? Tested locally?
Added integration/acceptance test(s)?
Unit tests are required.
-->
**How did you validate the change?**
N/A

<!--
Is it notable for release? e.g. schema updates, configuration or data migration
required? If so, please mention it.
-->
**Release notes**
N/A

<!--
Are there any documentation updates that should be made for these changes? We want to keep these sources up to date:
- user-guide: https://docs.gitops.weave.works
- internal docs: https://github.com/weaveworks/weave-gitops-enterprise/tree/main/docs
- architecture docs: https://github.com/weaveworks/weave-gitops-enterprise/blob/main/docs/architecture
-->
**Documentation Changes**
N/A