### PR TITLE
Bump gitopssets to v0.15.1

### DIFF
--- a/charts/mccp/Chart.yaml
+++ b/charts/mccp/Chart.yaml
@@ -37,6 +37,6 @@ dependencies:
     repository: "oci://ghcr.io/weaveworks/charts"
     condition: enablePipelines
   - name: gitopssets-controller
-    version: "0.14.1"
+    version: "0.15.1"
     repository: "oci://ghcr.io/weaveworks/charts"
     condition: gitopssets-controller.enabled

--- a/go.mod
+++ b/go.mod
@@ -66,7 +66,7 @@ require (
 	github.com/spf13/viper v1.15.0
 	github.com/tonglil/buflogr v1.0.1
 	github.com/weaveworks/cluster-controller v1.5.2
-	github.com/weaveworks/gitopssets-controller v0.14.1
+	github.com/weaveworks/gitopssets-controller v0.15.1
 	github.com/weaveworks/policy-agent/api v1.0.5
 	github.com/weaveworks/progressive-delivery v0.0.0-20230421131659-61a8aadf8aac
 	github.com/weaveworks/templates-controller v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -1261,8 +1261,8 @@ github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqri
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/weaveworks/cluster-controller v1.5.2 h1:HEgiovJSvrLsdU7Y4mswfCzq8ca2hzpnygBVIzbQQW8=
 github.com/weaveworks/cluster-controller v1.5.2/go.mod h1:rYBv/mUMvXOP6NdSSUvvpT6ptpOPE9cqSl7WMM4LkcY=
-github.com/weaveworks/gitopssets-controller v0.14.1 h1:KUwYz61ETJVzZFA6lDLadahOOLskG/BRtWwmt7rj0Ec=
-github.com/weaveworks/gitopssets-controller v0.14.1/go.mod h1:Cs4hqXZP8RWGoh8Ub12cowQRAB4VzwRpcEZ13l2lC5o=
+github.com/weaveworks/gitopssets-controller v0.15.1 h1:X5MyUY1Eyx4xTez6XmyejWYaOuvS0uOhvodMZxvCBKE=
+github.com/weaveworks/gitopssets-controller v0.15.1/go.mod h1:Cs4hqXZP8RWGoh8Ub12cowQRAB4VzwRpcEZ13l2lC5o=
 github.com/weaveworks/pipeline-controller/api v0.0.0-20230228164807-3af8aa2ecc3d h1:HhH19ygpcDDadUMNIc8PtSCqpQ49gpY7je7P/Ow4ZAc=
 github.com/weaveworks/pipeline-controller/api v0.0.0-20230228164807-3af8aa2ecc3d/go.mod h1:EMw4dkvNuR0GBKVbDFjZMUIma1sZhyS6heAZXM59s0Y=
 github.com/weaveworks/policy-agent/api v1.0.5 h1:4pqzzta8xPUsE9h9YhGJVg5XQ2NuAU/CDoU7zdCw5A0=


### PR DESCRIPTION
This is pulling in v0.15.1 https://github.com/weaveworks/gitopssets-controller/releases/tag/v0.15.1

This includes a fix for removal of resources caused by an empty GitRepository/OCIRepository in directory querying mode.