### PR TITLE
reverting oss make targets to dont hold the release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -237,3 +237,14 @@ swagger-docs:
 
 FORCE:
 
+
+tools/core-files/Makefile.$(CORE_REVISION):
+	@mkdir -p tools/core-files
+	@curl --silent -o tools/core-files/Makefile.core https://raw.githubusercontent.com/weaveworks/weave-gitops/$(CORE_REVISION)/Makefile
+
+tools/core-files/charts/gitops-server/Chart.yaml: tools/core-files/Makefile.$(CORE_REVISION)
+	@mkdir -p tools/core-files/charts/gitops-server
+	@curl --silent -o tools/core-files/charts/gitops-server/Chart.yaml https://raw.githubusercontent.com/weaveworks/weave-gitops/$(CORE_REVISION)/charts/gitops-server/Chart.yaml
+
+echo-ldflags: tools/core-files/charts/gitops-server/Chart.yaml tools/core-files/Makefile.$(CORE_REVISION)
+	@make --no-print-directory -f Makefile.core -C tools/core-files echo-ldflags VERSION="$(VERSION)-Enterprise-Edition-$(CORE_REVISION)" TIER="$(TIER)"


### PR DESCRIPTION
reverting as per the release fail https://github.com/weaveworks/weave-gitops-enterprise/actions/runs/6188553270/job/16800957146 

we could follow up next week to remove it again without holding the release