### PR TITLE
Standardize the sync/suspend/edit buttons

### DIFF
--- a/ui/src/components/GitOpsSets/GitOpsSetDetail.tsx
+++ b/ui/src/components/GitOpsSets/GitOpsSetDetail.tsx
@@ -16,6 +16,7 @@ import {
   RequestStateHandler,
   RouterTab,
   SubRouterTabs,
+  SyncControls,
   YamlView,
 } from '@weaveworks/weave-gitops';
 import { GroupVersionKind } from '@weaveworks/weave-gitops/ui/lib/api/core/types.pb';
@@ -157,6 +158,8 @@ function GitOpsDetail({ className, name, namespace, clusterName }: Props) {
     clusterName: gs.clusterName || '',
   };
 
+  const suspended = gs?.suspended;
+
   return (
     <Page
       loading={gitOpsSetLoading || isLoading}
@@ -178,26 +181,16 @@ function GitOpsDetail({ className, name, namespace, clusterName }: Props) {
           />
         </Box>
         <Box paddingBottom={3}>
-          <Flex>
-            <Button
-              loading={syncing}
-              variant="outlined"
-              onClick={handleSyncClick}
-              style={{ marginRight: 0, textTransform: 'uppercase' }}
-            >
-              Sync
-            </Button>
-            <Box paddingLeft={1}>
-              <Button
-                loading={suspending}
-                variant="outlined"
-                onClick={handleSuspendClick}
-                style={{ marginRight: 0, textTransform: 'uppercase' }}
-              >
-                {gs?.suspended ? 'Resume' : 'Suspend'}
-              </Button>
-            </Box>
-          </Flex>
+          <SyncControls
+            hideSyncOptions
+            syncLoading={syncing}
+            syncDisabled={suspended}
+            suspendDisabled={suspending || suspended}
+            resumeDisabled={suspending || !suspended}
+            onSyncClick={handleSyncClick}
+            onSuspendClick={handleSuspendClick}
+            onResumeClick={handleSuspendClick}
+          />
         </Box>
         <SubRouterTabs rootPath={`${path}/details`}>
           <RouterTab name="Details" path={`${path}/details`}>
@@ -207,7 +200,7 @@ function GitOpsDetail({ className, name, namespace, clusterName }: Props) {
                 items={[
                   ['Observed generation', gs?.observedGeneration],
                   ['Cluster', gs?.clusterName],
-                  ['Suspended', gs?.suspended ? 'True' : 'False'],
+                  ['Suspended', suspended ? 'True' : 'False'],
                 ]}
               />
               <Metadata metadata={getMetadata(gs)} labels={getLabels(gs)} />

--- a/ui/src/components/Secrets/SecretDetails/index.tsx
+++ b/ui/src/components/Secrets/SecretDetails/index.tsx
@@ -1,4 +1,4 @@
-import { Button, Flex } from '@weaveworks/weave-gitops';
+import { Button, Flex, SyncControls } from '@weaveworks/weave-gitops';
 import moment from 'moment';
 import { useState } from 'react';
 import useNotifications from '../../../contexts/Notifications';
@@ -72,15 +72,12 @@ const SecretDetails = ({
     >
       <NotificationsWrapper>
         <Flex column gap="16">
-          <Button
-            id="sync-secret"
-            loading={syncing}
-            variant="outlined"
-            onClick={handleSyncClick}
-            style={{ marginRight: 0, textTransform: 'uppercase' }}
-          >
-            Sync
-          </Button>
+          <SyncControls
+            hideSyncOptions
+            hideSuspend
+            syncLoading={syncing}
+            onSyncClick={handleSyncClick}
+          />
           <Flex column gap="8">
             <RowHeaders rows={defaultHeaders} />
           </Flex>

--- a/ui/src/components/Templates/Edit/EditButton.tsx
+++ b/ui/src/components/Templates/Edit/EditButton.tsx
@@ -1,5 +1,4 @@
-import EditIcon from '@material-ui/icons/Edit';
-import { Button, formatURL } from '@weaveworks/weave-gitops';
+import { Button, formatURL, Icon, IconType } from '@weaveworks/weave-gitops';
 import { Automation, Source } from '@weaveworks/weave-gitops/ui/lib/objects';
 import * as React from 'react';
 import { Link } from 'react-router-dom';
@@ -71,9 +70,11 @@ export const EditButton: React.FC<{
       <Tooltip title={`Edit ${resource.type}`} placement="top">
         <div className={className}>
           <EditWrapper
+            startIcon={<Icon type={IconType.SettingsIcon} size="base" />}
             disabled={disabled}
-            startIcon={<EditIcon fontSize="small" />}
-          />
+          >
+            Edit
+          </EditWrapper>
         </div>
       </Tooltip>
     </Link>

--- a/ui/src/components/Terraform/TerraformObjectDetail.tsx
+++ b/ui/src/components/Terraform/TerraformObjectDetail.tsx
@@ -12,6 +12,7 @@ import {
   Metadata,
   RouterTab,
   SubRouterTabs,
+  SyncControls,
   Timestamp,
   YamlView,
 } from '@weaveworks/weave-gitops';
@@ -152,6 +153,8 @@ function TerraformObjectDetail({ className, ...params }: Props) {
   const shouldShowReplanButton =
     pathname.endsWith('/plan') && !isLoadingPlan && enablePlanViewing && !error;
 
+  const suspended = object?.suspended;
+
   return (
     <Page
       loading={isLoading}
@@ -170,27 +173,26 @@ function TerraformObjectDetail({ className, ...params }: Props) {
           <Box paddingBottom={3}>
             <KubeStatusIndicator
               conditions={object?.conditions || []}
-              suspended={object?.suspended}
+              suspended={suspended}
             />
           </Box>
           <Box paddingBottom={3}>
             <Flex wide wrap between gap="8">
               <Flex gap="12">
-                <Button
-                  loading={syncing}
-                  variant="outlined"
-                  onClick={handleSyncClick}
-                >
-                  Sync
-                </Button>
-
-                <Button
-                  loading={suspending}
-                  variant="outlined"
-                  onClick={handleSuspendClick}
-                >
-                  {object?.suspended ? 'Resume' : 'Suspend'}
-                </Button>
+                <SyncControls
+                  syncLoading={syncing}
+                  syncDisabled={suspended}
+                  suspendDisabled={suspending || suspended}
+                  resumeDisabled={suspending || !suspended}
+                  customActions={[
+                    <EditButton
+                      resource={data || ({} as GetTerraformObjectResponse)}
+                    />,
+                  ]}
+                  onSyncClick={handleSyncClick}
+                  onSuspendClick={handleSuspendClick}
+                  onResumeClick={handleSuspendClick}
+                />
 
                 {shouldShowReplanButton && (
                   <Button
@@ -202,10 +204,6 @@ function TerraformObjectDetail({ className, ...params }: Props) {
                     Plan
                   </Button>
                 )}
-
-                <EditButton
-                  resource={data || ({} as GetTerraformObjectResponse)}
-                />
               </Flex>
               <Flex align gap="4">
                 <LargeInfo

--- a/ui/src/components/Terraform/__tests__/TerraformObjectDetail.test.tsx
+++ b/ui/src/components/Terraform/__tests__/TerraformObjectDetail.test.tsx
@@ -63,7 +63,7 @@ describe('TerraformObjectDetail', () => {
       render(c);
     });
 
-    const button = await screen.findByText('Sync');
+    const button = await screen.findByTestId('sync-button');
 
     fireEvent.click(button);
 
@@ -105,7 +105,7 @@ describe('TerraformObjectDetail', () => {
 
     expect(suspendedValue).toEqual('Suspended:False');
 
-    const button = await screen.findByText('Suspend');
+    const button = await screen.findByTestId('suspend-button');
 
     fireEvent.click(button);
 


### PR DESCRIPTION
Closes https://github.com/weaveworks/weave-gitops-enterprise/issues/3374

- Replaced custom sync/suspend controls with the new `SyncControls` component.
- Replaced the icon EditButton with a text-based EditButton with the new Settings icon.
- Updated the snapshots.
- Fixed related tests.

Notes:
- The current PR is an enterprise counterpart to:
https://github.com/weaveworks/weave-gitops/pull/4080
- Syncing a TF object never works for me locally, but I observed this issue before the current changes.
