### PR TITLE
Adds Last Updated and Namespace information to Terraform object details UI

### DIFF
--- a/pkg/terraform/internal/convert/convert.go
+++ b/pkg/terraform/internal/convert/convert.go
@@ -64,6 +64,7 @@ func ToPBTerraformObject(clusterName string, tf *tfctrl.Terraform) pb.TerraformO
 		AppliedRevision:      tf.Status.LastAppliedRevision,
 		Path:                 tf.Spec.Path,
 		Interval:             durationToInterval(tf.Spec.Interval),
+		LastUpdatedAt:        tf.Status.GetLastHandledReconcileRequest(),
 		DriftDetectionResult: tf.HasDrift(),
 		Inventory:            inv,
 		Conditions:           conditions,

--- a/ui/src/components/Terraform/TerraformObjectDetail.tsx
+++ b/ui/src/components/Terraform/TerraformObjectDetail.tsx
@@ -222,6 +222,7 @@ function TerraformObjectDetail({ className, ...params }: Props) {
                 <InfoList
                   data-testid="info-list"
                   items={[
+                    ['Namespace', object?.namespace],
                     ['Source', object?.sourceRef?.name],
                     ['Cluster', object?.clusterName],
                     ['Path', object?.path],


### PR DESCRIPTION
In testing Terraform sync we found that the information for the Last Updated field was missing in the backend object conversion file, and that somehow the namespace field got lost along the way in the UI. 

FIXED.

<img width="2023" alt="image" src="https://github.com/weaveworks/weave-gitops-enterprise/assets/65822698/6545864c-bcb8-46e0-8490-52f2d803f9e6">

