### PR TITLE
removed ssh bootstrap scenario as represents the same user journey as the https. 

### DIFF
--- a/cmd/gitops/app/bootstrap/cmd_acceptance_test.go
+++ b/cmd/gitops/app/bootstrap/cmd_acceptance_test.go
@@ -91,7 +91,6 @@ func TestBootstrapCmd(t *testing.T) {
 	privateKeyFlag := fmt.Sprintf("--private-key=%s", privateKeyFile)
 	kubeconfigFlag := fmt.Sprintf("--kubeconfig=%s", kubeconfigPath)
 
-	repoSSHURLFlag := fmt.Sprintf("--repo-url=%s", repoURLSSH)
 	repoHTTPSURLFlag := fmt.Sprintf("--repo-url=%s", repoURLHTTPS)
 
 	gitUsernameFlag := fmt.Sprintf("--git-username=%s", gitUsername)
@@ -114,7 +113,7 @@ func TestBootstrapCmd(t *testing.T) {
 		reset            func(t *testing.T)
 	}{
 		{
-			name: "should bootstrap non-interactive with valid arguments",
+			name: "journey flux exists: should bootstrap with valid arguments",
 			flags: []string{kubeconfigFlag,
 				"--version=0.35.0",
 				privateKeyFlag, "--private-key-password=\"\"",
@@ -136,29 +135,7 @@ func TestBootstrapCmd(t *testing.T) {
 			expectedErrorStr: "",
 		},
 		{
-			name: "should install wge with flux with provided repo url and detect the scheme type ssh",
-			flags: []string{kubeconfigFlag,
-				"--version=0.35.0",
-				privateKeyFlag, "--private-key-password=\"\"",
-				"--password=admin123",
-				"--domain-type=localhost",
-				"--discovery-url=https://dex-01.wge.dev.weave.works/.well-known/openid-configuration",
-				"--client-id=weave-gitops-enterprise",
-				repoSSHURLFlag, gitBranchFlag, gitRepoPathFlag,
-				oidcClientSecretFlag, "-s",
-			},
-			setup: func(t *testing.T) {
-				createEntitlements(t, testLog)
-			},
-			reset: func(t *testing.T) {
-				deleteEntitlements(t, testLog)
-				deleteClusterUser(t, testLog)
-				uninstallFlux(g, kubeconfigFlag)
-			},
-			expectedErrorStr: "",
-		},
-		{
-			name: "should install wge with flux with provided repo url and detect the scheme type https",
+			name: "journey flux does not exist: should bootstrap with valid arguments",
 			flags: []string{kubeconfigFlag,
 				"--version=0.35.0",
 				"--password=admin123",


### PR DESCRIPTION
leaving https cause the bootstrapped scenario already have ssh

Adding to my comments in the PR the fact that we have acceptance tests layers does not mean that we dont need integration test layer. we shoudl not rely on having the integrations tested at the acceptance layer as are the most expensive tests that we could have so they likely to be less reliable as more cases we add along. 