### PR TITLE
Update EE to the latest OSS main

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.7.0
 	github.com/stretchr/testify v1.8.4
-	github.com/weaveworks/weave-gitops v0.35.0
+	github.com/weaveworks/weave-gitops v0.35.1-0.20231027151317-7093984b18d9
 	github.com/weaveworks/weave-gitops-enterprise-credentials v0.0.2
 	github.com/weaveworks/weave-gitops-enterprise/common v0.0.0
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1268,8 +1268,8 @@ github.com/weaveworks/templates-controller v0.2.0 h1:7pWLCoHasLyk1qgDH6N9XVgozZv
 github.com/weaveworks/templates-controller v0.2.0/go.mod h1:qO/4Eeqas5kjLCacboFKcisszFMjCjIUMxhtqxYlMUw=
 github.com/weaveworks/tf-controller/api v0.0.0-20230416092146-4a7dfa5b6cc4 h1:+IkLtnXzCkhJzojbadPd+UxwaTa6K/Eb2grY6LcYfeo=
 github.com/weaveworks/tf-controller/api v0.0.0-20230416092146-4a7dfa5b6cc4/go.mod h1:LUBkwqS7FHz/QTNuYzvWj6svehhh1djnV0Gj3OTc87E=
-github.com/weaveworks/weave-gitops v0.35.0 h1:j4Mf8+F2PVvy/Rj8JrGRlSWER5y7sRekTL5z8rf/OcQ=
-github.com/weaveworks/weave-gitops v0.35.0/go.mod h1:+8Ud/ZraL0mQWLoC14yaVdiIsmXvKqMWA2ANb97du5I=
+github.com/weaveworks/weave-gitops v0.35.1-0.20231027151317-7093984b18d9 h1:L7PPs4INvnAB1fNpqghtNLhzth4zrnuqJU130ktnrZA=
+github.com/weaveworks/weave-gitops v0.35.1-0.20231027151317-7093984b18d9/go.mod h1:+8Ud/ZraL0mQWLoC14yaVdiIsmXvKqMWA2ANb97du5I=
 github.com/weaveworks/weave-gitops-enterprise-credentials v0.0.2 h1:7jeiQehqmI4ds6YIq8TW1Vqhlb6V7G2BVRJ8VM3r99I=
 github.com/weaveworks/weave-gitops-enterprise-credentials v0.0.2/go.mod h1:6PMYg+VtSNePnP7EXyNG+/hNRNZ3r0mQtolIZU4s/J0=
 github.com/xanzy/go-gitlab v0.83.0 h1:37p0MpTPNbsTMKX/JnmJtY8Ch1sFiJzVF342+RvZEGw=

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@types/styled-components": "^5.1.9",
     "@types/urijs": "^1.19.19",
     "@weaveworks/progressive-delivery": "0.0.0-rc13",
-    "@weaveworks/weave-gitops": "0.35.0",
+    "@weaveworks/weave-gitops": "npm:@weaveworks/weave-gitops-main@0.35.0-12-g7093984b",
     "babel-jest": "^27.4.2",
     "babel-plugin-named-asset-import": "^0.3.8",
     "babel-preset-react-app": "^10.0.1",

--- a/pkg/gitopssets/adapter/adapter.go
+++ b/pkg/gitopssets/adapter/adapter.go
@@ -23,8 +23,9 @@ func (obj GitOpsSetAdapter) GroupVersionKind() schema.GroupVersionKind {
 	return ctrl.GroupVersion.WithKind("GitOpsSet")
 }
 
-func (obj GitOpsSetAdapter) SetSuspended(suspend bool) {
+func (obj GitOpsSetAdapter) SetSuspended(suspend bool) error {
 	obj.Spec.Suspend = suspend
+	return nil
 }
 
 func (obj GitOpsSetAdapter) DeepCopyClientObject() client.Object {

--- a/pkg/terraform/internal/adapter/adapter.go
+++ b/pkg/terraform/internal/adapter/adapter.go
@@ -23,8 +23,9 @@ func (obj TerraformObjectAdapter) GroupVersionKind() schema.GroupVersionKind {
 	return tfctrl.GroupVersion.WithKind(tfctrl.TerraformKind)
 }
 
-func (obj TerraformObjectAdapter) SetSuspended(suspend bool) {
+func (obj TerraformObjectAdapter) SetSuspended(suspend bool) error {
 	obj.Spec.Suspend = suspend
+	return nil
 }
 
 func (obj TerraformObjectAdapter) DeepCopyClientObject() client.Object {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2826,10 +2826,10 @@
   resolved "https://npm.pkg.github.com/download/@weaveworks/progressive-delivery/0.0.0-rc13/2628159001f4812b90e068e64fae8de6b4e3f2b4"
   integrity sha512-51ET/FrGwKcBUSqRTtaWTTuWQi/y51JQAFYMT6ctOLaiIXSopCyi3alf4aYDZ5TPFAIdOQapJMYiq2HVj5XxOQ==
 
-"@weaveworks/weave-gitops@0.35.0":
-  version "0.35.0"
-  resolved "https://npm.pkg.github.com/download/@weaveworks/weave-gitops/0.35.0/26e6888230cd1ce826b5632b936156a6267ab235#26e6888230cd1ce826b5632b936156a6267ab235"
-  integrity sha512-lVeJL/sGub2MHZa9nleulNHklZerTkWPIXPjiOWA2k+q8lDf16pOJLNhcB/Ni2aSgJharjVi+8wfutiO+OAAew==
+"@weaveworks/weave-gitops@npm:@weaveworks/weave-gitops-main@0.35.0-12-g7093984b":
+  version "0.35.0-12-g7093984b"
+  resolved "https://npm.pkg.github.com/download/@weaveworks/weave-gitops-main/0.35.0-12-g7093984b/30ff18fa3da17c31caa0e77cf15e66ec25a7a655#30ff18fa3da17c31caa0e77cf15e66ec25a7a655"
+  integrity sha512-ri//nhIHz7I/QrI0kxFS0afmPRunhYCS58zdURMmyFw6x/euPLLZ4lACNhgMk3j6cVfM7ilsIn62XCQeX0pfyw==
   dependencies:
     "@material-ui/core" "^4.12.4"
     "@material-ui/icons" "^4.11.2"


### PR DESCRIPTION
- There are some small changes to the suspend interface that are updated here.

**What changed?**

Update EE to the latest OSS main, some small changes to the sync interface were intro'd in https://github.com/weaveworks/weave-gitops/pull/4096 which have to be updated in EE here


- Diff https://github.com/weaveworks/weave-gitops/compare/v0.35.0...7093984b