### PR TITLE
updated bug reporting document to reflect the changes in the templates.

### DIFF
--- a/docs/bug_reporting.md
+++ b/docs/bug_reporting.md
@@ -1,12 +1,9 @@
-# Internal Bug Reporting
+# Bug Reporting
 
-Bugs reported internally usually come from three test flows/streams:
+As summary, when you find a bug for WGE:
 
- 1) Bugs reported during the Acceptance Testing of a new feature/story. And by Acceptance Testing we mean manually testing a new feature to verify that it complies with the acceptance criteria, design, and behaves as expected before merging this feature into `main`. Those bugs are labeled with `bug_acceptance`. For reporting those bugs, `Acceptance Testing Bug Report` issue template can be used.
+1. Raise a [new bug](https://github.com/weaveworks/weave-gitops-enterprise/issues/new/choose) via [`bug`](../.github/ISSUE_TEMPLATE/bug.md) issue template.
+2. Fill-in the details about the bug, expected behaviour, etc ... Use the comments in the template to guide you through.   
+3. Once submitted, it will be labelled for [team/product-management](https://github.com/orgs/weaveworks/teams/product-management) to triage.  
+4. Follow the progress and / or interact via comments.
 
- 2) Bugs reported during any regular testing or regression testing of `main`. Those bugs are labeled with `bug_regression`. For reporting those bugs, `Bug Report` issue template can be used.
-
- 3)  Bugs reported during testing a released version. Those bugs are labeled with `bug_release`. For reporting those bugs, `Bug Report` issue template can be used.
-
-
- Both issue templates are created by default with the label `team/pesto` attached to them. Make sure to add your team's label instead if the bug is within one of the domains handled by your team.


### PR DESCRIPTION
<!--
Describe what has changed in this PR.
For UI changes also include a screenshot.
-->
**What changed?**
- Updated bug reporting doc to reflect the change of having a single bug issue template
- Open the conversation on how PM wants to handle this triage.

<!-- Tell your future self why have you made these changes. You could link to stories or initiative here. -->
**Why was this change made?**
Update docs given we no longer have three bug issue templates.
