### PR TITLE
Delay Explorer query input focus until drawer animation is complete

### DIFF
--- a/ui/src/components/Explorer/Explorer.tsx
+++ b/ui/src/components/Explorer/Explorer.tsx
@@ -85,7 +85,12 @@ function Explorer({
     }
     // Focus the input so you can click open and start typing
     if (filterDrawerOpen) {
-      inputRef.current.focus();
+      // Delay the focus so that the drawer animation makes sense.
+      // Without the delay, the animation will stutter
+      // due to something in material-ui expanding the width.
+      setTimeout(() => {
+        inputRef.current?.focus();
+      }, 500);
     } else {
       inputRef.current.blur();
     }


### PR DESCRIPTION
Closes #3634 

Fixes an issue where the FilterDialog would have a weird expansion animation. The root cause was the auto-focus logic triggering the input component to expand in width for some reason (this is a Material behavior).

See the original issue for videos.