### PR TITLE
Bump gitopssets-controller to v0.14.1

### DIFF
--- a/charts/mccp/Chart.yaml
+++ b/charts/mccp/Chart.yaml
@@ -37,6 +37,6 @@ dependencies:
     repository: "oci://ghcr.io/weaveworks/charts"
     condition: enablePipelines
   - name: gitopssets-controller
-    version: "0.14.0"
+    version: "0.14.1"
     repository: "oci://ghcr.io/weaveworks/charts"
     condition: gitopssets-controller.enabled

--- a/go.mod
+++ b/go.mod
@@ -117,7 +117,7 @@ require (
 	github.com/google/s2a-go v0.1.0 // indirect
 	github.com/klauspost/cpuid/v2 v2.0.4 // indirect
 	github.com/mschoch/smat v0.2.0 // indirect
-	github.com/weaveworks/gitopssets-controller v0.14.0
+	github.com/weaveworks/gitopssets-controller v0.14.1
 	go.etcd.io/bbolt v1.3.7 // indirect
 	go.opentelemetry.io/otel/metric v0.37.0 // indirect
 	google.golang.org/api v0.117.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1280,8 +1280,8 @@ github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqri
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/weaveworks/cluster-controller v1.5.2 h1:HEgiovJSvrLsdU7Y4mswfCzq8ca2hzpnygBVIzbQQW8=
 github.com/weaveworks/cluster-controller v1.5.2/go.mod h1:rYBv/mUMvXOP6NdSSUvvpT6ptpOPE9cqSl7WMM4LkcY=
-github.com/weaveworks/gitopssets-controller v0.14.0 h1:E9iWMN53uU4zupNJPRC8agjCXXtE7A4BnrKRUHQEuyQ=
-github.com/weaveworks/gitopssets-controller v0.14.0/go.mod h1:Cs4hqXZP8RWGoh8Ub12cowQRAB4VzwRpcEZ13l2lC5o=
+github.com/weaveworks/gitopssets-controller v0.14.1 h1:KUwYz61ETJVzZFA6lDLadahOOLskG/BRtWwmt7rj0Ec=
+github.com/weaveworks/gitopssets-controller v0.14.1/go.mod h1:Cs4hqXZP8RWGoh8Ub12cowQRAB4VzwRpcEZ13l2lC5o=
 github.com/weaveworks/pipeline-controller/api v0.0.0-20230228164807-3af8aa2ecc3d h1:HhH19ygpcDDadUMNIc8PtSCqpQ49gpY7je7P/Ow4ZAc=
 github.com/weaveworks/pipeline-controller/api v0.0.0-20230228164807-3af8aa2ecc3d/go.mod h1:EMw4dkvNuR0GBKVbDFjZMUIma1sZhyS6heAZXM59s0Y=
 github.com/weaveworks/policy-agent/api v1.0.5 h1:4pqzzta8xPUsE9h9YhGJVg5XQ2NuAU/CDoU7zdCw5A0=


### PR DESCRIPTION
This is a trivial change that bumps the gitopssets-controller to the latest version.