### PR TITLE
Remove duplicate key in `HelmChart` values.

### DIFF
--- a/charts/mccp/values.yaml
+++ b/charts/mccp/values.yaml
@@ -143,9 +143,6 @@ service:
   healthCheckNodePort: 0
   annotations: {}
 
-cluster-controller:
-  enabled: true
-
 policy-agent:
   enabled: false
   config:


### PR DESCRIPTION
There are two copies of the same cluster-controller key in `charts/mccp/values.yaml` :

https://github.com/weaveworks/weave-gitops-enterprise/blob/4e702bdebafbe91218b261394524706203e8646d/charts/mccp/values.yaml#L146
https://github.com/weaveworks/weave-gitops-enterprise/blob/4e702bdebafbe91218b261394524706203e8646d/charts/mccp/values.yaml#L213

I see the following error in VSCode:
<img width="1000" alt="Screenshot 2023-11-02 at 20 03 50" src="https://github.com/weaveworks/weave-gitops-enterprise/assets/8824708/f7f3e88e-4f4d-4676-b16d-179a0d4aaac2">

So, the current PR deletes the first duplicate key because the other one has more subkeys.
