### PR TITLE
Wge 3144 - create sops secrets uses v1 kustomizations api

### DIFF
--- a/cmd/clusters-service/pkg/server/common_test.go
+++ b/cmd/clusters-service/pkg/server/common_test.go
@@ -43,7 +43,7 @@ import (
 	"github.com/weaveworks/weave-gitops-enterprise/pkg/helm/helmfakes"
 
 	esv1beta1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1beta1"
-	kustomizev1beta2 "github.com/fluxcd/kustomize-controller/api/v1beta2"
+	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1"
 	gitopsv1alpha1 "github.com/weaveworks/cluster-controller/api/v1alpha1"
 	rbacv1 "k8s.io/api/rbac/v1"
 )
@@ -61,7 +61,7 @@ func newTestScheme(t *testing.T) *runtime.Scheme {
 		clusterv1.AddToScheme,
 		rbacv1.AddToScheme,
 		esv1beta1.AddToScheme,
-		kustomizev1beta2.AddToScheme,
+		kustomizev1.AddToScheme,
 	}
 	err := schemeBuilder.AddToScheme(scheme)
 	if err != nil {

--- a/cmd/clusters-service/pkg/server/sops.go
+++ b/cmd/clusters-service/pkg/server/sops.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 
 	gopgp "github.com/ProtonMail/gopenpgp/v2/crypto"
-	kustomizev1beta2 "github.com/fluxcd/kustomize-controller/api/v1beta2"
+	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1"
 	capiv1_proto "github.com/weaveworks/weave-gitops-enterprise/cmd/clusters-service/pkg/protos"
 	"github.com/weaveworks/weave-gitops/pkg/server/auth"
 	"go.mozilla.org/sops/v3"
@@ -125,7 +125,7 @@ func (s *server) EncryptSopsSecret(ctx context.Context, msg *capiv1_proto.Encryp
 		return nil, fmt.Errorf("error getting impersonating client: %w", err)
 	}
 
-	var kustomization kustomizev1beta2.Kustomization
+	var kustomization kustomizev1.Kustomization
 	kustomizationKey := client.ObjectKey{
 		Name:      msg.KustomizationName,
 		Namespace: msg.KustomizationNamespace,
@@ -257,7 +257,7 @@ func (s *server) ListSopsKustomizations(ctx context.Context, req *capiv1_proto.L
 	}
 
 	kustomizations := []*capiv1_proto.SopsKustomizations{}
-	kustomizationList := &kustomizev1beta2.KustomizationList{}
+	kustomizationList := &kustomizev1.KustomizationList{}
 
 	if err := clustersClient.List(ctx, req.ClusterName, kustomizationList); err != nil {
 		if strings.Contains(err.Error(), "no matches for kind") {

--- a/cmd/clusters-service/pkg/server/sops_test.go
+++ b/cmd/clusters-service/pkg/server/sops_test.go
@@ -11,7 +11,7 @@ import (
 	goage "filippo.io/age"
 
 	"github.com/ProtonMail/gopenpgp/v2/crypto"
-	kustomizev1beta2 "github.com/fluxcd/kustomize-controller/api/v1beta2"
+	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1"
 	"github.com/fluxcd/pkg/apis/meta"
 	"github.com/stretchr/testify/assert"
 	capiv1_proto "github.com/weaveworks/weave-gitops-enterprise/cmd/clusters-service/pkg/protos"
@@ -109,9 +109,9 @@ func TestEncryptSecret(t *testing.T) {
 						"gpg.asc": []byte(gpgPublicKey),
 					},
 				},
-				&kustomizev1beta2.Kustomization{
+				&kustomizev1.Kustomization{
 					TypeMeta: metav1.TypeMeta{
-						Kind:       kustomizev1beta2.KustomizationKind,
+						Kind:       kustomizev1.KustomizationKind,
 						APIVersion: v1.SchemeGroupVersion.Identifier(),
 					},
 					ObjectMeta: metav1.ObjectMeta{
@@ -122,9 +122,9 @@ func TestEncryptSecret(t *testing.T) {
 							SopsPublicKeyNamespaceAnnotation: "flux-system",
 						},
 					},
-					Spec: kustomizev1beta2.KustomizationSpec{
+					Spec: kustomizev1.KustomizationSpec{
 						Path: "./secrets/age",
-						Decryption: &kustomizev1beta2.Decryption{
+						Decryption: &kustomizev1.Decryption{
 							Provider: "sops",
 							SecretRef: &meta.LocalObjectReference{
 								Name: "sops-age",
@@ -132,9 +132,9 @@ func TestEncryptSecret(t *testing.T) {
 						},
 					},
 				},
-				&kustomizev1beta2.Kustomization{
+				&kustomizev1.Kustomization{
 					TypeMeta: metav1.TypeMeta{
-						Kind:       kustomizev1beta2.KustomizationKind,
+						Kind:       kustomizev1.KustomizationKind,
 						APIVersion: v1.SchemeGroupVersion.Identifier(),
 					},
 					ObjectMeta: metav1.ObjectMeta{
@@ -145,9 +145,9 @@ func TestEncryptSecret(t *testing.T) {
 							SopsPublicKeyNamespaceAnnotation: "flux-system",
 						},
 					},
-					Spec: kustomizev1beta2.KustomizationSpec{
+					Spec: kustomizev1.KustomizationSpec{
 						Path: "./secrets/gpg",
-						Decryption: &kustomizev1beta2.Decryption{
+						Decryption: &kustomizev1.Decryption{
 							Provider: "sops",
 							SecretRef: &meta.LocalObjectReference{
 								Name: "sops-gpg",
@@ -377,7 +377,7 @@ func TestListKustomizations(t *testing.T) {
 						Name: "namespace-a-2",
 					},
 				},
-				&kustomizev1beta2.Kustomization{
+				&kustomizev1.Kustomization{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "kustomization-a-1",
 						Namespace: "namespace-a-1",
@@ -386,13 +386,13 @@ func TestListKustomizations(t *testing.T) {
 							"sops-public-key/namespace": "flux-system",
 						},
 					},
-					Spec: kustomizev1beta2.KustomizationSpec{
-						Decryption: &kustomizev1beta2.Decryption{
+					Spec: kustomizev1.KustomizationSpec{
+						Decryption: &kustomizev1.Decryption{
 							Provider: "sops",
 						},
 					},
 				},
-				&kustomizev1beta2.Kustomization{
+				&kustomizev1.Kustomization{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "kustomization-a-2",
 						Namespace: "namespace-a-2",
@@ -401,36 +401,36 @@ func TestListKustomizations(t *testing.T) {
 							"sops-public-key/namespace": "flux-system",
 						},
 					},
-					Spec: kustomizev1beta2.KustomizationSpec{
-						Decryption: &kustomizev1beta2.Decryption{
+					Spec: kustomizev1.KustomizationSpec{
+						Decryption: &kustomizev1.Decryption{
 							Provider: "sops",
 						},
 					},
 				},
-				&kustomizev1beta2.Kustomization{
+				&kustomizev1.Kustomization{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "kustomization-a-3",
 						Namespace: "namespace-a-1",
 					},
-					Spec: kustomizev1beta2.KustomizationSpec{
-						Decryption: &kustomizev1beta2.Decryption{
+					Spec: kustomizev1.KustomizationSpec{
+						Decryption: &kustomizev1.Decryption{
 							Provider: "decryption-provider-a-2",
 						},
 					},
 				},
-				&kustomizev1beta2.Kustomization{
+				&kustomizev1.Kustomization{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "kustomization-a-4",
 						Namespace: "namespace-a-2",
 					},
 				},
-				&kustomizev1beta2.Kustomization{
+				&kustomizev1.Kustomization{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "kustomization-a-5",
 						Namespace: "namespace-a-1",
 					},
-					Spec: kustomizev1beta2.KustomizationSpec{
-						Decryption: &kustomizev1beta2.Decryption{
+					Spec: kustomizev1.KustomizationSpec{
+						Decryption: &kustomizev1.Decryption{
 							Provider: "sops",
 						},
 					},
@@ -450,7 +450,7 @@ func TestListKustomizations(t *testing.T) {
 						Name: "namespace-a-2",
 					},
 				},
-				&kustomizev1beta2.Kustomization{
+				&kustomizev1.Kustomization{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "kustomization-b-1",
 						Namespace: "namespace-b-1",
@@ -459,13 +459,13 @@ func TestListKustomizations(t *testing.T) {
 							"sops-public-key/namespace": "flux-system",
 						},
 					},
-					Spec: kustomizev1beta2.KustomizationSpec{
-						Decryption: &kustomizev1beta2.Decryption{
+					Spec: kustomizev1.KustomizationSpec{
+						Decryption: &kustomizev1.Decryption{
 							Provider: "sops",
 						},
 					},
 				},
-				&kustomizev1beta2.Kustomization{
+				&kustomizev1.Kustomization{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "kustomization-b-2",
 						Namespace: "namespace-a-2",


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Closes https://github.com/weaveworks/weave-gitops-enterprise/issues/3144

<!--
Describe what has changed in this PR.
For UI changes also include a screenshot.
-->
**What changed?**

Uses kustomizations api v1 instead of beta

<!-- Tell your future self why have you made these changes. You could link to stories or initiative here. -->
**Why was this change made?**

To restore the feature when using it in environments with flux v2


<!--
Explain to your reviewers the key implementation points, including why you made
certain choices in favour of others. Highlight key areas of the code which need
extra attention, and also indicate which parts are less relevant (eg renaming,
refactoring, etc
-->
**How was this change implemented?**

Changed api library to use v1 

<!-- Use the checklist to detail how you're sure that the change
works.  Check each box when you're satisfied you've dealt with that
item. -->
**How did you validate the change?**

 - [x] Explain how a reviewer can verify the change themselves

1. Run wge locally and 
2. create a sops secret  http://localhost:8000/secrets/sops/create 
3. select management cluster. At this point the client tries to list kustomizations that should not throw an error as shown below

<img width="1595" alt="Screenshot 2023-07-31 at 09 16 56" src="https://github.com/weaveworks/weave-gitops-enterprise/assets/12957664/1082058a-09ec-46d6-908e-97a5e9163e5c">

 - [x] Integration tests -- what is covered, what cannot be covered;
       or, explain why there are no new tests

 Not added as there are no new integration points 

 - [x] Unit tests -- what is covered, what cannot be covered; are
       there tests that fail _without_ the change?

Adjusted to be using v1 apis

<!--
Is it notable for release? e.g. schema updates, configuration or data migration
required? If so, please mention it.
-->
**Release notes**


<!--
Are there any documentation updates that should be made for these changes? We want to keep these sources up to date:
- user-guide: https://docs.gitops.weave.works
- internal docs: https://github.com/weaveworks/weave-gitops-enterprise/tree/main/docs
- architecture docs: https://github.com/weaveworks/weave-gitops-enterprise/blob/main/docs/architecture
-->
**Documentation Changes**


<!-- Is there anything else that will need to be done after this is
approved or merged? Ideally, log an issue for each follow-up task and
list them here -->
**Other follow ups**
