### PR TITLE
Add tenant field to Explorer objects

### DIFF
--- a/pkg/query/server/server.go
+++ b/pkg/query/server/server.go
@@ -27,6 +27,7 @@ import (
 	store "github.com/weaveworks/weave-gitops-enterprise/pkg/query/store"
 	"github.com/weaveworks/weave-gitops/core/clustersmngr"
 	"github.com/weaveworks/weave-gitops/pkg/server/auth"
+	v1 "k8s.io/api/core/v1"
 )
 
 type server struct {
@@ -39,6 +40,7 @@ type server struct {
 	cancelCollection context.CancelFunc
 	cleaner          cleaner.ObjectCleaner
 	enabledFor       []string
+	clustersManager  clustersmngr.ClustersManager
 }
 
 func (s *server) StopCollection() error {
@@ -75,10 +77,21 @@ type ServerOpts struct {
 
 func (s *server) DoQuery(ctx context.Context, msg *pb.DoQueryRequest) (*pb.DoQueryResponse, error) {
 	objs, err := s.qs.RunQuery(ctx, msg, msg)
-
 	if err != nil {
 		return nil, fmt.Errorf("failed to run query: %w", err)
 	}
+
+	user := auth.Principal(ctx)
+	// Force update the cluster manager cache
+	// It appears this gets called every request by the GetImpersonatedClient call,
+	// which does not get called in the Query code path.
+	// It should be safe to call on every request here.
+	s.clustersManager.UpdateUserNamespaces(ctx, user)
+
+	// Existing tenants machinery requires that we know the user's available namespaces.
+	// We check those tenant namespaces against the object's namespace.
+	userNamespaces := s.clustersManager.GetUserNamespaces(user)
+	objs = withTenants(objs, userNamespaces)
 
 	return &pb.DoQueryResponse{
 		Objects: convertToPbObject(objs),
@@ -215,8 +228,9 @@ func NewServer(opts ServerOpts) (_ pb.QueryServer, _ func() error, reterr error)
 	debug.Info("query service created")
 
 	serv := &server{
-		qs:         qs,
-		enabledFor: opts.EnabledFor,
+		qs:              qs,
+		enabledFor:      opts.EnabledFor,
+		clustersManager: opts.ClustersManager,
 	}
 
 	if !opts.SkipCollection {
@@ -355,4 +369,22 @@ func convertToPbFacet(facets store.Facets) []*pb.Facet {
 	}
 
 	return pbFacets
+}
+
+// Replicating the logic from here:
+// https://github.com/weaveworks/weave-gitops/blob/8b293044e6afec872453fee40923da3d2f066f12/core/server/utils.go#L13
+func withTenants(objs []models.Object, nsList map[string][]v1.Namespace) []models.Object {
+	out := []models.Object{}
+	for _, obj := range objs {
+		namespaces := nsList[obj.Cluster]
+		for _, ns := range namespaces {
+			if ns.GetName() == obj.Namespace {
+				obj.Tenant = ns.Labels["toolkit.fluxcd.io/tenant"]
+				break
+			}
+		}
+		out = append(out, obj)
+	}
+
+	return out
 }


### PR DESCRIPTION
Closes #3299 

Populates the `.tenant` column using the existing machinery. This is a temporary fix to get parity with existing views.
![Screenshot from 2023-11-01 12-19-25](https://github.com/weaveworks/weave-gitops-enterprise/assets/2802257/7414e8b0-a9c7-4351-83bb-329db4abebdd)



Currently, we don't have a list of namespaces stored in the database that we can easily look up.

A possible long-term solution would be to watch namespaces and store a table of namespaces and tenants for a faster lookup