### PR TITLE
Set dark mode black to white

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,5 +1,4 @@
 import '@fortawesome/fontawesome-free/css/all.css';
-import 'react-toastify/dist/ReactToastify.css';
 import { MuiThemeProvider } from '@material-ui/core/styles';
 import { ProgressiveDeliveryService } from '@weaveworks/progressive-delivery';
 import {
@@ -24,6 +23,7 @@ import {
 } from 'react-query';
 import { BrowserRouter, Route, Switch } from 'react-router-dom';
 import { ToastContainer } from 'react-toastify';
+import 'react-toastify/dist/ReactToastify.css';
 import { createGlobalStyle, ThemeProvider } from 'styled-components';
 import ProximaNova from 'url:./fonts/proximanova-regular.woff';
 import RobotoMono from 'url:./fonts/roboto-mono-regular.woff';
@@ -148,6 +148,16 @@ const StylesProvider = ({ children }: { children: ReactNode }) => {
   const { settings } = React.useContext(AppContext);
   const mode = settings.theme;
   const appliedTheme = theme(mode);
+
+  // Related to: https://github.com/weaveworks/weave-gitops-enterprise/issues/3555
+  // The `<body>` element is set to use `colors.black`. We need to invert it for dark mode.
+  if (mode === ThemeTypes.Dark) {
+    appliedTheme.colors = {
+      ...appliedTheme.colors,
+      black: appliedTheme.colors.white,
+    };
+  }
+
   return (
     <ThemeProvider theme={appliedTheme}>
       <MuiThemeProvider theme={muiTheme(appliedTheme.colors, mode)}>

--- a/ui/src/components/Explorer/Explorer.tsx
+++ b/ui/src/components/Explorer/Explorer.tsx
@@ -12,8 +12,8 @@ import ExplorerTable, { FieldWithIndex } from './ExplorerTable';
 import FilterDrawer from './FilterDrawer';
 import Filters from './Filters';
 import {
-  QueryStateProvider,
   columnHeaderHandler,
+  QueryStateProvider,
   useGetUnstructuredObjects,
 } from './hooks';
 import PaginationControls from './PaginationControls';


### PR DESCRIPTION
Closes #3555 

There was an issue where the `body` styling was not obeying dark mode styling. This was happening on many parts of the UI, not just the Explorer. After this change:

![Screenshot from 2023-10-30 14-28-11](https://github.com/weaveworks/weave-gitops-enterprise/assets/2802257/4b304dce-d1e7-4617-b885-ac782dd06aa8)

See the original issue for "before" screenshots.

One issue with our current theme structure is that we don't have a key/value for `textColor` for an easy, semantic value to use for `body`.