### PR TITLE
Add filter to only send smoke test failures when deploy is run on main

### DIFF
--- a/test/acceptance/test/pages/add_application_page.go
+++ b/test/acceptance/test/pages/add_application_page.go
@@ -61,7 +61,7 @@ func GetAddApplication(webDriver *agouti.Page, appNo ...int) *AddApplication {
 		Cluster:               app.Find(`[id="SELECT CLUSTER-input"]`),
 		RemoveApplication:     app.Find(`button#remove-application`),
 		CreateTargetNamespace: app.First(`input[type="checkbox"]`),
-		SourceHref:            app.FindByXPath(`div[contains(@class, "MuiGrid-container")]`),
+		SourceHref:            app.FindByXPath(`div[contains(@class, "MuiGrid-container")]/div[2]`),
 		GitRepository:         app.Find(`[id="SELECT_GIT_REPO-input"]`),
 	}
 }


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Part of #3064

Run https://github.com/weaveworks/weave-gitops-enterprise/actions/runs/5591591078 failed but Slack notification didn't go through as it didn't run on main 

Will need to keep an eye on it once merged to ensure the notifications are still going through as expected on main
