### PR TITLE
Revert "Continue when acceptance test fails to do not block on smoke …"

### DIFF
--- a/.github/workflows/acceptance-test.yaml
+++ b/.github/workflows/acceptance-test.yaml
@@ -166,7 +166,6 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     timeout-minutes: ${{ inputs.timeout-minutes }}
-    continue-on-error: true
     steps:
       - name: Checkout code
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1


### PR DESCRIPTION
Reverting the commit cause even the workflow is green

https://github.com/weaveworks/weave-gitops-enterprise/actions/runs/6849422093

The builds check still red so it is not a consistent picture for a dev looking into this. 

<img width="2168" alt="Screenshot 2023-11-13 at 12 21 10" src="https://github.com/weaveworks/weave-gitops-enterprise/assets/12957664/03022660-c3e7-43e7-9115-e1d12554e8b1">

We need to investigate on the build status checks to complete the solution. in the mean time reverting so dont confuse folks.