### PR TITLE
build(deps): Ensure protoc-gen-grpc-gateway-ts is installed when runn…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -131,6 +131,7 @@ godeps=$(shell go list -deps -f '{{if not .Standard}}{{$$dep := .}}{{range .GoFi
 
 dependencies: ## Install build dependencies
 	$(CURRENT_DIR)/tools/download-deps.sh $(CURRENT_DIR)/tools/dependencies.toml
+	@go install github.com/grpc-ecosystem/protoc-gen-grpc-gateway-ts
 
 lint:
 	bin/go-lint


### PR DESCRIPTION


<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Closes #2853 

<!--
Describe what has changed in this PR.
For UI changes also include a screenshot.
-->
**What changed?**
Ensure protoc-gen-grpc-gateway-ts is installed when running `make dependencies`.