### PR TITLE
Migrate from removed goreleaser "replacements" field

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -10,9 +10,11 @@ checksum:
   name_template: "{{ .ProjectName }}_checksums.txt"
 archives:
   - format: tar.gz
-    replacements:
-      amd64: x86_64
-    name_template: "gitops-{{.Os}}-{{.Arch}}"
+    name_template: >-
+      gitops-
+      {{- title .Os }}-
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else }}{{ .Arch }}{{ end }}
 builds:
   - <<: &build_defaults
       binary: "gitops"


### PR DESCRIPTION
- goreleaser removed the "replacements" fields
- follow their migration guide and update to using name_template https://goreleaser.com/deprecations/#archivesreplacements

<!-- Tell your future self why have you made these changes -->
**Why was this change made?**

So the next release goes smoothly

<!--
Explain to your reviewers the key implementation points, including why you made
certain choices in favour of others. Highlight key areas of the code which need
extra attention, and also indicate which parts are less relevant (eg renaming,
refactoring, etc
-->
**How was this change implemented?**

Copy and pasting the similar fix from OSS in https://github.com/weaveworks/weave-gitops/commit/54f8210cd421243b912a38004d53a1e32aeb5aea


<!--
How have you verified this change/product value? Tested locally?
Added integration/acceptance test(s)?
Unit tests are required.
-->
**How did you validate the change?**

- The release in OSS broke
- Fixed it using the linked fix
- Hopefully that makes sure this release will work too

<!--
Is it notable for release? e.g. schema updates, configuration or data migration
required? If so, please mention it.
-->
**Release notes**


<!--
Are there any documentation updates that should be made for these changes? We want to keep these sources up to date:
- user-guide: https://docs.gitops.weave.works
- internal docs: https://github.com/weaveworks/weave-gitops-enterprise/tree/main/docs
- architecture docs: https://github.com/weaveworks/weave-gitops-enterprise/blob/main/docs/architecture
-->
**Documentation Changes**
