### PR TITLE
Ignore docs/ and similar paths for test workflow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,6 +4,11 @@ on:
       - "main"
     tags-ignore:
       - "*"
+    paths-ignore:
+      - "docs/**"
+      - "bin/**"
+      - ".github/pull_request_template.md" # but don't exclude ./workflows !
+      - ".github/ISSUE_TEMPLATE/**"
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
The tests workflow just runs unit tests and integration tests (make targets `integration-tests` and `unit-tests-with-coverage`). I've added some fairly conservative paths to the GitHub workflow under on.paths-ignore, so that PRs with _just_ changes to docs aren't contingent on the tests. This saves some waiting, and some resources.

 - docs/** # these are not involved in the tests
 - bin/** # scripts that are not involved in the tests

In general we _do_ want to run tests if it's the workflow itself that's changed, so I've bene more specific in `.github/` and just ignored the templates.

**Why was this change made?**

I got annoyed waiting for test retries to complete on https://github.com/weaveworks/weave-gitops-enterprise/pull/2909.

**How did you validate the change?**

We'll have to wait until it's actually run. It's tricky to test CI scripts!
