### PR TITLE
Fix seeing resources after rolebinding has been deleted for user

### DIFF
--- a/pkg/query/configuration/objectkind.go
+++ b/pkg/query/configuration/objectkind.go
@@ -32,6 +32,7 @@ const (
 	CategoryEvent      ObjectCategory = "event"
 	CategoryGitopsSet  ObjectCategory = "gitopsset"
 	CategoryTemplate   ObjectCategory = "template"
+	CategoryRBAC       ObjectCategory = "rbac"
 )
 
 type ObjectKind struct {
@@ -165,6 +166,7 @@ var (
 			return &rbacv1.Role{}
 		},
 		AddToSchemeFunc: rbacv1.AddToScheme,
+		Category:        CategoryRBAC,
 	}
 	ClusterRoleObjectKind = ObjectKind{
 		Gvk: rbacv1.SchemeGroupVersion.WithKind("ClusterRole"),
@@ -172,6 +174,7 @@ var (
 			return &rbacv1.ClusterRole{}
 		},
 		AddToSchemeFunc: rbacv1.AddToScheme,
+		Category:        CategoryRBAC,
 	}
 	RoleBindingObjectKind = ObjectKind{
 		Gvk: rbacv1.SchemeGroupVersion.WithKind("RoleBinding"),
@@ -179,6 +182,7 @@ var (
 			return &rbacv1.RoleBinding{}
 		},
 		AddToSchemeFunc: rbacv1.AddToScheme,
+		Category:        CategoryRBAC,
 	}
 	ClusterRoleBindingObjectKind = ObjectKind{
 		Gvk: rbacv1.SchemeGroupVersion.WithKind("ClusterRoleBinding"),
@@ -186,6 +190,7 @@ var (
 			return &rbacv1.ClusterRoleBinding{}
 		},
 		AddToSchemeFunc: rbacv1.AddToScheme,
+		Category:        CategoryRBAC,
 	}
 
 	PolicyAgentAuditEventObjectKind = ObjectKind{

--- a/pkg/query/internal/models/role.go
+++ b/pkg/query/internal/models/role.go
@@ -32,6 +32,26 @@ func (o Role) GetID() string {
 	return fmt.Sprintf("%s/%s/%s/%s", o.Cluster, o.Namespace, o.Kind, o.Name)
 }
 
+func (o Role) IsValidID() (bool, error) {
+	if o.Cluster == "" {
+		return false, fmt.Errorf("missing cluster field")
+	}
+
+	if o.Name == "" {
+		return false, fmt.Errorf("missing name field")
+	}
+
+	if o.Kind == "Role" && o.Namespace == "" {
+		return false, fmt.Errorf("missing namespace field")
+	}
+
+	if o.Kind == "" {
+		return false, fmt.Errorf("missing kind field")
+	}
+
+	return true, nil
+}
+
 func (o Role) Validate() error {
 	if o.Cluster == "" {
 		return fmt.Errorf("missing cluster field")

--- a/pkg/query/rolecollector/rolecollector.go
+++ b/pkg/query/rolecollector/rolecollector.go
@@ -80,14 +80,16 @@ func processRecords(objectTransactions []models.ObjectTransaction, store store.S
 				return fmt.Errorf("cannot create role: %w", err)
 			}
 
-			if len(role.GetRules()) == 0 {
-				// Certain roles have no policy rules for some reason.
-				// Possibly related to the rbac.authorization.k8s.io/aggregate-to-gitops-reader label?
+			if obj.TransactionType() == models.TransactionTypeDelete {
+				rolesToDelete = append(rolesToDelete, role.ToModel())
 				continue
 			}
 
-			if obj.TransactionType() == models.TransactionTypeDelete {
-				rolesToDelete = append(rolesToDelete, role.ToModel())
+			// Explorer should support aggregated clusteroles.
+			// Related issue: https://github.com/weaveworks/weave-gitops-enterprise/issues/3443
+			if len(role.GetRules()) == 0 {
+				// Certain roles have no policy rules for some reason.
+				// Possibly related to the rbac.authorization.k8s.io/aggregate-to-gitops-reader label?
 				continue
 			}
 

--- a/pkg/query/rolecollector/rolecollector_test.go
+++ b/pkg/query/rolecollector/rolecollector_test.go
@@ -39,14 +39,18 @@ func TestRoleCollector_defaultProcessRecords(t *testing.T) {
 		{
 			name: "can process non-empty roles collection with no errors",
 			objectRecords: []models.ObjectTransaction{
-				testutils.NewObjectTransaction("anyCluster", testutils.NewRole("createdOrUpdatedRole", clusterName), models.TransactionTypeUpsert),
-				testutils.NewObjectTransaction("anyCluster", testutils.NewRole("deletedRole", clusterName, func(hr *rbacv1.Role) {
+				testutils.NewObjectTransaction("anyCluster", testutils.NewRole("createdOrUpdatedRole", clusterName, true), models.TransactionTypeUpsert),
+				testutils.NewObjectTransaction("anyCluster", testutils.NewRole("deletedRole", clusterName, true, func(r *rbacv1.Role) {
 					now := metav1.Now()
-					hr.DeletionTimestamp = &now
+					r.DeletionTimestamp = &now
 				}), models.TransactionTypeDelete),
-				testutils.NewObjectTransaction("anyCluster2", testutils.NewRole("deletedRole2", clusterName, func(hr *rbacv1.Role) {
+				testutils.NewObjectTransaction("anyCluster2", testutils.NewRole("deletedRole2", clusterName, true, func(r *rbacv1.Role) {
 					now := metav1.Now()
-					hr.DeletionTimestamp = &now
+					r.DeletionTimestamp = &now
+				}), models.TransactionTypeDelete),
+				testutils.NewObjectTransaction("anyCluster", testutils.NewRole("deletedRole3", clusterName, true, func(r *rbacv1.Role) {
+					now := metav1.Now()
+					r.DeletionTimestamp = &now
 				}), models.TransactionTypeDelete),
 				testutils.NewObjectTransaction("anyCluster3", nil, models.TransactionTypeDeleteAll),
 			},
@@ -54,6 +58,27 @@ func TestRoleCollector_defaultProcessRecords(t *testing.T) {
 				models.TransactionTypeDelete:    1,
 				models.TransactionTypeUpsert:    1,
 				models.TransactionTypeDeleteAll: 1,
+			},
+			errPattern: "",
+		},
+		{
+			name: "can process non-empty cluster roles collection with no errors",
+			objectRecords: []models.ObjectTransaction{
+				testutils.NewObjectTransaction("anyCluster", testutils.NewClusterRole("createdOrUpdatedRole", true), models.TransactionTypeUpsert),
+				testutils.NewObjectTransaction("anyCluster", testutils.NewClusterRole("deletedRole", true, func(cr *rbacv1.ClusterRole) {
+					now := metav1.Now()
+					cr.DeletionTimestamp = &now
+				}), models.TransactionTypeDelete),
+				testutils.NewObjectTransaction("anyCluster2", testutils.NewClusterRole("deletedRole2", false, func(cr *rbacv1.ClusterRole) {
+					now := metav1.Now()
+					cr.DeletionTimestamp = &now
+				}), models.TransactionTypeDelete),
+				testutils.NewObjectTransaction("anyCluster3", nil, models.TransactionTypeDeleteAll),
+			},
+			expectedStoreNumCalls: map[models.TransactionType]int{
+				models.TransactionTypeDelete:    2,
+				models.TransactionTypeUpsert:    2,
+				models.TransactionTypeDeleteAll: 2,
 			},
 			errPattern: "",
 		},

--- a/pkg/query/store/sqlite.go
+++ b/pkg/query/store/sqlite.go
@@ -365,8 +365,8 @@ func (i *SQLiteStore) DeleteRoles(ctx context.Context, roles []models.Role) (err
 	defer recordMetrics(metrics.DeleteRolesAction, time.Now(), err)
 
 	for _, role := range roles {
-		if err := role.Validate(); err != nil {
-			return fmt.Errorf("invalid role: %w", err)
+		if _, err := role.IsValidID(); err != nil {
+			return fmt.Errorf("invalid role ID: %w", err)
 		}
 
 		where := i.db.Where(


### PR DESCRIPTION
Closes https://github.com/weaveworks/weave-gitops-enterprise/issues/2733

- Added being able to create ClusterRoles and Roles without rules to simulate manual creation of objects for delete transactions.

- Added creating a role or binding client object for delete transactions manually in case of an "object not found" error (which was previously returned + ignored for objects without finalizers).

- Added sending delete object transactions with manually created RBAC client objects for deleted roles and bindings in case of an "object not found" error.

- As discussed with @enekofb , added `IsValidID` method to role to be able to delete roles without policy rules (those, which are manually constructed for passing them with delete transactions).

- Updated corresponding tests in `reconciler`, `rolecollector`, and `store` packages.

- Minor refactoring in variable names for consistency.

**Notes:**
- Added a `CategoryRBAC` category to `objectkind` to support `assertObjectTransaction` calls when running reconciler tests on RBAC objects. If there is another option, please let me know.

- In `rolecollector_test`, count of upsert, delete, and  deleteAll transactions (or calls?) are retained between tests. Is it expected behavior?

- Comment that "// Explorer should support aggregated clusteroles." was added based on a discussion with @enekofb 


Testing:
I test it when running the app in Tilt. So, first run WGE with Tilt as a developer.

The export the `wego-admin-read-apps` `ClusterRoleBinding` and `gitops-apps-reader` `ClusterRole` as YAML and copy and paste the output to a YAML file to re-apply them later.

```
kubectl get clusterrolebinding wego-admin-read-apps -o yaml
kubectl get clusterrole gitops-apps-reader -o yaml
```

Then open Explorer, confirm that objects are visible in Explorer as expected, and delete these `ClusterRoleBinding` and `ClusterRole`:
```
kubectl delete clusterrolebinding wego-admin-read-apps
kubectl delete clusterrole gitops-apps-reader
```

The objects should disappear in Explorer. Then apply the YAML to which you saved the output to re-create these `ClusterRoleBinding` and `ClusterRole` — and the objects should appear in Explorer again.

Here is a screen recording of a testing session:

https://github.com/weaveworks/weave-gitops-enterprise/assets/8824708/91ef0f5b-ef09-4f70-870a-6e67c5329e11

Not sure why the only object appears after deleting the ClusterRoleBinding, but I don't think it is related to Explorer, probably smth. related to how RBAC is setup for development.
