### PR TITLE
Update ClusterResourceSet to v1beta1

### DIFF
--- a/test/utils/data/bootstrap/calico-crs.yaml
+++ b/test/utils/data/bootstrap/calico-crs.yaml
@@ -1,4 +1,4 @@
-apiVersion: addons.cluster.x-k8s.io/v1alpha3
+apiVersion: addons.cluster.x-k8s.io/v1beta1
 kind: ClusterResourceSet
 metadata:
   name: "{{.Name}}"
@@ -8,6 +8,5 @@ spec:
     matchLabels:
       cni: calico
   resources:
-  - kind: ConfigMap
-    name: "{{.Name}}-calico-crs-configmap"
-
+    - kind: ConfigMap
+      name: "{{.Name}}-calico-crs-configmap"


### PR DESCRIPTION
- clusterctl 1.5.0 has been released and drops support for ClusterResourceSet/v1alpha3
- Doesn't seem to be any changes in the api between the version in the ClusterResourceSet itself
  - https://doc.crds.dev/github.com/kubernetes-sigs/cluster-api/addons.cluster.x-k8s.io/ClusterResourceSet/v1beta1@v1.4.4
  - https://doc.crds.dev/github.com/kubernetes-sigs/cluster-api/addons.cluster.x-k8s.io/ClusterResourceSet/v1alpha3@v0.3.19

