### PR TITLE
Add monitoring to objects cleaner

### DIFF
--- a/charts/mccp/templates/clusters-service/configmap.yaml
+++ b/charts/mccp/templates/clusters-service/configmap.yaml
@@ -59,3 +59,4 @@ data:
   MONITORING_METRICS_ENABLED: {{ .Values.monitoring.metrics.enabled | quote }}
   MONITORING_PROFILING_ENABLED: {{ .Values.monitoring.profiling.enabled | quote }}
   EXPLORER_ENABLED_FOR: {{ .Values.explorer.enabledFor | join "," | quote }}
+  EXPLORER_CLEANER_DISABLED: {{ .Values.explorer.cleaner.disabled | quote }}

--- a/cmd/clusters-service/app/options.go
+++ b/cmd/clusters-service/app/options.go
@@ -59,7 +59,7 @@ type Options struct {
 	PipelineControllerAddress string
 	CollectorServiceAccount   collector.ImpersonateServiceAccount
 	MonitoringOptions         monitoring.Options
-	EnableObjectCleaner       bool
+	ExplorerCleanerDisabled   bool
 	ExplorerEnabledFor        []string
 }
 
@@ -285,10 +285,10 @@ func WithMonitoring(enabled bool, address string, metricsEnabled bool, profiling
 	}
 }
 
-// WithObjectCleaner enables the object cleaner
-func WithObjectCleaner(enabled bool) Option {
+// WithExplorerCleanerDisabled configures the object cleaner
+func WithExplorerCleanerDisabled(disabled bool) Option {
 	return func(o *Options) {
-		o.EnableObjectCleaner = enabled
+		o.ExplorerCleanerDisabled = disabled
 	}
 }
 

--- a/cmd/clusters-service/app/server.go
+++ b/cmd/clusters-service/app/server.go
@@ -162,7 +162,7 @@ type Params struct {
 	MonitoringBindAddress             string                    `mapstructure:"monitoring-bind-address"`
 	MetricsEnabled                    bool                      `mapstructure:"monitoring-metrics-enabled"`
 	ProfilingEnabled                  bool                      `mapstructure:"monitoring-profiling-enabled"`
-	EnableObjectCleaner               bool                      `mapstructure:"enable-object-cleaner"`
+	ExplorerCleanerDisabled           bool                      `mapstructure:"explorer-cleaner-disabled"`
 	NoAuthUser                        string                    `mapstructure:"insecure-no-authentication-user"`
 	ExplorerEnabledFor                []string                  `mapstructure:"explorer-enabled-for"`
 }
@@ -586,7 +586,7 @@ func StartServer(ctx context.Context, p Params, logOptions flux_logger.Options) 
 		WithPipelineControllerAddress(p.PipelineControllerAddress),
 		WithCollectorServiceAccount(p.CollectorServiceAccountName, p.CollectorServiceAccountNamespace),
 		WithMonitoring(p.MonitoringEnabled, p.MonitoringBindAddress, p.MetricsEnabled, p.ProfilingEnabled, log),
-		WithObjectCleaner(p.EnableObjectCleaner),
+		WithExplorerCleanerDisabled(p.ExplorerCleanerDisabled),
 		WithExplorerEnabledFor(p.ExplorerEnabledFor),
 	)
 }
@@ -707,7 +707,7 @@ func RunInProcessGateway(ctx context.Context, addr string, setters ...Option) er
 			SkipCollection:      false,
 			ObjectKinds:         configuration.SupportedObjectKinds,
 			ServiceAccount:      args.CollectorServiceAccount,
