### PR TITLE
fix: Populate promotion field  per environment in API response

### DIFF
--- a/pkg/pipelines/internal/convert/pipeline.go
+++ b/pkg/pipelines/internal/convert/pipeline.go
@@ -33,7 +33,7 @@ func PipelineToProto(p ctrl.Pipeline) *pb.Pipeline {
 			},
 		}
 
-		env.Promotion = makePromotion(e.Promotion)
+		env.Promotion = makePromotion(p.Spec.GetPromotion(e.Name))
 
 		for _, t := range e.Targets {
 			var clusterRef pb.ClusterRef


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Closes #3694
This PR enables https://github.com/weaveworks/weave-gitops-enterprise/pull/3688 to proceed as per our Figma designs.

<!--
Describe what has changed in this PR.
For UI changes also include a screenshot.
-->
**What changed?**
The promotion field is now populated for each environment in the `GetPipeline` API response. 

<!-- Tell your future self why have you made these changes. You could link to stories or initiative here. -->
**Why was this change made?**
As part of the new Pipelines UI, each environment has to show information about its promotion strategy.

<!--
Explain to your reviewers the key implementation points, including why you made
certain choices in favour of others. Highlight key areas of the code which need
extra attention, and also indicate which parts are less relevant (eg renaming,
refactoring, etc
-->
**How was this change implemented?**
Reused existing logic that looks up promotion set for each environment. If no promotion has been set for a given environment, the default promotion is used.

<!-- Use the checklist to detail how you're sure that the change
works.  Check each box when you're satisfied you've dealt with that
item. -->
**How did you validate the change?**

 - [x] Explain how a reviewer can verify the change themselves
  Run `tilt up` and check `GetPipeline` API response to ensure each environment now has a populated promotion field.

 - [x] Integration tests -- what is covered, what cannot be covered;
       or, explain why there are no new tests
  No need for integration tests, unit tests are sufficient.

 - [x] Unit tests -- what is covered, what cannot be covered; are
       there tests that fail _without_ the change?
  Default promotion (no explicit promotion for environment has been set) is being tested as well as when a promotion for an environment has been set.   

<!--
Is it notable for release? e.g. schema updates, configuration or data migration
required? If so, please mention it.
-->
**Release notes**
N/A

<!--
Are there any documentation updates that should be made for these changes? We want to keep these sources up to date:
- user-guide: https://docs.gitops.weave.works
- internal docs: https://github.com/weaveworks/weave-gitops-enterprise/tree/main/docs
- architecture docs: https://github.com/weaveworks/weave-gitops-enterprise/blob/main/docs/architecture
-->
**Documentation Changes**
N/A

<!-- Is there anything else that will need to be done after this is
approved or merged? Ideally, log an issue for each follow-up task and
list them here -->
**Other follow ups**
None