### PR TITLE
Remove duplicate namespace key in image automation info lists

### DIFF
--- a/ui-cra/src/components/ImageAutomation/policies/ImagePolicyDetails.tsx
+++ b/ui-cra/src/components/ImageAutomation/policies/ImagePolicyDetails.tsx
@@ -6,9 +6,9 @@ import {
 } from '@weaveworks/weave-gitops';
 import { ImagePolicy } from '@weaveworks/weave-gitops/ui/lib/objects';
 import styled from 'styled-components';
+import { Page } from '../../Layout/App';
 import { NotificationsWrapper } from '../../Layout/NotificationsWrapper';
 import ImageAutomationDetails from '../ImageAutomationDetails';
-import { Page } from '../../Layout/App';
 
 type Props = {
   className?: string;
@@ -45,7 +45,7 @@ function ImagePolicyDetails({ name, namespace, clusterName }: Props) {
             infoFields={[
               ['Kind', Kind.ImagePolicy],
               ['Namespace', data?.namespace],
-              ['Namespace', data?.clusterName],
+              ['Cluster Name', data?.clusterName],
               ['Image Policy', data?.imagePolicy?.type || ''],
               ['Order/Range', data?.imagePolicy?.value],
             ]}

--- a/ui-cra/src/components/ImageAutomation/repositories/ImageAutomationRepoDetails.tsx
+++ b/ui-cra/src/components/ImageAutomation/repositories/ImageAutomationRepoDetails.tsx
@@ -9,9 +9,9 @@ import {
 import { ImageRepository } from '@weaveworks/weave-gitops/ui/lib/objects';
 import styled from 'styled-components';
 import { toFilterQueryString } from '../../../utils/FilterQueryString';
+import { Page } from '../../Layout/App';
 import { NotificationsWrapper } from '../../Layout/NotificationsWrapper';
 import ImageAutomationDetails from '../ImageAutomationDetails';
-import { Page } from '../../Layout/App';
 
 type Props = {
   className?: string;
@@ -52,7 +52,7 @@ function ImageAutomationRepoDetails({ name, namespace, clusterName }: Props) {
             infoFields={[
               ['Kind', Kind.ImageRepository],
               ['Namespace', data?.namespace],
-              ['Namespace', data?.clusterName],
+              ['Cluster Name', data?.clusterName],
               [
                 'Image',
                 <Link newTab={true} to={data.obj?.spec?.image}>

--- a/ui-cra/src/components/ImageAutomation/updates/ImageAutomationUpdatesDetails.tsx
+++ b/ui-cra/src/components/ImageAutomation/updates/ImageAutomationUpdatesDetails.tsx
@@ -8,9 +8,9 @@ import {
 import { InfoField } from '@weaveworks/weave-gitops/ui/components/InfoList';
 import { ImageUpdateAutomation } from '@weaveworks/weave-gitops/ui/lib/objects';
 import styled from 'styled-components';
+import { Page } from '../../Layout/App';
 import { NotificationsWrapper } from '../../Layout/NotificationsWrapper';
 import ImageAutomationDetails from '../ImageAutomationDetails';
-import { Page } from '../../Layout/App';
 
 type Props = {
   className?: string;
@@ -32,7 +32,7 @@ function getInfoList(
   return [
     ['Kind', kind],
     ['Namespace', data?.namespace],
-    ['Namespace', data?.clusterName],
+    ['ClusterName', data?.clusterName],
     [
       'Source',
       <SourceLink sourceRef={data.sourceRef} clusterName={clusterName} />,


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Closes #3065 

Fixes typo in Image Automation info lists where the namespace key was repeated where it should instead be cluster name