### PR TITLE
fix: Remove action that configured AWS credentials

### DIFF
--- a/.github/workflows/acceptance-test.yaml
+++ b/.github/workflows/acceptance-test.yaml
@@ -128,12 +128,6 @@ on:
       GCP_SA_KEY:
         description: "Google Cloud service account key"
         required: false
-      WGE_EKS_AWS_ACCESS_KEY_ID:
-        description: "AWS user access key id"
-        required: false
-      WGE_EKS_AWS_SECRET_ACCESS_KEY:
-        description: "AWS user access key secret"
-        required: false
 
 env:
   GO_CACHE_NAME: cache-go-modules
@@ -185,19 +179,6 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: 1.20.x
-      - name: setup aws credentials
-        uses: aws-actions/configure-aws-credentials@v1-node16
-        with:
-          aws-access-key-id: ${{ secrets.WGE_EKS_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.WGE_EKS_AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-east-1
-      - name: Install eksctl
-        if: ${{ inputs.management-cluster-kind == 'eks' }}
-        run: |
-          curl --silent --location "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp
-          sudo mv /tmp/eksctl /usr/local/bin
-          eksctl version
-          eksctl get clusters
       - name: Install flux
         run: |
           curl --silent --location https://github.com/fluxcd/flux2/releases/download/v2.0.0/flux_2.0.0_${{ inputs.os-name }}_amd64.tar.gz | tar xz -C /tmp

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -92,8 +92,6 @@ jobs:
       WGE_GITHUB_USER: ${{ secrets.WGE_GITHUB_USER }}
       WGE_GITHUB_PASSWORD: ${{ secrets.WGE_GITHUB_PASSWORD }}
       WGE_GITHUB_MFA_KEY: ${{ secrets.WGE_GITHUB_MFA_KEY }}
-      WGE_EKS_AWS_ACCESS_KEY_ID: ${{ secrets.WGE_EKS_AWS_ACCESS_KEY_ID }}
-      WGE_EKS_AWS_SECRET_ACCESS_KEY: ${{ secrets.WGE_EKS_AWS_SECRET_ACCESS_KEY }}
 
   smoke-tests-gitlab-deploy:
     needs: [build, coverage]
@@ -124,8 +122,6 @@ jobs:
       WGE_GITLAB_PASSWORD: ${{ secrets.WGE_ON_PREM_GITLAB_PASSWORD }}
       WGE_GITLAB_CLIENT_ID: ${{ secrets.WGE_ON_PREM_GITLAB_CLIENT_ID }}
       WGE_GITLAB_CLIENT_SECRET: ${{ secrets.WGE_ON_PREM_GITLAB_CLIENT_SECRET }}
-      WGE_EKS_AWS_ACCESS_KEY_ID: ${{ secrets.WGE_EKS_AWS_ACCESS_KEY_ID }}
-      WGE_EKS_AWS_SECRET_ACCESS_KEY: ${{ secrets.WGE_EKS_AWS_SECRET_ACCESS_KEY }}
 
   smoke-tests-gitlab-tenant:
     needs: [build, coverage]
@@ -156,8 +152,6 @@ jobs:
       WGE_GITLAB_PASSWORD: ${{ secrets.WGE_ON_PREM_GITLAB_PASSWORD }}
       WGE_GITLAB_CLIENT_ID: ${{ secrets.WGE_ON_PREM_GITLAB_CLIENT_ID }}
       WGE_GITLAB_CLIENT_SECRET: ${{ secrets.WGE_ON_PREM_GITLAB_CLIENT_SECRET }}
-      WGE_EKS_AWS_ACCESS_KEY_ID: ${{ secrets.WGE_EKS_AWS_ACCESS_KEY_ID }}
-      WGE_EKS_AWS_SECRET_ACCESS_KEY: ${{ secrets.WGE_EKS_AWS_SECRET_ACCESS_KEY }}
 
   smoke-test-results:
     if: ${{ always() }}


### PR DESCRIPTION

<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->

<!--
Describe what has changed in this PR.
For UI changes also include a screenshot.
-->
**What changed?**
Remove action that configured AWS credentials for use against an EKS test cluster. We are no longer running smoke tests against EKS.