### PR TITLE
Bump to gitopssets 0.16.2.

### DIFF
--- a/charts/mccp/Chart.lock
+++ b/charts/mccp/Chart.lock
@@ -13,6 +13,6 @@ dependencies:
   version: 0.21.0
 - name: gitopssets-controller
   repository: oci://ghcr.io/weaveworks/charts
-  version: 0.16.1
-digest: sha256:704d62bdfa86581e931aaad4efed54bab78860a5759311d4e7b501c09f9aa31e
-generated: "2023-09-06T14:12:46.260305+01:00"
+  version: 0.16.2
+digest: sha256:8c2af9a594b3c177adb90e340f9a72b9f1a1964094422ebb63983253197cc225
+generated: "2023-09-13T14:07:28.551285+01:00"

--- a/charts/mccp/Chart.yaml
+++ b/charts/mccp/Chart.yaml
@@ -37,6 +37,6 @@ dependencies:
     repository: "oci://ghcr.io/weaveworks/charts"
     condition: enablePipelines
   - name: gitopssets-controller
-    version: "0.16.1"
+    version: "0.16.2"
     repository: "oci://ghcr.io/weaveworks/charts"
     condition: gitopssets-controller.enabled

--- a/go.mod
+++ b/go.mod
@@ -67,7 +67,7 @@ require (
 	github.com/spf13/viper v1.15.0
 	github.com/tonglil/buflogr v1.0.1
 	github.com/weaveworks/cluster-controller v1.5.2
-	github.com/weaveworks/gitopssets-controller v0.15.3
+	github.com/weaveworks/gitopssets-controller v0.16.2
 	github.com/weaveworks/policy-agent/api v1.0.5
 	github.com/weaveworks/progressive-delivery v0.0.0-20230421131659-61a8aadf8aac
 	github.com/weaveworks/templates-controller v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -1263,8 +1263,8 @@ github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqri
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/weaveworks/cluster-controller v1.5.2 h1:HEgiovJSvrLsdU7Y4mswfCzq8ca2hzpnygBVIzbQQW8=
 github.com/weaveworks/cluster-controller v1.5.2/go.mod h1:rYBv/mUMvXOP6NdSSUvvpT6ptpOPE9cqSl7WMM4LkcY=
-github.com/weaveworks/gitopssets-controller v0.15.3 h1:VJu2u8XEDcnJuYgWVGB2D8EG0Vu7SOarWlkhL6if+Zk=
-github.com/weaveworks/gitopssets-controller v0.15.3/go.mod h1:Cs4hqXZP8RWGoh8Ub12cowQRAB4VzwRpcEZ13l2lC5o=
+github.com/weaveworks/gitopssets-controller v0.16.2 h1:Obp77F0y66yrmQnA88Gp5TA4ZpxLLgSxH98u1IaC9Hk=
+github.com/weaveworks/gitopssets-controller v0.16.2/go.mod h1:EvfQKCDlQpLkXb047qMDO3ILNppk1Bs8dC1xoOwwpQY=
 github.com/weaveworks/pipeline-controller/api v0.0.0-20230228164807-3af8aa2ecc3d h1:HhH19ygpcDDadUMNIc8PtSCqpQ49gpY7je7P/Ow4ZAc=
 github.com/weaveworks/pipeline-controller/api v0.0.0-20230228164807-3af8aa2ecc3d/go.mod h1:EMw4dkvNuR0GBKVbDFjZMUIma1sZhyS6heAZXM59s0Y=
 github.com/weaveworks/policy-agent/api v1.0.5 h1:4pqzzta8xPUsE9h9YhGJVg5XQ2NuAU/CDoU7zdCw5A0=


### PR DESCRIPTION
This bumps gitopssets to 0.16.2 with support for `toYaml` in the template rendering.