### PR TITLE
starts server out of the creation function to control when is ready to query

### DIFF
--- a/pkg/monitoring/server.go
+++ b/pkg/monitoring/server.go
@@ -24,7 +24,7 @@ type Options struct {
 	ProfilingOptions profiling.Options
 }
 
-// NewSever creates and starts a management server for all endpoints that we need to expose internally. For example metrics or profiling.
+// NewServer creates a new monitoring server for all endpoints that we need to expose internally. For example metrics or profiling.
 func NewServer(opts Options) (*http.Server, error) {
 	if opts.ServerAddress == "" {
 		return nil, fmt.Errorf("cannot create server for empty address")
@@ -49,13 +49,6 @@ func NewServer(opts Options) (*http.Server, error) {
 		Addr:    opts.ServerAddress,
 		Handler: pprofMux,
 	}
-
-	go func() {
-		log.Info("starting server", "address", server.Addr)
-		if err := server.ListenAndServe(); err != nil {
-			log.Error(err, "could not start metrics server")
-		}
-	}()
 
 	return server, nil
 }


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Closes https://github.com/weaveworks/weave-gitops-enterprise/issues/3368

<!--
Describe what has changed in this PR.
For UI changes also include a screenshot.
-->
**What changed?**

- Addressed error by just consuming endpoints after the server is started.

<!-- Tell your future self why have you made these changes. You could link to stories or initiative here. -->
**Why was this change made?**

- To reduce the chances of querying the server before it is started

<!--
Explain to your reviewers the key implementation points, including why you made
certain choices in favour of others. Highlight key areas of the code which need
extra attention, and also indicate which parts are less relevant (eg renaming,
refactoring, etc
-->
**How was this change implemented?**

<!-- Use the checklist to detail how you're sure that the change
works.  Check each box when you're satisfied you've dealt with that
item. -->
**How did you validate the change?**

 - [x] Explain how a reviewer can verify the change themselves

1. run the test should not fail
2. tilt the branch, expose monitoring server and consume its `/metrics` endpoint, you should see it available.

 - [x] Integration tests -- what is covered, what cannot be covered;
       or, explain why there are no new tests

Not required 

 - [x] Unit tests -- what is covered, what cannot be covered; are
       there tests that fail _without_ the change?

flake refactored ~ hope that metrics failure no longer appears

<!--
Is it notable for release? e.g. schema updates, configuration or data migration
required? If so, please mention it.
-->
**Release notes**


<!--
Are there any documentation updates that should be made for these changes? We want to keep these sources up to date:
- user-guide: https://docs.gitops.weave.works
- internal docs: https://github.com/weaveworks/weave-gitops-enterprise/tree/main/docs
- architecture docs: https://github.com/weaveworks/weave-gitops-enterprise/blob/main/docs/architecture
-->
**Documentation Changes**


<!-- Is there anything else that will need to be done after this is
approved or merged? Ideally, log an issue for each follow-up task and
list them here -->
**Other follow ups**
