### PR TITLE
Add debug/pprof http endpoint

### DIFF
--- a/cmd/clusters-service/app/server.go
+++ b/cmd/clusters-service/app/server.go
@@ -94,6 +94,8 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
+
+	"net/http/pprof"
 )
 
 const (
@@ -820,6 +822,10 @@ func RunInProcessGateway(ctx context.Context, addr string, setters ...Option) er
 	}
 
 	mux.Handle("/v1/", commonMiddleware(grpcHttpHandler))
+
+	if os.Getenv("WEAVE_GITOPS_ENABLE_PROFILING") == "true" {
+		mux.Handle("/debug/pprof/", http.HandlerFunc(pprof.Index))
+	}
 
 	staticAssetsWithGz := gziphandler.GzipHandler(staticAssets)
 

--- a/tools/dev-values.yaml
+++ b/tools/dev-values.yaml
@@ -31,6 +31,8 @@ extraEnvVars:
     value: "bitbucket.yiannis.net"
   - name: DEV_MODE
     value: "true"
+  - name: WEAVE_GITOPS_ENABLE_PROFILING
+    value: "true"
 
 extraEnvVarsSecret: ""
 

--- a/ui-cra/src/setupProxy.js
+++ b/ui-cra/src/setupProxy.js
@@ -12,5 +12,6 @@ module.exports = function (app) {
     secure,
   });
   app.use('/v1', proxyMiddleWare);
+  app.use('/debug', proxyMiddleWare);
   app.use('/oauth2', proxyMiddleWare);
 };


### PR DESCRIPTION
Part of #3189 

Adds a way to see heap stats via the `pprof` package. To interact with the `pprof` endpoint, use this command

```sh
$ go tool pprof http://localhost:8000/debug/pprof/heap
```
Substitute the `localhost` host with a remote one if necessary.

Heap profile looks like this:

![profile001](https://github.com/weaveworks/weave-gitops-enterprise/assets/2802257/0c972087-2430-4bad-8083-de41fb5386d3)

It will need to be tracked over time to understand which parts of the app are growing in memory.