-			EnableObjectCleaner: args.EnableObjectCleaner,
+			EnableObjectCleaner: !args.ExplorerCleanerDisabled,
 			EnabledFor:          args.ExplorerEnabledFor,
 		})
 		if err != nil {

--- a/pkg/query/cleaner/cleaner_test.go
+++ b/pkg/query/cleaner/cleaner_test.go
@@ -2,11 +2,16 @@ package cleaner
 
 import (
 	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
 	"github.com/go-logr/logr"
 	. "github.com/onsi/gomega"
+	"github.com/weaveworks/weave-gitops-enterprise/pkg/monitoring/metrics"
+	cleanermetrics "github.com/weaveworks/weave-gitops-enterprise/pkg/query/cleaner/metrics"
 	"github.com/weaveworks/weave-gitops-enterprise/pkg/query/configuration"
 	"github.com/weaveworks/weave-gitops-enterprise/pkg/query/internal/models"
 	"github.com/weaveworks/weave-gitops-enterprise/pkg/query/store/storefakes"
@@ -70,5 +75,76 @@ func TestObjectCleaner(t *testing.T) {
 	// The `iter` mock will return only the second object, which is not old enough to be deleted.
 	g.Expect(oc.removeOldObjects(context.Background())).To(Succeed())
 	g.Expect(s.DeleteObjectsCallCount()).To(Equal(1))
+}
 
+func TestObjectCleanerMetrics(t *testing.T) {
+	g := NewWithT(t)
+	s := storefakes.FakeStore{}
+
+	cfg := configuration.BucketObjectKind
+	cfg.RetentionPolicy = configuration.RetentionPolicy(60 * time.Second)
+
+	cleanermetrics.CleanerLatencyHistogram.Reset()
+	cleanermetrics.CleanerInflightRequests.Reset()
+
+	_, h := metrics.NewDefaultPrometheusHandler()
+	ts := httptest.NewServer(h)
+	defer ts.Close()
+
+	objs := []models.Object{
+		{
+			Cluster:    "cluster1",
+			Kind:       cfg.Gvk.Kind,
+			Name:       "name1",
+			APIGroup:   cfg.Gvk.Group,
+			APIVersion: cfg.Gvk.Version,
+			// Deleted 1 hour ago, our retention policy is 60s, so this should be deleted.
+			KubernetesDeletedAt: time.Now().Add(-time.Hour),
+		},
+		{
+			Cluster:    "cluster1",
+			Kind:       cfg.Gvk.Kind,
+			Name:       "name2",
+			APIGroup:   cfg.Gvk.Group,
+			APIVersion: cfg.Gvk.Version,
+			// Deleted 10s ago, our retention policy is 60s, so this should not be deleted.
+			KubernetesDeletedAt: time.Now().Add(10 * -time.Second),
+		},
+	}
+
+	iter := storefakes.FakeIterator{}
+	iter.AllReturnsOnCall(0, objs, nil)
+	// Pretend the first object is deleted on the second call
+	iter.AllReturnsOnCall(1, objs[1:2], nil)
+	s.GetAllObjectsReturns(&iter, nil)
+
+	index := storefakes.FakeIndexWriter{}
+
+	oc := objectCleaner{
+		log:    logr.Discard(),
+		store:  &s,
+		idx:    &index,
+		config: []configuration.ObjectKind{cfg},
+	}
+
+	// Skipping starting the cleaner here to avoid dealing with async and time stuff.
+	g.Expect(oc.removeOldObjects(context.Background())).To(Succeed())
+
+	wantMetrics := []string{
+		`objects_cleaner_inflight_requests{action="RemoveObjects"} 0`,
+		`objects_cleaner_latency_seconds_count{action="RemoveObjects",status="success"} 1`,
+	}
+	assertMetrics(g, ts, wantMetrics)
+}
+
+func assertMetrics(g *WithT, ts *httptest.Server, expMetrics []string) {
+	resp, err := http.Get(ts.URL)
+	g.Expect(err).NotTo(HaveOccurred())
+	b, err := io.ReadAll(resp.Body)
+	g.Expect(err).NotTo(HaveOccurred())
+	metrics := string(b)
+
+	for _, expMetric := range expMetrics {
+		g.Expect(metrics).To(ContainSubstring(expMetric))
+	}
 }

--- a/pkg/query/cleaner/metrics/recorder.go
+++ b/pkg/query/cleaner/metrics/recorder.go
@@ -1,0 +1,60 @@
+package metrics
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	cleanerSubsystem = "objects_cleaner"
+
+	// cleaner actions
+	removeObjectsAction = "RemoveObjects"
+
+	FailedLabel  = "error"
+	SuccessLabel = "success"
+)
+
+var cleanerWatcher = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	Subsystem: cleanerSubsystem,
+	Name:      "status",
+	Help:      "cleaner status",
+}, []string{"status"})
+
+var CleanerLatencyHistogram = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+	Subsystem: cleanerSubsystem,
+	Name:      "latency_seconds",
+	Help:      "cleaner latency",
+	Buckets:   prometheus.LinearBuckets(0.01, 0.01, 10),
+}, []string{"action", "status"})
+
+var CleanerInflightRequests = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	Subsystem: cleanerSubsystem,
+	Name:      "inflight_requests",
+	Help:      "number of cleaner in-flight requests.",
+}, []string{"action"})
+
+func init() {
+	prometheus.MustRegister(cleanerWatcher)
+	prometheus.MustRegister(CleanerLatencyHistogram)
+	prometheus.MustRegister(CleanerInflightRequests)
+}
+
+// CleanerWatcherDecrease decreases cleaner_watcher metric for status
+func CleanerWatcherDecrease(status string) {
+	cleanerWatcher.WithLabelValues(status).Dec()
+}
+
+// CleanerWatcherIncrease increases cleaner_watcher metric for status
+func CleanerWatcherIncrease(status string) {
+	cleanerWatcher.WithLabelValues(status).Inc()
+}
+
+func CleanerSetLatency(status string, duration time.Duration) {
+	CleanerLatencyHistogram.WithLabelValues(removeObjectsAction, status).Observe(duration.Seconds())
+}
+
+func CleanerAddInflightRequests(number float64) {
+	CleanerInflightRequests.WithLabelValues(removeObjectsAction).Add(number)
+}

