### PR TITLE
[UI] use the correct PolicyDetailsPage import

### DIFF
--- a/ui-cra/src/routes.tsx
+++ b/ui-cra/src/routes.tsx
@@ -1,4 +1,4 @@
-import { PolicyDetails, V2Routes } from '@weaveworks/weave-gitops';
+import { V2Routes } from '@weaveworks/weave-gitops';
 import qs from 'query-string';
 import Lottie from 'react-lottie-player';
 import { Redirect, Route, Switch } from 'react-router-dom';
@@ -34,6 +34,7 @@ import { NotificationsWrapper } from './components/Layout/NotificationsWrapper';
 import Pipelines from './components/Pipelines';
 import PipelineDetails from './components/Pipelines/PipelineDetails';
 import Policies from './components/Policies/PoliciesListPage';
+import PolicyDetailsPage from './components/Policies/PolicyDetailsPage';
 import PolicyViolationPage from './components/Policies/PolicyViolationPage';
 import PolicyConfigsList from './components/PolicyConfigs';
 import PolicyConfigsDetails from './components/PolicyConfigs/PolicyConfigDetails';
@@ -218,7 +219,7 @@ const AppRoutes = () => {
       />
       <Route exact path={V2Routes.Policies} component={Policies} />
       <Route
-        component={withSearchParams(PolicyDetails)}
+        component={withSearchParams(PolicyDetailsPage)}
         path={V2Routes.PolicyDetailsPage}
       />
       <Route component={TemplatesDashboard} exact path={Routes.Templates} />


### PR DESCRIPTION
![image](https://github.com/weaveworks/weave-gitops-enterprise/assets/4614360/f323c994-f41b-4342-9124-295d9aca51d8)

<!--
Describe what has changed in this PR.
For UI changes also include a screenshot.
-->
**What changed?**

it seems that Route component points to the [policyDetails](https://github.com/weaveworks/weave-gitops-enterprise/blob/main/ui-cra/src/routes.tsx#L221C52-L221C52)  when it should points to  [PolicyDetailsPage](https://github.com/weaveworks/weave-gitops-enterprise/blob/main/ui-cra/src/components/Policies/PolicyDetailsPage.tsx)


https://github.com/weaveworks/weave-gitops-enterprise/assets/4614360/729e332d-2db4-4916-b6a1-1a47e5602185




<!-- Tell your future self why have you made these changes -->
**Why was this change made?**


<!--
Explain to your reviewers the key implementation points, including why you made
certain choices in favour of others. Highlight key areas of the code which need
extra attention, and also indicate which parts are less relevant (eg renaming,
refactoring, etc
-->
**How was this change implemented?**


<!--
How have you verified this change/product value? Tested locally?
Added integration/acceptance test(s)?
Unit tests are required.
-->
**How did you validate the change?**


<!--
Is it notable for release? e.g. schema updates, configuration or data migration
required? If so, please mention it.
-->
**Release notes**


<!--
Are there any documentation updates that should be made for these changes? We want to keep these sources up to date:
- user-guide: https://docs.gitops.weave.works
- internal docs: https://github.com/weaveworks/weave-gitops-enterprise/tree/main/docs
- architecture docs: https://github.com/weaveworks/weave-gitops-enterprise/blob/main/docs/architecture
-->
**Documentation Changes**
