### PR TITLE
Fix uncontrolled component error

### DIFF
--- a/ui/src/components/Templates/Form/Partials/ProfileListItem.tsx
+++ b/ui/src/components/Templates/Form/Partials/ProfileListItem.tsx
@@ -27,7 +27,7 @@ const ProfilesListItem: FC<{
   const [version, setVersion] = useState<string>('');
   const [yaml, setYaml] = useState<string>('');
   const [openYamlPreview, setOpenYamlPreview] = useState<boolean>(false);
-  const [namespace, setNamespace] = useState<string>();
+  const [namespace, setNamespace] = useState<string>('');
   const [isNamespaceValid, setNamespaceValidation] = useState<boolean>(true);
 
   const profileVersions = (profile: UpdatedProfile) => [


### PR DESCRIPTION
Closes https://github.com/weaveworks/weave-gitops-enterprise/issues/3222

- Fixed warning `A component is changing an uncontrolled input to be controlled` because of the initial value of `namespace` being `undefined`.

Notes:
- The cause of the warning displayed is that the initial value of namespace in the `ProfileListItem` component, used in the create template form, is `undefined`, so React thinks the input in the component is switched from uncontrolled to controlled. So, the fix is adding an initial empty string value to namespace's state hook.

Testing:
- Just start the app with

```
MANUAL_MODE=true tilt up
PROXY_HOST=http://localhost:8000 yarn start
```
and go to
```
http://localhost:3000/templates/create?name=vcluster-template-development&namespace=default
```

You will see the warning on uncontrolled input in the console.

Here is this warning with debug messages added to print namespaces passed to `ProfileListItems`:
<img width="1526" alt="Screenshot 2023-09-21 at 01 29 34" src="https://github.com/weaveworks/weave-gitops-enterprise/assets/8824708/0208d466-6867-4de5-86f2-c21f1f56cabb">

After adding the fix in the current branch the warning disappears:
<img width="1526" alt="Screenshot 2023-09-21 at 01 36 03" src="https://github.com/weaveworks/weave-gitops-enterprise/assets/8824708/cc338f8b-3eec-4b4c-aaf7-68aab444a865">

As you can see, before the fix the namespace in `ProfileListItems` is initially `undefined` and then changes to an empty string, and after applying the it is an empty string from the very beginning, thus removing the warning.
