### PR TITLE
[UI] Dropdown menus broken in dark-mode

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -107,7 +107,17 @@ const GlobalStyle = createGlobalStyle`
     .MuiFormControl-root {
       min-width: 0px;
     }
-   
+    .MuiPaper-root{
+      background-color: ${props =>
+        props.theme.mode === ThemeTypes.Dark
+          ? props.theme.colors.neutralGray
+          : props.theme.colors.white};
+    }
+    .MuiListItem-button:hover{
+      background-color: ${props =>
+        props.theme.mode === ThemeTypes.Dark
+          ? props.theme.colors.blueWithOpacity
+          : props.theme.colors.neutral10}};
   }
   
   #root {


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Closes #3601 

<!--
Describe what has changed in this PR.
For UI changes also include a screenshot.
-->
**What changed?**
change bg-color & onHover bg in dark-mode for Dropdown 


https://github.com/weaveworks/weave-gitops-enterprise/assets/4614360/a5f823a6-532f-4953-befb-7322e8f2de36
