### PR TITLE
Bump gitopssets to 0.15.3

### DIFF
--- a/charts/mccp/Chart.lock
+++ b/charts/mccp/Chart.lock
@@ -13,6 +13,6 @@ dependencies:
   version: 0.21.0
 - name: gitopssets-controller
   repository: oci://ghcr.io/weaveworks/charts
-  version: 0.14.1
-digest: sha256:27971cca153e0e0ffdbb225de7f4f25f2a7628263dbf6ed99b865e39f822265f
-generated: "2023-08-07T14:43:35.032636+01:00"
+  version: 0.15.3
+digest: sha256:acf1cc8c615d7006a445d2d558d7ac58f0aabdf523736718fdf458e5e9a4c249
+generated: "2023-08-17T16:13:52.611648+02:00"

--- a/charts/mccp/Chart.yaml
+++ b/charts/mccp/Chart.yaml
@@ -37,6 +37,6 @@ dependencies:
     repository: "oci://ghcr.io/weaveworks/charts"
     condition: enablePipelines
   - name: gitopssets-controller
-    version: "0.15.1"
+    version: "0.15.3"
     repository: "oci://ghcr.io/weaveworks/charts"
     condition: gitopssets-controller.enabled

--- a/go.mod
+++ b/go.mod
@@ -66,7 +66,7 @@ require (
 	github.com/spf13/viper v1.15.0
 	github.com/tonglil/buflogr v1.0.1
 	github.com/weaveworks/cluster-controller v1.5.2
-	github.com/weaveworks/gitopssets-controller v0.15.1
+	github.com/weaveworks/gitopssets-controller v0.15.3
 	github.com/weaveworks/policy-agent/api v1.0.5
 	github.com/weaveworks/progressive-delivery v0.0.0-20230421131659-61a8aadf8aac
 	github.com/weaveworks/templates-controller v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -1261,8 +1261,8 @@ github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqri
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/weaveworks/cluster-controller v1.5.2 h1:HEgiovJSvrLsdU7Y4mswfCzq8ca2hzpnygBVIzbQQW8=
 github.com/weaveworks/cluster-controller v1.5.2/go.mod h1:rYBv/mUMvXOP6NdSSUvvpT6ptpOPE9cqSl7WMM4LkcY=
-github.com/weaveworks/gitopssets-controller v0.15.1 h1:X5MyUY1Eyx4xTez6XmyejWYaOuvS0uOhvodMZxvCBKE=
-github.com/weaveworks/gitopssets-controller v0.15.1/go.mod h1:Cs4hqXZP8RWGoh8Ub12cowQRAB4VzwRpcEZ13l2lC5o=
+github.com/weaveworks/gitopssets-controller v0.15.3 h1:VJu2u8XEDcnJuYgWVGB2D8EG0Vu7SOarWlkhL6if+Zk=
+github.com/weaveworks/gitopssets-controller v0.15.3/go.mod h1:Cs4hqXZP8RWGoh8Ub12cowQRAB4VzwRpcEZ13l2lC5o=
 github.com/weaveworks/pipeline-controller/api v0.0.0-20230228164807-3af8aa2ecc3d h1:HhH19ygpcDDadUMNIc8PtSCqpQ49gpY7je7P/Ow4ZAc=
 github.com/weaveworks/pipeline-controller/api v0.0.0-20230228164807-3af8aa2ecc3d/go.mod h1:EMw4dkvNuR0GBKVbDFjZMUIma1sZhyS6heAZXM59s0Y=
 github.com/weaveworks/policy-agent/api v1.0.5 h1:4pqzzta8xPUsE9h9YhGJVg5XQ2NuAU/CDoU7zdCw5A0=


### PR DESCRIPTION
- Last bump https://github.com/weaveworks/weave-gitops-enterprise/pull/3224
- https://github.com/weaveworks/gitopssets-controller/releases/tag/v0.15.3
- https://github.com/weaveworks/gitopssets-controller/compare/v0.15.1...v0.15.3