### PR TITLE
Remove titles from detail pages for consistency

### DIFF
--- a/ui-cra/src/components/ProgressiveDelivery/CanaryDetails/CanaryDetailsSection.tsx
+++ b/ui-cra/src/components/ProgressiveDelivery/CanaryDetails/CanaryDetailsSection.tsx
@@ -19,9 +19,6 @@ import DetailsSection from './Details/DetailsSection';
 import ListEvents from './Events/ListEvents';
 import ListManagedObjects from './ManagedObjects/ListManagedObjects';
 
-const TitleWrapper = styled.h2`
-  margin: 0px;
-`;
 const CanaryDetailsWrapper = styled.div`
   width: 100%;
 `;
@@ -36,7 +33,6 @@ function CanaryDetailsSection({
   const path = Routes.CanaryDetails;
   return (
     <Flex column gap="16">
-      <TitleWrapper>{canary.name}</TitleWrapper>
       <Flex gap="8" align start>
         <CanaryStatus
           status={canary.status?.phase || '--'}


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Closes [#3890](https://github.com/weaveworks/weave-gitops/issues/3890)

Only title that seemed appropriate to remove for this case was in Canary detail:
before:
<img width="2044" alt="image" src="https://github.com/weaveworks/weave-gitops-enterprise/assets/65822698/992fc833-4879-4638-87e0-c0be0c023b88">
after:
<img width="2043" alt="image" src="https://github.com/weaveworks/weave-gitops-enterprise/assets/65822698/7cdbad94-16a8-4e73-b92b-9cb9e4c4db3e">
