### PR TITLE
Flip CAPI support to disabled by default

### DIFF
--- a/charts/mccp/values.yaml
+++ b/charts/mccp/values.yaml
@@ -176,17 +176,13 @@ networkPolicy:
   enabled: true
 
 global:
-  capiEnabled: true
+  capiEnabled: false
   useK8sCachedClients: false
 
 clustersService:
   args: []
 
-templates-controller:
-  enabled: true
-
 gitopssets-controller:
-  enabled: true
   controllerManager:
     manager:
       args:
@@ -197,7 +193,6 @@ gitopssets-controller:
         - --enabled-generators=GitRepository,Cluster,PullRequests,List,APIClient,Matrix,Config
 
 cluster-controller:
-  enabled: true
   # cluster-controller-manager etc
   fullnameOverride: cluster
   controllerManager:
@@ -210,7 +205,6 @@ cluster-reflector-controller:
   enabled: false
 
 cluster-bootstrap-controller:
-  enabled: true
   manager:
     resources:
       limits:
@@ -231,8 +225,8 @@ explorer:
   cleaner:
     disabled: false
   enabledFor:
-#    - applications
-#    - sources
+    # - applications
+    # - sources
     - gitopssets
     - templates
-#    - clusterdiscovery
+    # - clusterdiscovery


### PR DESCRIPTION
Partially addresses https://github.com/weaveworks/weave-gitops-enterprise/issues/3658

Other issues to address:
- [ ] [user-guide] Update the user-guide to show how to enable CAPI
- [ ] [user-guide] Add a page about disabling / enabling CAPI support + restarting deployments
- [ ] [user-guide] Make it more explicit that Policy still requires cert-manager (which is often implicitly installed with a capi-provider)

<!--
Describe what has changed in this PR.
For UI changes also include a screenshot.
-->
**What changed?**

- Flip CAPI support to disabled by default
- Also remove the explicit ".enabled: true" options in the values.yaml.

<!-- Tell your future self why have you made these changes. You could link to stories or initiative here. -->
**Why was this change made?**

> - Also remove the explicit ".enabled: true" options in the values.yaml.

You cannot actually disable any of the controllers without a lot of things breaking. This reduces the visibility of this option and discourages users for playing with it.

<!--
Explain to your reviewers the key implementation points, including why you made
certain choices in favour of others. Highlight key areas of the code which need
extra attention, and also indicate which parts are less relevant (eg renaming,
refactoring, etc
-->
**How was this change implemented?**

Parts of the system that recognise `global.capiEnabled`
1. cluster-service: if capi is enabled then capi cluster details are queried for and returned in the /v1/clusters endpoint
2. cluster-controller: if capi is enabled then capi clusters status is used to calculate the gitopscluster status

<!-- Use the checklist to detail how you're sure that the change
works.  Check each box when you're satisfied you've dealt with that
item. -->
**How did you validate the change?**

 - [ ] Explain how a reviewer can verify the change themselves
 - [ ] Integration tests -- what is covered, what cannot be covered;
       or, explain why there are no new tests
 - [ ] Unit tests -- what is covered, what cannot be covered; are
       there tests that fail _without_ the change?


<!--
Is it notable for release? e.g. schema updates, configuration or data migration
required? If so, please mention it.
-->
**Release notes**


<!--
Are there any documentation updates that should be made for these changes? We want to keep these sources up to date:
- user-guide: https://docs.gitops.weave.works
- internal docs: https://github.com/weaveworks/weave-gitops-enterprise/tree/main/docs
- architecture docs: https://github.com/weaveworks/weave-gitops-enterprise/blob/main/docs/architecture
-->
**Documentation Changes**


<!-- Is there anything else that will need to be done after this is
approved or merged? Ideally, log an issue for each follow-up task and
list them here -->
**Other follow ups**
