### PR TITLE
verified that explorer query support authz based on clusterrole + rolebinding

### DIFF
--- a/pkg/query/access_test.go
+++ b/pkg/query/access_test.go
@@ -392,7 +392,6 @@ func TestRunQuery_AccessRules(t *testing.T) {
 				},
 			},
 		},
-
 		{
 			name: "rule with resource name",
 			user: auth.NewUserPrincipal(auth.ID("some-user"), auth.Groups([]string{"group-a"})),
@@ -441,6 +440,66 @@ func TestRunQuery_AccessRules(t *testing.T) {
 				}},
 				RoleRefName: "role-a",
 				RoleRefKind: "Role",
+			}},
+			expected: []models.Object{
+				{
+					Cluster:    "cluster-a",
+					Namespace:  "ns-a",
+					APIGroup:   helmv2.GroupVersion.Group,
+					APIVersion: helmv2.GroupVersion.Version,
+					Kind:       helmv2.HelmReleaseKind,
+					Name:       "somename",
+					Category:   models.CategoryAutomation,
+				},
+			},
+		},
+		{
+			name: "should support clusterrole + rolebinding",
+			user: auth.NewUserPrincipal(auth.ID("some-user"), auth.Groups([]string{"group-a"})),
+			objects: []models.Object{
+				{
+					Cluster:    "cluster-a",
+					Namespace:  "ns-a",
+					APIGroup:   helmv2.GroupVersion.Group,
+					APIVersion: helmv2.GroupVersion.Version,
+					Kind:       helmv2.HelmReleaseKind,
+					Name:       "somename",
+					Category:   models.CategoryAutomation,
+				},
+				{
+					Cluster:    "cluster-a",
+					Namespace:  "ns-b",
+					APIGroup:   helmv2.GroupVersion.Group,
+					APIVersion: helmv2.GroupVersion.Version,
+					Kind:       helmv2.HelmReleaseKind,
+					Name:       "othername",
+					Category:   models.CategoryAutomation,
+				},
+			},
+			roles: []models.Role{
+				{
+					Name:      "clusterrole-a",
+					Cluster:   "cluster-a",
+					Namespace: "",
+					Kind:      "ClusterRole",
+					PolicyRules: []models.PolicyRule{{
+						APIGroups: strings.Join([]string{helmv2.GroupVersion.Group}, ","),
+						Resources: strings.Join([]string{"helmreleases"}, ","),
+						Verbs:     strings.Join([]string{"get", "list", "watch"}, ","),
+					}},
+				},
+			},
+			bindings: []models.RoleBinding{{
+				Cluster:   "cluster-a",
+				Name:      "binding-a",
+				Namespace: "ns-a",
+				Kind:      "RoleBinding",
+				Subjects: []models.Subject{{
+					Kind: "Group",
+					Name: "group-a",
+				}},
+				RoleRefName: "clusterrole-a",
+				RoleRefKind: "ClusterRole",
 			}},
 			expected: []models.Object{
 				{


### PR DESCRIPTION


<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Closes https://github.com/weaveworks/weave-gitops-enterprise/issues/2736

<!--
Describe what has changed in this PR.
For UI changes also include a screenshot.
-->
**What changed?**

Added a unit test to extend authz use cases to clusterrolebinding + rolebinding to verify that we support it. It also serves as regression. 


<!-- Tell your future self why have you made these changes. You could link to stories or initiative here. -->
**Why was this change made?**

This ticket was originally raised when we didn't leveraged kube rbac libraries so there were few cases not supported. clusterrolebinding + rolebinding case was one of them. Once we moved to kube RBAC library we guessed that we supported but not verified. 

This PR verifies + sets regression on it.

<!--
Explain to your reviewers the key implementation points, including why you made
certain choices in favour of others. Highlight key areas of the code which need
extra attention, and also indicate which parts are less relevant (eg renaming,
refactoring, etc
-->
**How was this change implemented?**
Added unit test with an example of the scenario to test

<!-- Use the checklist to detail how you're sure that the change
works.  Check each box when you're satisfied you've dealt with that
item. -->
**How did you validate the change?**

 - [x] Explain how a reviewer can verify the change themselves
Run the added test case

 - [x] Integration tests -- what is covered, what cannot be covered;
       or, explain why there are no new tests

Not required as there are no integrations included here.

 - [x] Unit tests -- what is covered, what cannot be covered; are
       there tests that fail _without_ the change?
covered the expected clusterrole + rolebinding case.  it hardens our regression posture.

<!--
Is it notable for release? e.g. schema updates, configuration or data migration
required? If so, please mention it.
-->
**Release notes**

Not required

<!--
Are there any documentation updates that should be made for these changes? We want to keep these sources up to date:
- user-guide: https://docs.gitops.weave.works
- internal docs: https://github.com/weaveworks/weave-gitops-enterprise/tree/main/docs
- architecture docs: https://github.com/weaveworks/weave-gitops-enterprise/blob/main/docs/architecture
-->
**Documentation Changes**
Not required

<!-- Is there anything else that will need to be done after this is
approved or merged? Ideally, log an issue for each follow-up task and
list them here -->
**Other follow ups**

No