--- a/pkg/query/collector/watching.go
+++ b/pkg/query/collector/watching.go
@@ -98,7 +98,6 @@ type child struct {
 }
 
 // setStatus sets watcher status and records it as a metric.
-// It does not record metrics for stopped state non-active states = notStarted and Stopped
 func (c *child) setStatus(s string) {
 	if c.status != "" {
 		metrics.ClusterWatcherDecrease(c.collector, c.status)
@@ -145,7 +144,7 @@ func newWatchingCollector(opts CollectorOpts) (*watchingCollector, error) {
 	}, nil
 }
 
-func (w *watchingCollector) watch(cluster cluster.Cluster) (reterr error) {
+func (w *watchingCollector) watch(cluster cluster.Cluster) (retErr error) {
 	clusterName := cluster.GetName()
 	if clusterName == "" {
 		return fmt.Errorf("cluster name is empty")
@@ -159,7 +158,7 @@ func (w *watchingCollector) watch(cluster cluster.Cluster) (reterr error) {
 	childctx, cancel := context.WithCancel(context.Background())
 	c.cancel = cancel
 	defer func() {
-		if reterr != nil {
+		if retErr != nil {
 			w.clusterWatchersMu.Lock()
 			c.setStatus(ClusterWatchingFailed)
 			cancel := c.cancel

--- a/pkg/query/server/server.go
+++ b/pkg/query/server/server.go
@@ -198,7 +198,7 @@ func (so *ServerOpts) Validate() error {
 	return nil
 }
 
-func NewServer(opts ServerOpts) (_ pb.QueryServer, _ func() error, reterr error) {
+func NewServer(opts ServerOpts) (_ pb.QueryServer, _ func() error, retErr error) {
 	if err := opts.Validate(); err != nil {
 		return nil, nil, fmt.Errorf("invalid query server options: %w", err)
 	}
@@ -256,7 +256,7 @@ func NewServer(opts ServerOpts) (_ pb.QueryServer, _ func() error, reterr error)
 
 		ctx, cancel := context.WithCancel(context.Background())
 		defer func() {
-			if reterr != nil {
+			if retErr != nil {
 				cancel()
 			}
 		}()


### PR DESCRIPTION
Closes https://github.com/weaveworks/weave-gitops-enterprise/issues/3043

**What changed?**

To enhance the troubleshooting experience of the Explorer's management path for users, we have added RED metrics to the objects cleaner component of Explorer:

1. Added recording of objects cleaner status and object removal operations as metrics.

2. Introduced Grafana dashboard panels: "Objects Cleaner Request Rate" and "Objects Cleaner Requests Duration" for the objects cleaner.

3. Updated Explorer's monitoring documentation to include the new metrics.

**Release Notes**

(Include in the next release notes under the Highlights section)

## Highlights

RED metrics and corresponding Grafana dashboard panels have been added to the objects cleaner component of Explorer, enhancing the troubleshooting capabilities in Explorer's management path.