### PR TITLE
Adding paging method to query service store iterator

### DIFF
--- a/pkg/query/internal/sqliterator/sqliterator.go
+++ b/pkg/query/internal/sqliterator/sqliterator.go
@@ -65,6 +65,38 @@ func (i *iterator) All() ([]models.Object, error) {
 	return objects, nil
 }
 
+func (i *iterator) Page(count int, offset int) ([]models.Object, error) {
+	var objects []models.Object
+
+	index := -1
+
+	for i.rows.Next() {
+		index++
+
+		if index < offset {
+			continue
+		}
+
+		var object models.Object
+
+		if err := i.result.ScanRows(i.rows, &object); err != nil {
+			return nil, fmt.Errorf("failed to scan rows: %w", err)
+		}
+
+		objects = append(objects, object)
+
+		if index >= offset+count-1 {
+			break
+		}
+	}
+
+	if err := i.rows.Err(); err != nil {
+		return nil, fmt.Errorf("failed to get rows: %w", err)
+	}
+
+	return objects, nil
+}
+
 func (i *iterator) Close() error {
 	return i.rows.Close()
 }

--- a/pkg/query/store/store.go
+++ b/pkg/query/store/store.go
@@ -87,6 +87,8 @@ type Iterator interface {
 	Row() (models.Object, error)
 	// All returns all rows of the iterator
 	All() ([]models.Object, error)
+	// Page returns a specified number of rows of the iterator with a specified offset
+	Page(count int, offset int) ([]models.Object, error)
 
 	// Close closes the iterator
 	Close() error

--- a/pkg/query/store/store_test.go
+++ b/pkg/query/store/store_test.go
@@ -40,11 +40,109 @@ func TestGetObjects(t *testing.T) {
 
 	g.Expect(len(objects) > 0).To(BeTrue())
 	g.Expect(objects[0].Name).To(Equal(obj.Name))
+}
 
+func TestGetObjectsWithPagination(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	store, db := createStore(t)
+
+	testObjects := []models.Object{
+		{
+			Cluster:   "test-cluster",
+			Name:      "someName-1",
+			Namespace: "namespace",
+			Kind:      "ValidKind",
+		},
+		{
+			Cluster:   "test-cluster",
+			Name:      "someName-2",
+			Namespace: "namespace",
+			Kind:      "ValidKind",
+		},
+		{
+			Cluster:   "test-cluster",
+			Name:      "someName-3",
+			Namespace: "namespace",
+			Kind:      "ValidKind",
+		},
+		{
+			Cluster:   "test-cluster",
+			Name:      "someName-4",
+			Namespace: "namespace",
+			Kind:      "ValidKind",
+		},
+		{
+			Cluster:   "test-cluster",
+			Name:      "someName-5",
+			Namespace: "namespace",
+			Kind:      "ValidKind",
+		},
+		{
+			Cluster:   "test-cluster",
+			Name:      "someName-6",
+			Namespace: "namespace",
+			Kind:      "ValidKind",
+		},
+		{
+			Cluster:   "test-cluster",
+			Name:      "someName-7",
+			Namespace: "namespace",
+			Kind:      "ValidKind",
+		},
+	}
+
+	g.Expect(SeedObjects(db, testObjects)).To(Succeed())
+
+	iter, err := store.GetObjects(context.Background(), nil, nil)
+	g.Expect(err).To(BeNil())
+
+	objects, err := iter.All()
+	g.Expect(err).To(BeNil())
+	g.Expect(len(objects)).To(Equal(len(testObjects)))
+	g.Expect(objects[0].Name).To(Equal(testObjects[0].Name))
+	g.Expect(objects[3].Name).To(Equal(testObjects[3].Name))
+
+	// With pagination and without an offset.
+	iter, err = store.GetObjects(context.Background(), nil, nil)
+	g.Expect(err).To(BeNil())
+
+	objects, err = iter.Page(3, 0)
+	g.Expect(err).To(BeNil())
+	g.Expect(len(objects)).To(Equal(3))
+	g.Expect(objects[0].Name).To(Equal(testObjects[0].Name))
+
+	objects, err = iter.Page(3, 0)
+	g.Expect(err).To(BeNil())
+	g.Expect(len(objects)).To(Equal(3))
+	g.Expect(objects[0].Name).To(Equal(testObjects[3].Name))
+
+	objects, err = iter.Page(3, 0)
+	g.Expect(err).To(BeNil())
+	g.Expect(len(objects)).To(Equal(1))
+	g.Expect(objects[0].Name).To(Equal(testObjects[6].Name))
+
+	// With pagination and with an initial offset.
+	iter, err = store.GetObjects(context.Background(), nil, nil)
+	g.Expect(err).To(BeNil())
+
+	objects, err = iter.Page(2, 2)
+	g.Expect(err).To(BeNil())
+	g.Expect(len(objects)).To(Equal(2))
+	g.Expect(objects[0].Name).To(Equal(testObjects[2].Name))
+
+	objects, err = iter.Page(2, 0)
+	g.Expect(err).To(BeNil())
+	g.Expect(len(objects)).To(Equal(2))
+	g.Expect(objects[0].Name).To(Equal(testObjects[4].Name))
+
+	objects, err = iter.Page(2, 0)
+	g.Expect(err).To(BeNil())
+	g.Expect(len(objects)).To(Equal(1))
+	g.Expect(objects[0].Name).To(Equal(testObjects[6].Name))
 }
 
 func TestDeleteObjects(t *testing.T) {
-
 	tests := []struct {
 		name     string
 		seed     []models.Object

--- a/pkg/query/store/storefakes/fake_iterator.go
+++ b/pkg/query/store/storefakes/fake_iterator.go
@@ -41,6 +41,20 @@ type FakeIterator struct {
 	nextReturnsOnCall map[int]struct {
 		result1 bool
 	}
+	PageStub        func(int, int) ([]models.Object, error)
+	pageMutex       sync.RWMutex
+	pageArgsForCall []struct {
+		arg1 int
+		arg2 int
+	}
+	pageReturns struct {
+		result1 []models.Object
+		result2 error
+	}
+	pageReturnsOnCall map[int]struct {
+		result1 []models.Object
+		result2 error
+	}
 	RowStub        func() (models.Object, error)
 	rowMutex       sync.RWMutex
 	rowArgsForCall []struct {
@@ -219,6 +233,71 @@ func (fake *FakeIterator) NextReturnsOnCall(i int, result1 bool) {
 	}{result1}
 }
 
+func (fake *FakeIterator) Page(arg1 int, arg2 int) ([]models.Object, error) {
+	fake.pageMutex.Lock()
+	ret, specificReturn := fake.pageReturnsOnCall[len(fake.pageArgsForCall)]
+	fake.pageArgsForCall = append(fake.pageArgsForCall, struct {
+		arg1 int
+		arg2 int
+	}{arg1, arg2})
+	stub := fake.PageStub
+	fakeReturns := fake.pageReturns
+	fake.recordInvocation("Page", []interface{}{arg1, arg2})
+	fake.pageMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeIterator) PageCallCount() int {
+	fake.pageMutex.RLock()
+	defer fake.pageMutex.RUnlock()
+	return len(fake.pageArgsForCall)
+}
+
+func (fake *FakeIterator) PageCalls(stub func(int, int) ([]models.Object, error)) {
+	fake.pageMutex.Lock()
+	defer fake.pageMutex.Unlock()
+	fake.PageStub = stub
+}
+
+func (fake *FakeIterator) PageArgsForCall(i int) (int, int) {
+	fake.pageMutex.RLock()
+	defer fake.pageMutex.RUnlock()
+	argsForCall := fake.pageArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakeIterator) PageReturns(result1 []models.Object, result2 error) {
+	fake.pageMutex.Lock()
+	defer fake.pageMutex.Unlock()
+	fake.PageStub = nil
+	fake.pageReturns = struct {
+		result1 []models.Object
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeIterator) PageReturnsOnCall(i int, result1 []models.Object, result2 error) {
+	fake.pageMutex.Lock()
+	defer fake.pageMutex.Unlock()
+	fake.PageStub = nil
+	if fake.pageReturnsOnCall == nil {
+		fake.pageReturnsOnCall = make(map[int]struct {
+			result1 []models.Object
+			result2 error
+		})
+	}
+	fake.pageReturnsOnCall[i] = struct {
+		result1 []models.Object
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeIterator) Row() (models.Object, error) {
 	fake.rowMutex.Lock()
 	ret, specificReturn := fake.rowReturnsOnCall[len(fake.rowArgsForCall)]
@@ -284,6 +363,8 @@ func (fake *FakeIterator) Invocations() map[string][][]interface{} {
 	defer fake.closeMutex.RUnlock()
 	fake.nextMutex.RLock()
 	defer fake.nextMutex.RUnlock()
+	fake.pageMutex.RLock()
+	defer fake.pageMutex.RUnlock()
 	fake.rowMutex.RLock()
 	defer fake.rowMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}


### PR DESCRIPTION
Closes https://github.com/weaveworks/weave-gitops-enterprise/issues/3044

- Added `Page` methods to iterators.

- Re-ordered iterator methods for consistency.

- Updated iterator fakes.

- Added tests for pagination in iterators.

Notes:

- The order or objects returned by `i.result.Hits` in `indexerIterator`, unlike `sqliterator` is mostly reverse (to the order the objects are seeded) and slightly inconsistent (this part needs to be re-checked, but I saw items for the first page returns in the order of `name-7, name-6, name-5` or `name-7, name-5, name-6`).

- Because of different behavior of `sqliterator` and `indexerIterator`, which implement the same `Iterator` interface, when calling the `Page` method for `sqliterator`, you need only to specify the initial offset, the iterator will advance its index automatically by calling Next. But with `indexerIterator`, you need to specify the offset each time when calling the `Page` method. 

But the above-mentioned issues are of no concern to using `Page` methods during cleanup. If we need different iterator behavior later, we can research it further and rework it in another issue.

Testing:

-  The desired behavior of pagination in `sqliterator` and `indexerIterator` is described in tests. For now, just run
```
go test -v ./pkg/query/store
```
to make sure pagination works as expected.
