### PR TITLE
Remove Jordan as a CODEOWNER

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,1 @@
-/ui/src/components/Pipelines  @jpellizzari
-/ui/src/components/ProgressiveDelivery  @jpellizzari
+


### PR DESCRIPTION
We tried adding me as a CODEOWNER and it just created a lot of noise. It often pinged me for a review on trivial changes, or at times when someone was still working on their PR (draft state).

As an alternative, we can use the `Blame` and other context clues to know who would be a good reviewer.